### PR TITLE
feat(v0.2.0): config merge model, enabled flag, move-to action

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Iori Yoshida
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/config.default.toml
+++ b/config.default.toml
@@ -1,3 +1,9 @@
+# omamori default configuration
+#
+# Built-in rules are always inherited. This file shows the full schema.
+# To customize, create ~/.config/omamori/config.toml with only the rules
+# you want to change. Run `omamori init` to generate a starter template.
+
 [[detectors]]
 name = "claude-code"
 type = "env_var"
@@ -22,6 +28,7 @@ command = "rm"
 action = "trash"
 match_any = ["-r", "-rf", "-fr", "--recursive"]
 message = "omamori moved the recursive rm targets to Trash instead of deleting them"
+# enabled = true  # default; set to false to disable
 
 [[rules]]
 name = "git-reset-hard-stash"
@@ -52,6 +59,15 @@ command = "chmod"
 action = "block"
 match_any = ["777"]
 message = "omamori blocked chmod 777"
+
+# --- Example: move-to action (new in v0.2) ---
+# [[rules]]
+# name = "rm-to-backup"
+# command = "rm"
+# action = "move-to"
+# destination = "/tmp/omamori-quarantine/"
+# match_any = ["-r", "-rf", "-fr", "--recursive"]
+# message = "omamori moved targets to backup instead of deleting"
 
 [audit]
 enabled = false

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,7 +1,8 @@
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 
+use crate::config::BLOCKED_DESTINATION_PREFIXES;
 use crate::rules::{ActionKind, CommandInvocation, RuleConfig};
 
 fn exit_code_from_status(status: ExitStatus) -> i32 {
@@ -24,6 +25,7 @@ pub enum ActionOutcome {
     Trashed { exit_code: i32, message: String },
     ExecutedAfterStash { exit_code: i32, message: String },
     LoggedOnly { exit_code: i32, message: String },
+    MovedTo { exit_code: i32, message: String },
     Blocked { message: String },
     Failed { message: String },
 }
@@ -34,7 +36,8 @@ impl ActionOutcome {
             Self::PassedThrough { exit_code }
             | Self::Trashed { exit_code, .. }
             | Self::ExecutedAfterStash { exit_code, .. }
-            | Self::LoggedOnly { exit_code, .. } => *exit_code,
+            | Self::LoggedOnly { exit_code, .. }
+            | Self::MovedTo { exit_code, .. } => *exit_code,
             Self::Blocked { .. } | Self::Failed { .. } => 1,
         }
     }
@@ -45,6 +48,7 @@ impl ActionOutcome {
             Self::Trashed { message, .. }
             | Self::ExecutedAfterStash { message, .. }
             | Self::LoggedOnly { message, .. }
+            | Self::MovedTo { message, .. }
             | Self::Blocked { message }
             | Self::Failed { message } => message,
         }
@@ -56,6 +60,7 @@ impl ActionOutcome {
             Self::Trashed { .. } => "trash",
             Self::ExecutedAfterStash { .. } => "stash-then-exec",
             Self::LoggedOnly { .. } => "log-only",
+            Self::MovedTo { .. } => "move-to",
             Self::Blocked { .. } => "block",
             Self::Failed { .. } => "failed",
         }
@@ -65,6 +70,7 @@ impl ActionOutcome {
 pub trait ExecOps {
     fn passthrough(&mut self, invocation: &CommandInvocation) -> io::Result<i32>;
     fn move_to_trash(&mut self, targets: &[String]) -> Result<(), String>;
+    fn move_to_dir(&mut self, targets: &[String], destination: &Path) -> Result<usize, String>;
     fn git_stash(&mut self) -> Result<(), String>;
 }
 
@@ -89,6 +95,94 @@ impl ExecOps for SystemOps {
     fn move_to_trash(&mut self, targets: &[String]) -> Result<(), String> {
         let paths = targets.iter().map(PathBuf::from).collect::<Vec<_>>();
         trash::delete_all(paths).map_err(|error| error.to_string())
+    }
+
+    fn move_to_dir(&mut self, targets: &[String], destination: &Path) -> Result<usize, String> {
+        // Validate destination at execution time (fail-close)
+        if !destination.exists() {
+            return Err(format!(
+                "move-to directory `{}` does not exist; refusing to run the original command",
+                destination.display()
+            ));
+        }
+        if !destination.is_dir() {
+            return Err(format!(
+                "move-to path `{}` is not a directory",
+                destination.display()
+            ));
+        }
+
+        // Check for symlink at execution time (TOCTOU mitigation)
+        let meta = std::fs::symlink_metadata(destination).map_err(|e| e.to_string())?;
+        if meta.file_type().is_symlink() {
+            return Err(format!(
+                "move-to directory `{}` is a symlink; refusing for security",
+                destination.display()
+            ));
+        }
+
+        // Re-check blocked prefixes at execution time (M1 fix: canonicalize may
+        // have failed at config-load time if the directory didn't exist yet)
+        if let Ok(canonical) = destination.canonicalize() {
+            let canonical_str = canonical.to_string_lossy();
+            for prefix in BLOCKED_DESTINATION_PREFIXES {
+                if canonical_str.starts_with(prefix) {
+                    return Err(format!(
+                        "move-to directory `{}` resolves to blocked system path `{canonical_str}`",
+                        destination.display()
+                    ));
+                }
+            }
+        }
+
+        // Create timestamped subdirectory to avoid filename collisions
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let sub_dir = destination.join(format!("{timestamp}"));
+        std::fs::create_dir_all(&sub_dir)
+            .map_err(|e| format!("failed to create subdirectory `{}`: {e}", sub_dir.display()))?;
+
+        let mut moved = 0usize;
+        let mut used_names = std::collections::HashSet::new();
+        for target in targets {
+            let src = PathBuf::from(target);
+            let base_name = src
+                .file_name()
+                .unwrap_or(src.as_os_str())
+                .to_string_lossy()
+                .into_owned();
+            // Deduplicate basenames: append _2, _3, etc. if collision
+            let unique_name = if used_names.contains(&base_name) {
+                let mut counter = 2u32;
+                loop {
+                    let candidate = format!("{base_name}_{counter}");
+                    if !used_names.contains(&candidate) {
+                        break candidate;
+                    }
+                    counter += 1;
+                }
+            } else {
+                base_name.clone()
+            };
+            used_names.insert(unique_name.clone());
+            let dest = sub_dir.join(&unique_name);
+
+            std::fs::rename(&src, &dest).map_err(|e| {
+                if e.raw_os_error() == Some(18) {
+                    // EXDEV: cross-device link
+                    format!(
+                        "cannot move `{target}` to `{}`: cross-device move is not supported (use a destination on the same volume)",
+                        destination.display()
+                    )
+                } else {
+                    format!("failed to move `{target}` to `{}`: {e}", dest.display())
+                }
+            })?;
+            moved += 1;
+        }
+        Ok(moved)
     }
 
     fn git_stash(&mut self) -> Result<(), String> {
@@ -174,6 +268,43 @@ impl<T: ExecOps> ActionExecutor<T> {
                     ),
                 },
             },
+            ActionKind::MoveTo => {
+                let destination = match &rule.destination {
+                    Some(dest) => PathBuf::from(dest),
+                    None => {
+                        return Ok(ActionOutcome::Failed {
+                            message: "omamori move-to rule has no destination configured"
+                                .to_string(),
+                        });
+                    }
+                };
+                let targets: Vec<String> = invocation
+                    .target_args()
+                    .into_iter()
+                    .map(String::from)
+                    .collect();
+                if targets.is_empty() {
+                    ActionOutcome::Failed {
+                        message: "omamori could not identify any targets to move".to_string(),
+                    }
+                } else {
+                    match self.ops.move_to_dir(&targets, &destination) {
+                        Ok(count) => ActionOutcome::MovedTo {
+                            exit_code: 0,
+                            message: format!(
+                                "{message} ({count} target(s) moved to {})",
+                                destination.display()
+                            ),
+                        },
+                        Err(error) => ActionOutcome::Failed {
+                            message: format!(
+                                "omamori failed to move targets to `{}` and refused to run the original command: {error}",
+                                destination.display()
+                            ),
+                        },
+                    }
+                }
+            }
             ActionKind::Block => ActionOutcome::Blocked { message },
             ActionKind::LogOnly => {
                 let exit_code = self.ops.passthrough(invocation)?;
@@ -195,8 +326,11 @@ mod tests {
         passthrough_calls: usize,
         passthrough_status: i32,
         trash_error: Option<String>,
+        move_to_dir_error: Option<String>,
         stash_error: Option<String>,
         last_trash_targets: Vec<String>,
+        last_move_targets: Vec<String>,
+        last_move_destination: Option<PathBuf>,
     }
 
     impl ExecOps for FakeOps {
@@ -210,6 +344,15 @@ mod tests {
             match &self.trash_error {
                 Some(error) => Err(error.clone()),
                 None => Ok(()),
+            }
+        }
+
+        fn move_to_dir(&mut self, targets: &[String], destination: &Path) -> Result<usize, String> {
+            self.last_move_targets = targets.to_vec();
+            self.last_move_destination = Some(destination.to_path_buf());
+            match &self.move_to_dir_error {
+                Some(error) => Err(error.clone()),
+                None => Ok(targets.len()),
             }
         }
 
@@ -266,7 +409,11 @@ mod tests {
         let mut executor = ActionExecutor::new(FakeOps::default());
         let invocation = CommandInvocation::new(
             "rm".to_string(),
-            vec!["-rf".to_string(), "--".to_string(), "-dangerous.txt".to_string()],
+            vec![
+                "-rf".to_string(),
+                "--".to_string(),
+                "-dangerous.txt".to_string(),
+            ],
         );
         let outcome = executor
             .execute(&invocation, &rule(ActionKind::Trash, "rm"))
@@ -276,12 +423,74 @@ mod tests {
     }
 
     #[test]
-    fn trash_with_only_double_dash_fails() {
+    fn move_to_succeeds_with_destination() {
         let mut executor = ActionExecutor::new(FakeOps::default());
         let invocation = CommandInvocation::new(
             "rm".to_string(),
-            vec!["-rf".to_string(), "--".to_string()],
+            vec!["-rf".to_string(), "target/".to_string()],
         );
+        let rule = RuleConfig::new(
+            "rm-move",
+            "rm",
+            ActionKind::MoveTo,
+            Vec::new(),
+            Vec::new(),
+            Some("moved".to_string()),
+        )
+        .with_destination("/tmp/backup".to_string());
+        let outcome = executor.execute(&invocation, &rule).unwrap();
+        assert!(matches!(outcome, ActionOutcome::MovedTo { .. }));
+        assert_eq!(executor.ops.last_move_targets, vec!["target/"]);
+    }
+
+    #[test]
+    fn move_to_without_destination_fails() {
+        let mut executor = ActionExecutor::new(FakeOps::default());
+        let invocation = CommandInvocation::new(
+            "rm".to_string(),
+            vec!["-rf".to_string(), "target/".to_string()],
+        );
+        let rule = RuleConfig::new(
+            "rm-move",
+            "rm",
+            ActionKind::MoveTo,
+            Vec::new(),
+            Vec::new(),
+            None,
+        );
+        let outcome = executor.execute(&invocation, &rule).unwrap();
+        assert!(matches!(outcome, ActionOutcome::Failed { .. }));
+    }
+
+    #[test]
+    fn move_to_failure_does_not_fall_back_to_passthrough() {
+        let mut executor = ActionExecutor::new(FakeOps {
+            move_to_dir_error: Some("disk full".to_string()),
+            ..Default::default()
+        });
+        let invocation = CommandInvocation::new(
+            "rm".to_string(),
+            vec!["-rf".to_string(), "target/".to_string()],
+        );
+        let rule = RuleConfig::new(
+            "rm-move",
+            "rm",
+            ActionKind::MoveTo,
+            Vec::new(),
+            Vec::new(),
+            None,
+        )
+        .with_destination("/tmp/backup".to_string());
+        let outcome = executor.execute(&invocation, &rule).unwrap();
+        assert!(matches!(outcome, ActionOutcome::Failed { .. }));
+        assert_eq!(executor.ops.passthrough_calls, 0);
+    }
+
+    #[test]
+    fn trash_with_only_double_dash_fails() {
+        let mut executor = ActionExecutor::new(FakeOps::default());
+        let invocation =
+            CommandInvocation::new("rm".to_string(), vec!["-rf".to_string(), "--".to_string()]);
         let outcome = executor
             .execute(&invocation, &rule(ActionKind::Trash, "rm"))
             .unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -7,6 +8,10 @@ use crate::AppError;
 use crate::audit::AuditConfig;
 use crate::detector::DetectorConfig;
 use crate::rules::{ActionKind, RuleConfig};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -34,6 +39,43 @@ pub struct ConfigLoadResult {
     pub warnings: Vec<String>,
 }
 
+// ---------------------------------------------------------------------------
+// User config (deserialized from TOML — all rule fields optional for merge)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+struct UserConfig {
+    detectors: Option<Vec<DetectorConfig>>,
+    #[serde(default)]
+    rules: Vec<UserRule>,
+    #[serde(default)]
+    audit: AuditConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct UserRule {
+    name: String,
+    command: Option<String>,
+    action: Option<ActionKind>,
+    enabled: Option<bool>,
+    destination: Option<String>,
+    match_all: Option<Vec<String>>,
+    match_any: Option<Vec<String>>,
+    message: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Blocked system directories for move-to destination
+// ---------------------------------------------------------------------------
+
+pub const BLOCKED_DESTINATION_PREFIXES: &[&str] = &[
+    "/usr", "/etc", "/System", "/Library", "/bin", "/sbin", "/var", "/private",
+];
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
 pub fn load_config(path: Option<&Path>) -> Result<ConfigLoadResult, AppError> {
     let path = path.map(Path::to_path_buf).or_else(default_config_path);
     let mut warnings = Vec::new();
@@ -54,8 +96,8 @@ pub fn load_config(path: Option<&Path>) -> Result<ConfigLoadResult, AppError> {
                 Config::default()
             } else {
                 let content = fs::read_to_string(&path)?;
-                match toml::from_str::<Config>(&content) {
-                    Ok(config) => config,
+                match toml::from_str::<UserConfig>(&content) {
+                    Ok(user_config) => build_merged_config(user_config, &mut warnings),
                     Err(error) => {
                         warnings.push(format!(
                             "failed to parse `{}` ({error}); using built-in default rules",
@@ -72,6 +114,182 @@ pub fn load_config(path: Option<&Path>) -> Result<ConfigLoadResult, AppError> {
     Ok(ConfigLoadResult { config, warnings })
 }
 
+// ---------------------------------------------------------------------------
+// Merge logic
+// ---------------------------------------------------------------------------
+
+fn build_merged_config(user: UserConfig, warnings: &mut Vec<String>) -> Config {
+    let detectors = user.detectors.unwrap_or_else(default_detectors);
+    let mut rules = merge_rules(default_rules(), &user.rules, warnings);
+    validate_rules(&mut rules, warnings);
+    Config {
+        detectors,
+        rules,
+        audit: user.audit,
+    }
+}
+
+fn merge_rules(
+    defaults: Vec<RuleConfig>,
+    user_rules: &[UserRule],
+    warnings: &mut Vec<String>,
+) -> Vec<RuleConfig> {
+    // Check for duplicate names in user config
+    let mut seen_names = HashSet::new();
+    for ur in user_rules {
+        if !seen_names.insert(&ur.name) {
+            warnings.push(format!(
+                "duplicate rule name `{}` in config; only the first occurrence is used",
+                ur.name
+            ));
+        }
+    }
+
+    let mut merged = defaults;
+    let mut applied_names = HashSet::new();
+
+    for ur in user_rules {
+        if applied_names.contains(&ur.name) {
+            continue; // skip duplicates
+        }
+        applied_names.insert(ur.name.clone());
+
+        if let Some(existing) = merged.iter_mut().find(|r| r.name == ur.name) {
+            // Override existing rule fields
+            apply_user_overrides(existing, ur);
+        } else {
+            // New rule — must have command + action
+            match (&ur.command, &ur.action) {
+                (Some(command), Some(action)) => {
+                    let mut rule = RuleConfig::new(
+                        &ur.name,
+                        command,
+                        action.clone(),
+                        ur.match_all.clone().unwrap_or_default(),
+                        ur.match_any.clone().unwrap_or_default(),
+                        ur.message.clone(),
+                    );
+                    if let Some(enabled) = ur.enabled {
+                        rule.enabled = enabled;
+                    }
+                    if let Some(dest) = &ur.destination {
+                        rule.destination = Some(dest.clone());
+                    }
+                    merged.push(rule);
+                }
+                _ => {
+                    warnings.push(format!(
+                        "rule `{}` is not a built-in rule and is missing `command` or `action`; skipped",
+                        ur.name
+                    ));
+                }
+            }
+        }
+    }
+
+    merged
+}
+
+fn apply_user_overrides(rule: &mut RuleConfig, ur: &UserRule) {
+    if let Some(command) = &ur.command {
+        rule.command = command.clone();
+    }
+    if let Some(action) = &ur.action {
+        rule.action = action.clone();
+    }
+    if let Some(enabled) = ur.enabled {
+        rule.enabled = enabled;
+    }
+    if let Some(dest) = &ur.destination {
+        rule.destination = Some(dest.clone());
+    }
+    if let Some(match_all) = &ur.match_all {
+        rule.match_all = match_all.clone();
+    }
+    if let Some(match_any) = &ur.match_any {
+        rule.match_any = match_any.clone();
+    }
+    if let Some(message) = &ur.message {
+        rule.message = Some(message.clone());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+fn validate_rules(rules: &mut [RuleConfig], warnings: &mut Vec<String>) {
+    for rule in rules.iter_mut() {
+        // MoveTo requires destination
+        if rule.action == ActionKind::MoveTo && rule.destination.is_none() {
+            warnings.push(format!(
+                "rule `{}` uses action `move-to` but has no `destination`; rule disabled",
+                rule.name
+            ));
+            rule.enabled = false;
+        }
+
+        // destination without MoveTo
+        if rule.destination.is_some() && rule.action != ActionKind::MoveTo {
+            warnings.push(format!(
+                "rule `{}` has a `destination` but action is `{}`; destination is ignored",
+                rule.name,
+                rule.action.as_str()
+            ));
+        }
+
+        // Validate destination path — violations disable the rule (enforcement)
+        if let Some(dest) = &rule.destination.clone()
+            && !validate_destination(dest, &rule.name, warnings)
+        {
+            rule.enabled = false;
+        }
+    }
+}
+
+/// Returns `true` if the destination is valid, `false` if it should be blocked.
+fn validate_destination(dest: &str, rule_name: &str, warnings: &mut Vec<String>) -> bool {
+    let path = Path::new(dest);
+
+    // Must be absolute
+    if !path.is_absolute() {
+        warnings.push(format!(
+            "rule `{rule_name}`: destination `{dest}` is not an absolute path; rule disabled"
+        ));
+        return false;
+    }
+
+    // Resolve canonical path (catches .. traversal)
+    if let Ok(canonical) = path.canonicalize() {
+        let canonical_str = canonical.to_string_lossy();
+        for prefix in BLOCKED_DESTINATION_PREFIXES {
+            if canonical_str.starts_with(prefix) {
+                warnings.push(format!(
+                    "rule `{rule_name}`: destination `{dest}` resolves to system directory \
+                     `{canonical_str}`; rule disabled for security"
+                ));
+                return false;
+            }
+        }
+
+        // Check symlink
+        if let Ok(meta) = fs::symlink_metadata(&canonical)
+            && meta.file_type().is_symlink()
+        {
+            warnings.push(format!(
+                "rule `{rule_name}`: destination `{dest}` is a symlink; rule disabled for security"
+            ));
+            return false;
+        }
+    }
+    // If canonicalize fails (path doesn't exist yet), we'll catch it at runtime
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
 fn default_config_path() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .map(PathBuf::from)
@@ -86,7 +304,7 @@ fn default_detectors() -> Vec<DetectorConfig> {
     ]
 }
 
-fn default_rules() -> Vec<RuleConfig> {
+pub fn default_rules() -> Vec<RuleConfig> {
     vec![
         RuleConfig::new(
             "rm-recursive-to-trash",
@@ -139,6 +357,10 @@ fn default_rules() -> Vec<RuleConfig> {
     ]
 }
 
+// ---------------------------------------------------------------------------
+// Permissions check
+// ---------------------------------------------------------------------------
+
 #[cfg(unix)]
 fn permissions_are_safe(path: &Path) -> Result<bool, AppError> {
     use std::os::unix::fs::MetadataExt;
@@ -150,4 +372,266 @@ fn permissions_are_safe(path: &Path) -> Result<bool, AppError> {
 #[cfg(not(unix))]
 fn permissions_are_safe(_path: &Path) -> Result<bool, AppError> {
     Ok(true)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_override_disables_rule() {
+        let user_rules = vec![UserRule {
+            name: "git-push-force-block".to_string(),
+            command: None,
+            action: None,
+            enabled: Some(false),
+            destination: None,
+            match_all: None,
+            match_any: None,
+            message: None,
+        }];
+        let mut warnings = Vec::new();
+        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+
+        let rule = merged
+            .iter()
+            .find(|r| r.name == "git-push-force-block")
+            .unwrap();
+        assert!(!rule.enabled);
+        assert_eq!(rule.action, ActionKind::Block); // action preserved
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn merge_adds_new_rule() {
+        let user_rules = vec![UserRule {
+            name: "custom-rm".to_string(),
+            command: Some("rm".to_string()),
+            action: Some(ActionKind::MoveTo),
+            enabled: None,
+            destination: Some("/tmp/backup".to_string()),
+            match_all: None,
+            match_any: Some(vec!["-rf".to_string()]),
+            message: Some("custom".to_string()),
+        }];
+        let mut warnings = Vec::new();
+        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+
+        let rule = merged.iter().find(|r| r.name == "custom-rm").unwrap();
+        assert_eq!(rule.action, ActionKind::MoveTo);
+        assert_eq!(rule.destination.as_deref(), Some("/tmp/backup"));
+        assert!(rule.enabled);
+    }
+
+    #[test]
+    fn merge_new_rule_without_command_warns() {
+        let user_rules = vec![UserRule {
+            name: "bad-rule".to_string(),
+            command: None,
+            action: None,
+            enabled: Some(false),
+            destination: None,
+            match_all: None,
+            match_any: None,
+            message: None,
+        }];
+        let mut warnings = Vec::new();
+        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+
+        assert!(merged.iter().all(|r| r.name != "bad-rule"));
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("missing `command` or `action`"))
+        );
+    }
+
+    #[test]
+    fn merge_duplicate_name_warns() {
+        let user_rules = vec![
+            UserRule {
+                name: "git-push-force-block".to_string(),
+                command: None,
+                action: None,
+                enabled: Some(false),
+                destination: None,
+                match_all: None,
+                match_any: None,
+                message: None,
+            },
+            UserRule {
+                name: "git-push-force-block".to_string(),
+                command: None,
+                action: None,
+                enabled: Some(true),
+                destination: None,
+                match_all: None,
+                match_any: None,
+                message: None,
+            },
+        ];
+        let mut warnings = Vec::new();
+        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+
+        let rule = merged
+            .iter()
+            .find(|r| r.name == "git-push-force-block")
+            .unwrap();
+        assert!(!rule.enabled); // first occurrence wins
+        assert!(warnings.iter().any(|w| w.contains("duplicate rule name")));
+    }
+
+    #[test]
+    fn merge_preserves_all_defaults_when_no_user_rules() {
+        let mut warnings = Vec::new();
+        let merged = merge_rules(default_rules(), &[], &mut warnings);
+        assert_eq!(merged.len(), default_rules().len());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn merge_override_changes_action() {
+        let user_rules = vec![UserRule {
+            name: "rm-recursive-to-trash".to_string(),
+            command: None,
+            action: Some(ActionKind::MoveTo),
+            enabled: None,
+            destination: Some("/tmp/quarantine".to_string()),
+            match_all: None,
+            match_any: None,
+            message: None,
+        }];
+        let mut warnings = Vec::new();
+        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+
+        let rule = merged
+            .iter()
+            .find(|r| r.name == "rm-recursive-to-trash")
+            .unwrap();
+        assert_eq!(rule.action, ActionKind::MoveTo);
+        assert_eq!(rule.destination.as_deref(), Some("/tmp/quarantine"));
+        // match_any is preserved from default
+        assert!(!rule.match_any.is_empty());
+    }
+
+    #[test]
+    fn validate_move_to_without_destination_disables_rule() {
+        let mut rules = vec![RuleConfig::new(
+            "bad",
+            "rm",
+            ActionKind::MoveTo,
+            Vec::new(),
+            Vec::new(),
+            None,
+        )];
+        let mut warnings = Vec::new();
+        validate_rules(&mut rules, &mut warnings);
+        assert!(warnings.iter().any(|w| w.contains("no `destination`")));
+        assert!(!rules[0].enabled); // rule gets disabled
+    }
+
+    #[test]
+    fn validate_destination_on_non_move_to_warns() {
+        let mut rules = vec![
+            RuleConfig::new(
+                "weird",
+                "rm",
+                ActionKind::Trash,
+                Vec::new(),
+                Vec::new(),
+                None,
+            )
+            .with_destination("/tmp/x".to_string()),
+        ];
+        let mut warnings = Vec::new();
+        validate_rules(&mut rules, &mut warnings);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("destination is ignored"))
+        );
+        assert!(rules[0].enabled); // rule stays enabled (just a warning)
+    }
+
+    #[test]
+    fn validate_relative_destination_disables_rule() {
+        let mut rules = vec![
+            RuleConfig::new(
+                "rel",
+                "rm",
+                ActionKind::MoveTo,
+                Vec::new(),
+                Vec::new(),
+                None,
+            )
+            .with_destination("relative/path".to_string()),
+        ];
+        let mut warnings = Vec::new();
+        validate_rules(&mut rules, &mut warnings);
+        assert!(warnings.iter().any(|w| w.contains("not an absolute path")));
+        assert!(!rules[0].enabled); // rule gets disabled
+    }
+
+    #[test]
+    fn default_rules_all_enabled() {
+        for rule in default_rules() {
+            assert!(
+                rule.enabled,
+                "rule {} should be enabled by default",
+                rule.name
+            );
+        }
+    }
+
+    #[test]
+    fn user_config_without_detectors_uses_defaults() {
+        let toml_str = r#"
+[[rules]]
+name = "git-push-force-block"
+enabled = false
+"#;
+        let user: UserConfig = toml::from_str(toml_str).unwrap();
+        assert!(user.detectors.is_none());
+        let mut warnings = Vec::new();
+        let config = build_merged_config(user, &mut warnings);
+        assert_eq!(config.detectors.len(), 3); // defaults
+    }
+
+    #[test]
+    fn user_config_with_custom_detectors_replaces() {
+        let toml_str = r#"
+[[detectors]]
+name = "my-tool"
+type = "env_var"
+env_key = "MY_TOOL"
+env_value = "1"
+"#;
+        let user: UserConfig = toml::from_str(toml_str).unwrap();
+        assert!(user.detectors.is_some());
+        let mut warnings = Vec::new();
+        let config = build_merged_config(user, &mut warnings);
+        assert_eq!(config.detectors.len(), 1);
+        assert_eq!(config.detectors[0].name, "my-tool");
+    }
+
+    #[test]
+    fn enabled_field_defaults_to_true_in_toml() {
+        let toml_str = r#"
+[[rules]]
+name = "test-rule"
+command = "rm"
+action = "block"
+"#;
+        // Parse as full RuleConfig (simulating direct deserialization)
+        #[derive(Deserialize)]
+        struct Wrapper {
+            rules: Vec<RuleConfig>,
+        }
+        let parsed: Wrapper = toml::from_str(toml_str).unwrap();
+        assert!(parsed.rules[0].enabled);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub fn run(args: &[OsString]) -> Result<i32, AppError> {
         Some("exec") => run_exec_command(args),
         Some("install") => run_install_command(args),
         Some("uninstall") => run_uninstall_command(args),
+        Some("init") => run_init_command(),
         Some("help") | Some("--help") | Some("-h") | None => {
             print_usage();
             Ok(0)
@@ -73,22 +74,58 @@ fn run_policy_test_command(args: &[OsString]) -> Result<i32, AppError> {
     let load_result = load_config(config_path.as_deref())?;
     emit_config_warnings(&load_result);
 
-    let results = run_policy_tests(&load_result);
-    let failures = results.iter().filter(|result| !result.passed).count();
+    // Rules section
+    let config = &load_result.config;
+    let active_count = config.rules.iter().filter(|r| r.enabled).count();
+    let disabled_count = config.rules.len() - active_count;
 
+    println!("\nRules:");
+    for rule in &config.rules {
+        if !rule.enabled {
+            println!("  SKIP  {:<28} (disabled by user config)", rule.name);
+        } else {
+            let action_display = match &rule.action {
+                rules::ActionKind::MoveTo => {
+                    let dest = rule.destination.as_deref().unwrap_or("(no destination)");
+                    format!("move-to {dest}")
+                }
+                other => other.as_str().to_string(),
+            };
+            let pattern = if !rule.match_all.is_empty() {
+                format!("{} {}", rule.command, rule.match_all.join(" "))
+            } else if !rule.match_any.is_empty() {
+                format!("{} {}", rule.command, rule.match_any.join("|"))
+            } else {
+                rule.command.clone()
+            };
+            println!(
+                "  PASS  {:<28} {:<24} -> {}",
+                rule.name, pattern, action_display
+            );
+        }
+    }
+
+    // Detection section
+    let results = run_policy_tests(&load_result);
+    let failures = results.iter().filter(|r| !r.passed).count();
+
+    println!("\nDetection:");
     for result in &results {
         let status = if result.passed { "PASS" } else { "FAIL" };
-        println!("{status} {}", result.name);
-        println!("  {}", result.details);
+        println!("  {status}  {:<28} {}", result.name, result.details);
     }
 
-    if failures == 0 {
-        println!("policy tests passed: {}", results.len());
-        Ok(0)
-    } else {
-        println!("policy tests failed: {failures}/{}", results.len());
-        Ok(1)
-    }
+    // Summary
+    println!(
+        "\nSummary: {} rules ({} active, {} disabled), {} detection tests {}",
+        config.rules.len(),
+        active_count,
+        disabled_count,
+        results.len(),
+        if failures == 0 { "passed" } else { "FAILED" }
+    );
+
+    if failures == 0 { Ok(0) } else { Ok(1) }
 }
 
 fn run_exec_command(args: &[OsString]) -> Result<i32, AppError> {
@@ -242,11 +279,14 @@ fn run_command(
         executor.exec_passthrough(&invocation)?
     } else if let Some(rule) = matched_rule {
         let outcome = executor.execute(&invocation, rule)?;
-        if matches!(
-            outcome,
-            ActionOutcome::Blocked { .. } | ActionOutcome::Failed { .. }
-        ) {
-            eprintln!("{}", outcome.message());
+        match &outcome {
+            ActionOutcome::Blocked { .. } | ActionOutcome::Failed { .. } => {
+                eprintln!("{}", outcome.message());
+            }
+            ActionOutcome::Trashed { message, .. } | ActionOutcome::MovedTo { message, .. } => {
+                eprintln!("{message}");
+            }
+            _ => {}
         }
         outcome
     } else {
@@ -280,12 +320,53 @@ fn print_usage() {
     println!("{}", usage_text());
 }
 
+fn run_init_command() -> Result<i32, AppError> {
+    let defaults = config::default_rules();
+    println!(
+        "# omamori config — only write the rules you want to change.\n\
+         # Built-in rules are inherited automatically.\n\
+         # To disable a rule: set enabled = false\n\
+         # To change an action: override the action field\n\
+         #\n\
+         # Usage:\n\
+         #   omamori init > ~/.config/omamori/config.toml\n\
+         #   chmod 600 ~/.config/omamori/config.toml\n\
+         #   omamori test\n\
+         #"
+    );
+    for rule in &defaults {
+        println!("\n# [[rules]]");
+        println!("# name = \"{}\"", rule.name);
+        println!("# command = \"{}\"", rule.command);
+        println!("# action = \"{}\"", rule.action.as_str());
+        if !rule.match_all.is_empty() {
+            println!("# match_all = {:?}", rule.match_all);
+        }
+        if !rule.match_any.is_empty() {
+            println!("# match_any = {:?}", rule.match_any);
+        }
+        println!("# # enabled = false  # uncomment to disable this rule");
+    }
+    println!(
+        "\n# --- Custom rule example ---\n\
+         # [[rules]]\n\
+         # name = \"rm-to-backup\"\n\
+         # command = \"rm\"\n\
+         # action = \"move-to\"\n\
+         # destination = \"/tmp/omamori-quarantine/\"\n\
+         # match_any = [\"-r\", \"-rf\", \"-fr\", \"--recursive\"]\n\
+         # message = \"omamori moved targets to backup instead of deleting\""
+    );
+    Ok(0)
+}
+
 fn usage_text() -> &'static str {
     "omamori usage:
   omamori test [--config PATH]
   omamori exec [--config PATH] -- <command> [args...]
   omamori install [--base-dir PATH] [--source PATH] [--hooks]
   omamori uninstall [--base-dir PATH]
+  omamori init
 
 When installed as a PATH shim (for example via a symlink named `rm`), omamori
 uses the invoked binary name as the target command and evaluates its policies."

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -34,6 +34,7 @@ pub enum ActionKind {
     StashThenExec,
     Block,
     LogOnly,
+    MoveTo,
 }
 
 impl ActionKind {
@@ -43,8 +44,13 @@ impl ActionKind {
             Self::StashThenExec => "stash-then-exec",
             Self::Block => "block",
             Self::LogOnly => "log-only",
+            Self::MoveTo => "move-to",
         }
     }
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,6 +63,10 @@ pub struct RuleConfig {
     #[serde(default)]
     pub match_any: Vec<String>,
     pub message: Option<String>,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub destination: Option<String>,
 }
 
 impl RuleConfig {
@@ -75,13 +85,29 @@ impl RuleConfig {
             match_all,
             match_any,
             message,
+            enabled: true,
+            destination: None,
         }
+    }
+
+    pub fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    pub fn with_destination(mut self, destination: String) -> Self {
+        self.destination = Some(destination);
+        self
     }
 }
 
-pub fn match_rule<'a>(rules: &'a [RuleConfig], invocation: &CommandInvocation) -> Option<&'a RuleConfig> {
+pub fn match_rule<'a>(
+    rules: &'a [RuleConfig],
+    invocation: &CommandInvocation,
+) -> Option<&'a RuleConfig> {
     rules
         .iter()
+        .filter(|rule| rule.enabled)
         .find(|rule| rule_matches(rule, invocation))
 }
 
@@ -175,17 +201,19 @@ mod tests {
     fn target_args_respects_double_dash_separator() {
         let inv = CommandInvocation::new(
             "rm".to_string(),
-            vec!["-rf".to_string(), "--".to_string(), "-dangerous.txt".to_string()],
+            vec![
+                "-rf".to_string(),
+                "--".to_string(),
+                "-dangerous.txt".to_string(),
+            ],
         );
         assert_eq!(inv.target_args(), vec!["-dangerous.txt"]);
     }
 
     #[test]
     fn target_args_empty_after_double_dash() {
-        let inv = CommandInvocation::new(
-            "rm".to_string(),
-            vec!["-rf".to_string(), "--".to_string()],
-        );
+        let inv =
+            CommandInvocation::new("rm".to_string(), vec!["-rf".to_string(), "--".to_string()]);
         assert!(inv.target_args().is_empty());
     }
 
@@ -193,7 +221,12 @@ mod tests {
     fn target_args_all_after_double_dash() {
         let inv = CommandInvocation::new(
             "rm".to_string(),
-            vec!["--".to_string(), "-a".to_string(), "-b".to_string(), "-c".to_string()],
+            vec![
+                "--".to_string(),
+                "-a".to_string(),
+                "-b".to_string(),
+                "-c".to_string(),
+            ],
         );
         assert_eq!(inv.target_args(), vec!["-a", "-b", "-c"]);
     }
@@ -247,7 +280,12 @@ mod tests {
             "rm",
             ActionKind::Trash,
             Vec::new(),
-            vec!["-r".to_string(), "-rf".to_string(), "-fr".to_string(), "--recursive".to_string()],
+            vec![
+                "-r".to_string(),
+                "-rf".to_string(),
+                "-fr".to_string(),
+                "--recursive".to_string(),
+            ],
             None,
         );
         // -rfv should match because it expands to include -r
@@ -256,6 +294,57 @@ mod tests {
             vec!["-rfv".to_string(), "target/".to_string()],
         );
         assert!(match_rule(&[rule], &inv).is_some());
+    }
+
+    #[test]
+    fn disabled_rule_is_skipped() {
+        let rule = RuleConfig::new(
+            "git-push-force",
+            "git",
+            ActionKind::Block,
+            vec!["push".to_string()],
+            vec!["-f".to_string(), "--force".to_string()],
+            None,
+        )
+        .with_enabled(false);
+        let inv = CommandInvocation::new(
+            "git".to_string(),
+            vec!["push".to_string(), "--force".to_string()],
+        );
+        assert!(match_rule(&[rule], &inv).is_none());
+    }
+
+    #[test]
+    fn enabled_rule_still_matches() {
+        let rule = RuleConfig::new(
+            "git-push-force",
+            "git",
+            ActionKind::Block,
+            vec!["push".to_string()],
+            vec!["-f".to_string(), "--force".to_string()],
+            None,
+        )
+        .with_enabled(true);
+        let inv = CommandInvocation::new(
+            "git".to_string(),
+            vec!["push".to_string(), "--force".to_string()],
+        );
+        assert!(match_rule(&[rule], &inv).is_some());
+    }
+
+    #[test]
+    fn move_to_action_serializes_correctly() {
+        let rule = RuleConfig::new(
+            "rm-to-backup",
+            "rm",
+            ActionKind::MoveTo,
+            Vec::new(),
+            vec!["-rf".to_string()],
+            None,
+        )
+        .with_destination("/tmp/backup".to_string());
+        assert_eq!(rule.action.as_str(), "move-to");
+        assert_eq!(rule.destination.as_deref(), Some("/tmp/backup"));
     }
 
     #[test]
@@ -270,7 +359,12 @@ mod tests {
         );
         let inv = CommandInvocation::new(
             "git".to_string(),
-            vec!["push".to_string(), "-f".to_string(), "origin".to_string(), "main".to_string()],
+            vec![
+                "push".to_string(),
+                "-f".to_string(),
+                "origin".to_string(),
+                "main".to_string(),
+            ],
         );
         assert!(match_rule(&[rule], &inv).is_some());
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -24,7 +24,10 @@ fn omamori_test_command_succeeds_with_defaults() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("policy tests passed"));
+    assert!(
+        stdout.contains("detection tests passed"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- **Config merge model**: Built-in default rules are always inherited. Users write only the rules they want to change in `config.toml`
- **`enabled: false`**: Disable individual rules (e.g. allow force push) with 3 lines of config
- **`move-to` action**: Move files to a user-specified directory instead of macOS Trash
- **`omamori test` improvement**: Shows SKIP for disabled rules, full match_any patterns, summary line
- **`omamori init`**: Generates commented TOML template for easy configuration
- **MIT LICENSE file**: Added proper license file
- **Security hardening**: Destination validation (blocklist enforcement, symlink rejection, runtime re-check), basename collision avoidance

## Key design decisions
- **Merge model** (not full-replace): `UserRule` struct with all-optional fields enables partial overrides
- **Enforcement** (not just warnings): Blocked destination paths and missing `destination` field disable the rule
- **Runtime re-check**: `move_to_dir()` re-validates blocked prefixes via `canonicalize()` to catch paths that didn't exist at config load time
- **`/private` in blocklist**: macOS resolves `/etc` → `/private/etc` after `canonicalize()`

## Test plan
- [x] 50 unit + integration tests all PASS
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] Codex code review: 2 fixes applied (basename collision, blocklist enforcement)
- [x] /simplify: 3 agents report "code is clean"
- [x] QA specialist review: 0 Critical, 2 Major fixed (M1: runtime blocklist re-check, M2: match_any display)
- [x] Security specialist review: 0 Critical/High, 1 Medium fixed (M1), 4 Low noted for backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)