### PR TITLE
docs: update README, SECURITY, CHANGELOG for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.2.0] - 2026-03-14
+
+### Added
+
+- **Config merge model**: Built-in default rules are always inherited. User config overrides by rule `name` — write only the rules you want to change.
+- **`enabled` flag**: Disable individual rules with `enabled = false`. Defaults to `true` for backward compatibility (`#[serde(default = "default_true")]`).
+- **`move-to` action**: Move files to a user-specified directory instead of macOS Trash. Requires `destination` field.
+- **`omamori init` command**: Generates a commented TOML config template to stdout.
+- **`omamori test` improvements**: Shows rule status table with SKIP for disabled rules, full `match_any` pattern display, and summary line.
+- **Destination validation**: Absolute path required, blocked system prefix enforcement (`/usr`, `/etc`, `/System`, `/Library`, `/bin`, `/sbin`, `/var`, `/private`), symlink rejection at config load and runtime, cross-device move rejection.
+- **Runtime blocked-prefix re-check**: `move_to_dir()` re-validates via `canonicalize()` to catch paths created after config load (TOCTOU mitigation).
+- **Basename collision avoidance**: Dedup suffix (`_2`, `_3`, ...) prevents overwrite when multiple targets share the same filename.
+- **MIT LICENSE file**.
+- 16 new unit tests (total: 50).
+
+### Changed
+
+- Config file parsing now uses `UserConfig`/`UserRule` structs for partial overrides (all rule fields optional except `name`).
+- `BLOCKED_DESTINATION_PREFIXES` is now a public constant shared between `config.rs` and `actions.rs`.
+- `omamori test` output format changed from flat PASS/FAIL to structured Rules + Detection + Summary sections.
+- `config.default.toml` updated with `enabled` and `move-to` examples.
+
+### Fixed
+
+- Blocked destination paths now **enforce** rule disabling (previously only warned).
+
 ## [0.1.1] - 2026-03-13
 
 ### Fixed
@@ -37,5 +63,6 @@ The format is based on Keep a Changelog.
 - Claude Code hook template generation via `omamori install --hooks`.
 - Expanded README and SECURITY documentation for protected and unprotected command coverage.
 
+[0.2.0]: https://github.com/yottayoshida/omamori/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/yottayoshida/omamori/compare/v0.1.0...v0.1.1
 [Unreleased]: https://github.com/yottayoshida/omamori/commits/main

--- a/README.md
+++ b/README.md
@@ -36,9 +36,23 @@ omamori install --hooks
 
 # 3. Add shim directory to PATH (add to .zshrc / .bashrc)
 export PATH="$HOME/.omamori/shim:$PATH"
+
+# 4. Verify
+omamori test
 ```
 
-After installation, run `omamori test` to verify your policy rules are working.
+After installation, `omamori test` shows which rules are active:
+
+```
+Rules:
+  PASS  rm-recursive-to-trash        rm -r|-rf|-fr|--recursive -> trash
+  PASS  git-reset-hard-stash         git reset --hard         -> stash-then-exec
+  PASS  git-push-force-block         git push                 -> block
+  PASS  git-clean-force-block        git clean                -> block
+  PASS  chmod-777-block              chmod 777                -> block
+
+Summary: 5 rules (5 active, 0 disabled), 4 detection tests passed
+```
 
 ## How It Works
 
@@ -58,7 +72,73 @@ After installation, run `omamori test` to verify your policy rules are working.
 
 Combined short flags are normalized: `rm -rfv` expands to match `-r` and `-rf` rules. The POSIX `--` separator is respected for target extraction.
 
-Rules are configurable via TOML. See `config.default.toml` for the full schema.
+## Configuration (v0.2+)
+
+Built-in rules are always inherited. Create a config file to customize:
+
+```bash
+# Generate a starter template
+omamori init > ~/.config/omamori/config.toml
+chmod 600 ~/.config/omamori/config.toml
+```
+
+**Disable a rule** (e.g. allow force push):
+
+```toml
+[[rules]]
+name = "git-push-force-block"
+enabled = false
+```
+
+**Move files to a custom directory** instead of Trash:
+
+```toml
+[[rules]]
+name = "rm-to-backup"
+command = "rm"
+action = "move-to"
+destination = "/tmp/omamori-quarantine/"
+match_any = ["-r", "-rf", "-fr", "--recursive"]
+message = "omamori moved targets to quarantine instead of deleting"
+```
+
+**Override an existing rule's action**:
+
+```toml
+[[rules]]
+name = "rm-recursive-to-trash"
+action = "move-to"
+destination = "/tmp/omamori-quarantine/"
+```
+
+After editing, run `omamori test` to verify. Disabled rules show as `SKIP`:
+
+```
+Rules:
+  PASS  rm-recursive-to-trash        rm -r|-rf|-fr|--recursive -> trash
+  SKIP  git-push-force-block         (disabled by user config)
+  ...
+Summary: 5 rules (4 active, 1 disabled), 4 detection tests passed
+```
+
+### Configuration notes
+
+- Config file requires `chmod 600` (permissions check enforced)
+- Only write rules you want to change — everything else is inherited
+- `destination` must be an absolute path on the same volume
+- System directories (`/usr`, `/etc`, `/System`, `/Library`, `/bin`, `/sbin`, `/var`, `/private`) are blocked as destinations
+- Symlinks are rejected as destinations
+- `destination` directory must exist before use (omamori will not create it)
+
+## Available Actions
+
+| Action | Behavior |
+|--------|----------|
+| `trash` | Move targets to macOS Trash |
+| `move-to` | Move targets to a user-specified directory (requires `destination`) |
+| `stash-then-exec` | Run `git stash` first, then execute the original command |
+| `block` | Refuse to execute |
+| `log-only` | Log the event, then execute normally |
 
 ## Safe Defaults
 
@@ -67,8 +147,9 @@ Rules are configurable via TOML. See `config.default.toml` for the full schema.
 | No AI env var detected | Pass through to real command (no interference) |
 | Config file missing | Fail-close: built-in default rules apply |
 | Config file broken | Fail-close: built-in default rules apply + warning |
-| Trash operation fails | Fail-close: refuse to run `rm` |
+| Trash / move-to fails | Fail-close: refuse to run the original command |
 | `sudo` detected | Block the command |
+| Blocked destination | Fail-close: rule is disabled at config load time |
 | Shim binary crashes | Fail-open: real command runs |
 
 ## CLI
@@ -78,6 +159,7 @@ omamori test [--config PATH]                          # Verify policy rules
 omamori exec [--config PATH] -- <command> [args...]   # Run through policy engine
 omamori install [--base-dir PATH] [--hooks]           # Create shims + hook templates
 omamori uninstall [--base-dir PATH]                   # Remove shims + hook files
+omamori init                                          # Print config template to stdout
 ```
 
 ## Structural Limitations
@@ -87,8 +169,8 @@ These are inherent to the PATH shim approach and documented honestly:
 - **Full-path execution** (`/bin/rm`, `/usr/bin/git`) bypasses the shim — partially mitigated by Layer 2 hooks
 - **`sudo`** changes PATH before the shim runs — omamori blocks when it detects elevated execution in-process
 - **Other interpreters** (`python -c "os.remove(...)"`, `perl -e`) are not intercepted
-- **Non-rm destructive commands** (`find -delete`, `rsync --delete`) are not covered in v0.1
-- **`-R` as alias for `-r`** is not yet normalized (tracked for v0.2)
+- **Non-rm destructive commands** (`find -delete`, `rsync --delete`) are not covered
+- **Cross-device moves** are not supported for `move-to` (use a destination on the same volume)
 
 For the full security model, see [SECURITY.md](SECURITY.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,29 +4,40 @@
 
 `omamori` is a PATH-shim safeguard for AI-triggered shell commands. It reduces risk for a narrow set of destructive commands, but it is not a sandbox and it does not claim complete mediation.
 
-## What It Protects In v0.1.1
+## What It Protects In v0.2.0
 
 - recursive `rm` variants matched by the default rules
 - `git reset --hard`
 - force pushes
 - destructive `git clean`
 - `chmod 777`
+- Custom rules defined via `config.toml`
 
-### v0.1.1 Improvements
+### v0.2.0 Security Changes
 
-- **Flag normalization**: Combined short flags like `-rfv` are expanded to individual flags (`-r`, `-f`, `-v`) for matching. Expansion is restricted to ASCII alphabetic characters only. The original combined form is preserved for backward compatibility.
-- **`--` separator**: The POSIX `--` end-of-options marker is now respected when extracting targets for the Trash action. Arguments after `--` are treated as targets regardless of leading `-`.
-- **Hook pattern boundaries**: The Claude Code hook script now uses boundary-aware patterns to avoid matching `/bin/rmdir` when checking for `/bin/rm`.
-- **Internal `git stash` isolation**: The `git stash` subprocess used by `stash-then-exec` now strips AI detector environment variables (`CLAUDECODE`, `AI_GUARD`) to prevent self-interference.
-- **Signal exit codes**: Processes terminated by signals now return `128 + signal_number` per POSIX convention, instead of a generic exit code 1.
+- **`enabled: false` and config.toml editing risk**: The `enabled` flag allows users to intentionally disable individual rules. This opens a new attack vector: an AI agent could attempt to edit `config.toml` to disable protection rules. Mitigations:
+  - Config file requires `chmod 600` permissions (enforced at load time)
+  - Violation of blocked destination paths **disables the rule** (enforcement, not just warning)
+  - Users should not allow AI tools to edit `~/.config/omamori/config.toml`
+
+- **`move-to` destination validation**: The `move-to` action validates destinations at two points:
+  - **Config load time**: Absolute path required, blocked system prefixes checked via `canonicalize()`, symlinks rejected
+  - **Runtime**: Directory existence, `is_dir()`, symlink re-check via `symlink_metadata()`, blocked prefixes re-checked via `canonicalize()` (catches paths created after config load)
+
+- **Blocked destination prefixes**: `/usr`, `/etc`, `/System`, `/Library`, `/bin`, `/sbin`, `/var`, `/private`. Rules with blocked destinations are automatically disabled.
+
+- **Basename collision avoidance**: When `move-to` processes multiple targets, a dedup suffix (`_2`, `_3`, ...) prevents same-named files from overwriting each other.
+
+- **Cross-device move rejection**: `move-to` uses `rename(2)` which is atomic on the same filesystem. Cross-device moves (`EXDEV`) are rejected to avoid the TOCTOU window that copy+delete would introduce.
 
 ## Structural Limits
 
 - Full-path execution such as `/bin/rm` or `/usr/bin/git` can bypass the PATH shim.
 - `sudo` may change PATH before the shim runs.
 - Other interpreters or subprocess launchers can bypass the rules entirely.
-- `-R` as an alias for `-r` is not yet normalized (tracked for v0.2).
 - Commands outside the curated default rules are not protected.
+- Non-existent `destination` paths skip `canonicalize()` validation at config load time (caught at runtime via fail-close).
+- macOS resolves `/etc` to `/private/etc` — the blocked prefix list includes `/private` to cover this.
 
 ## Claude Code Hook Coverage
 
@@ -40,15 +51,26 @@ It is not a complete parser and should be treated as partial coverage, not full 
 
 ## Safe Defaults
 
-- Missing config -> fail-close using built-in default rules
-- Broken config parse -> fail-close using built-in default rules
-- Trash failure -> fail-close; omamori refuses to run the original `rm`
-- Sudo/elevated execution detected -> block
+- Missing config → fail-close using built-in default rules
+- Broken config parse → fail-close using built-in default rules
+- Trash failure → fail-close; omamori refuses to run the original `rm`
+- `move-to` failure (any cause) → fail-close; omamori refuses to run the original command
+- Blocked destination → rule disabled at config load time
+- Sudo/elevated execution detected → block
 - Binary crash remains a fail-open risk outside the process boundary
+
+## Config Merge Model (v0.2+)
+
+Built-in rules are always loaded first. User config rules are merged by `name`:
+- Matching name → fields are overridden (partial overrides supported)
+- New name → added as a new rule (requires `command` + `action`)
+- Duplicate names in user config → warning, first occurrence wins
+
+This means users cannot accidentally remove default protection by creating a config file. They can only override or disable specific rules intentionally.
 
 ## Internal Subprocess Isolation
 
-The `stash-then-exec` action runs `git stash` as a subprocess. To prevent this internal call from triggering omamori's own protection (via PATH shim), the subprocess environment strips the default detector variables (`CLAUDECODE`, `AI_GUARD`). Custom detector environment keys are not stripped in v0.1.1; this is tracked for v0.2 via an `OMAMORI_INTERNAL` flag.
+The `stash-then-exec` action runs `git stash` as a subprocess. To prevent this internal call from triggering omamori's own protection (via PATH shim), the subprocess environment strips the default detector variables (`CLAUDECODE`, `AI_GUARD`).
 
 ## Logging
 
@@ -64,4 +86,4 @@ Current schema includes:
 - `target_count`
 - `target_hash`
 
-`target_hash` is derived from target paths using SHA-256 so operators can correlate repeated events without storing the original paths.
+`target_hash` is derived from target paths using SHA-256 so operators can correlate repeated events without storing the original paths. The `destination` path for `move-to` actions is not recorded in audit logs; it can be derived from the `rule_id` via config lookup.


### PR DESCRIPTION
## Summary
- **README**: Configuration section with merge model examples, `omamori init`/`omamori test` output samples, available actions table, configuration notes
- **SECURITY**: `enabled: false` risk disclosure, `move-to` destination validation details, merge model security properties, `/private` prefix coverage
- **CHANGELOG**: Full v0.2.0 entry (Added/Changed/Fixed)

## Test plan
- [x] No code changes — docs only
- [x] `cargo test` still passes (50/50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)