### PR TITLE
docs: replace WIP warning with pre-1.0 notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # omamori
 
-> **WIP — This project is under active development and not ready for general use.**
-> Do not install in production environments. Breaking changes will occur without notice.
+> **Pre-1.0** — Breaking changes may occur between minor versions.
 
 AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools.
 


### PR DESCRIPTION
## Summary
- Remove "not ready for general use" WIP warning from README
- Replace with lightweight "Pre-1.0 — Breaking changes may occur between minor versions" notice
- v0.2.0 is released and available via Homebrew, so the old warning no longer reflects reality

## Test plan
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)