### PR TITLE
feat(init): rewrite init to write config file directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["Iori Yoshida <yotta@users.noreply.github.com>"]
 readme = "README.md"
 
 [dependencies]
+libc = "0.2.183"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -84,13 +85,18 @@ pub fn load_config(path: Option<&Path>) -> Result<ConfigLoadResult, AppError> {
         Some(path) => {
             if !path.exists() {
                 warnings.push(format!(
-                    "config `{}` not found; using built-in default rules",
+                    "config not found at {}\n  \
+                     Built-in default rules are active (safe to use as-is).\n  \
+                     To create a config for customization, run: omamori init",
                     path.display()
                 ));
                 Config::default()
             } else if !permissions_are_safe(&path)? {
                 warnings.push(format!(
-                    "config `{}` permissions are not 600; using built-in default rules",
+                    "config permissions are too open at {}\n  \
+                     Built-in default rules are active for security.\n  \
+                     To fix, run: chmod 600 {}",
+                    path.display(),
                     path.display()
                 ));
                 Config::default()
@@ -100,7 +106,9 @@ pub fn load_config(path: Option<&Path>) -> Result<ConfigLoadResult, AppError> {
                     Ok(user_config) => build_merged_config(user_config, &mut warnings),
                     Err(error) => {
                         warnings.push(format!(
-                            "failed to parse `{}` ({error}); using built-in default rules",
+                            "failed to parse config at {} ({error})\n  \
+                             Built-in default rules are active for safety.\n  \
+                             Fix the syntax error or run: omamori init --force",
                             path.display()
                         ));
                         Config::default()
@@ -290,7 +298,17 @@ fn validate_destination(dest: &str, rule_name: &str, warnings: &mut Vec<String>)
 // Defaults
 // ---------------------------------------------------------------------------
 
-fn default_config_path() -> Option<PathBuf> {
+/// Returns the default config file path, respecting `XDG_CONFIG_HOME`.
+/// Priority: `$XDG_CONFIG_HOME/omamori/config.toml` → `$HOME/.config/omamori/config.toml`.
+pub fn default_config_path() -> Option<PathBuf> {
+    // XDG_CONFIG_HOME must be absolute if set
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        let xdg_path = PathBuf::from(&xdg);
+        if xdg_path.is_absolute() {
+            return Some(xdg_path.join("omamori").join("config.toml"));
+        }
+        // Relative XDG_CONFIG_HOME is ignored (XDG spec requires absolute)
+    }
     std::env::var_os("HOME")
         .map(PathBuf::from)
         .map(|home| home.join(".config").join("omamori").join("config.toml"))
@@ -357,6 +375,158 @@ pub fn default_rules() -> Vec<RuleConfig> {
             Some("omamori blocked chmod 777".to_string()),
         ),
     ]
+}
+
+// ---------------------------------------------------------------------------
+// Config file writing
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct WriteConfigResult {
+    pub path: PathBuf,
+    pub created: bool,
+}
+
+/// Generate the default config template as a string (all rules commented out).
+pub fn config_template() -> String {
+    let defaults = default_rules();
+    let mut out = String::new();
+    out.push_str(
+        "# omamori config — only write the rules you want to change.\n\
+         # Built-in rules are inherited automatically.\n\
+         # To disable a rule: set enabled = false\n\
+         # To change an action: override the action field\n\
+         #\n\
+         # Docs: https://github.com/yottayoshida/omamori\n\
+         #\n",
+    );
+    for rule in &defaults {
+        out.push_str("\n# [[rules]]\n");
+        out.push_str(&format!("# name = \"{}\"\n", rule.name));
+        out.push_str(&format!("# command = \"{}\"\n", rule.command));
+        out.push_str(&format!("# action = \"{}\"\n", rule.action.as_str()));
+        if !rule.match_all.is_empty() {
+            out.push_str(&format!("# match_all = {:?}\n", rule.match_all));
+        }
+        if !rule.match_any.is_empty() {
+            out.push_str(&format!("# match_any = {:?}\n", rule.match_any));
+        }
+        out.push_str("# # enabled = false  # uncomment to disable this rule\n");
+    }
+    out.push_str(
+        "\n# --- Custom rule example ---\n\
+         # [[rules]]\n\
+         # name = \"rm-to-backup\"\n\
+         # command = \"rm\"\n\
+         # action = \"move-to\"\n\
+         # destination = \"/tmp/omamori-quarantine/\"\n\
+         # match_any = [\"-r\", \"-rf\", \"-fr\", \"--recursive\"]\n\
+         # message = \"omamori moved targets to backup instead of deleting\"\n",
+    );
+    out
+}
+
+/// Write the default config template to the given path.
+///
+/// Safety features:
+/// - Refuses to write to symlinks (`O_NOFOLLOW` + `symlink_metadata` check)
+/// - `force=false`: uses `create_new(true)` to prevent TOCTOU races
+/// - `force=true`: atomic write via temp file + rename + fsync
+/// - Sets directory permissions to 700, file permissions to 600
+pub fn write_default_config(path: &Path, force: bool) -> Result<WriteConfigResult, AppError> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| AppError::Config(format!("invalid config path: {}", path.display())))?;
+
+    // Create directory with mode 700
+    if !dir.exists() {
+        fs::create_dir_all(dir)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(dir, fs::Permissions::from_mode(0o700))?;
+        }
+    } else {
+        // P2 fix: reject symlinked parent directory
+        reject_symlink(dir, "config directory")?;
+    }
+
+    // Check for symlink at target path
+    if path.exists() || path.symlink_metadata().is_ok() {
+        reject_symlink(path, "config path")?;
+
+        if !force {
+            return Err(AppError::Config(format!(
+                "config already exists at {}\n  Use `omamori init --force` to overwrite.",
+                path.display()
+            )));
+        }
+    }
+
+    let content = config_template();
+
+    if force && path.exists() {
+        // Atomic write: temp file → fsync → rename
+        let temp_path = path.with_extension("toml.tmp");
+        // P1 fix: reject symlink at temp path too
+        if temp_path.symlink_metadata().is_ok() {
+            reject_symlink(&temp_path, "temp config path")?;
+            // Remove stale temp file (non-symlink) if it exists
+            let _ = fs::remove_file(&temp_path);
+        }
+        write_new_config(&temp_path, &content)?;
+        // fsync the file
+        let file = fs::File::open(&temp_path)?;
+        file.sync_all()?;
+        drop(file);
+        // Atomic rename
+        fs::rename(&temp_path, path)?;
+        // fsync the parent directory
+        if let Ok(dir_file) = fs::File::open(dir) {
+            let _ = dir_file.sync_all();
+        }
+    } else {
+        // New file: use O_NOFOLLOW + create_new for TOCTOU safety
+        write_new_config(path, &content)?;
+    }
+
+    Ok(WriteConfigResult {
+        path: path.to_path_buf(),
+        created: true,
+    })
+}
+
+fn reject_symlink(path: &Path, label: &str) -> Result<(), AppError> {
+    if let Ok(meta) = fs::symlink_metadata(path)
+        && meta.file_type().is_symlink()
+    {
+        return Err(AppError::Config(format!(
+            "{label} `{}` is a symlink; refusing to write for security",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_new_config(path: &Path, content: &str) -> Result<(), AppError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    file.write_all(content.as_bytes())?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_new_config(path: &Path, content: &str) -> Result<(), AppError> {
+    fs::write(path, content)?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub fn run(args: &[OsString]) -> Result<i32, AppError> {
         Some("exec") => run_exec_command(args),
         Some("install") => run_install_command(args),
         Some("uninstall") => run_uninstall_command(args),
-        Some("init") => run_init_command(),
+        Some("init") => run_init_command(args),
         Some("help") | Some("--help") | Some("-h") | None => {
             print_usage();
             Ok(0)
@@ -327,44 +327,59 @@ fn print_usage() {
     println!("{}", usage_text());
 }
 
-fn run_init_command() -> Result<i32, AppError> {
-    let defaults = config::default_rules();
-    println!(
-        "# omamori config — only write the rules you want to change.\n\
-         # Built-in rules are inherited automatically.\n\
-         # To disable a rule: set enabled = false\n\
-         # To change an action: override the action field\n\
-         #\n\
-         # Usage:\n\
-         #   omamori init > ~/.config/omamori/config.toml\n\
-         #   chmod 600 ~/.config/omamori/config.toml\n\
-         #   omamori test\n\
-         #"
-    );
-    for rule in &defaults {
-        println!("\n# [[rules]]");
-        println!("# name = \"{}\"", rule.name);
-        println!("# command = \"{}\"", rule.command);
-        println!("# action = \"{}\"", rule.action.as_str());
-        if !rule.match_all.is_empty() {
-            println!("# match_all = {:?}", rule.match_all);
+fn run_init_command(args: &[OsString]) -> Result<i32, AppError> {
+    let mut force = false;
+    let mut stdout_mode = false;
+    let mut index = 2usize;
+
+    while let Some(arg) = args.get(index).and_then(|item| item.to_str()) {
+        match arg {
+            "--force" => {
+                force = true;
+                index += 1;
+            }
+            "--stdout" => {
+                stdout_mode = true;
+                index += 1;
+            }
+            _ => {
+                return Err(AppError::Usage(format!(
+                    "unknown init flag: {arg}\n\n{}",
+                    usage_text()
+                )));
+            }
         }
-        if !rule.match_any.is_empty() {
-            println!("# match_any = {:?}", rule.match_any);
-        }
-        println!("# # enabled = false  # uncomment to disable this rule");
     }
-    println!(
-        "\n# --- Custom rule example ---\n\
-         # [[rules]]\n\
-         # name = \"rm-to-backup\"\n\
-         # command = \"rm\"\n\
-         # action = \"move-to\"\n\
-         # destination = \"/tmp/omamori-quarantine/\"\n\
-         # match_any = [\"-r\", \"-rf\", \"-fr\", \"--recursive\"]\n\
-         # message = \"omamori moved targets to backup instead of deleting\""
-    );
-    Ok(0)
+
+    // --stdout: backward-compatible stdout output
+    if stdout_mode {
+        print!("{}", config::config_template());
+        return Ok(0);
+    }
+
+    // File write mode (default)
+    let path = config::default_config_path().ok_or_else(|| {
+        AppError::Config(
+            "cannot determine config path: neither XDG_CONFIG_HOME nor HOME is set".to_string(),
+        )
+    })?;
+
+    match config::write_default_config(&path, force) {
+        Ok(result) => {
+            eprintln!("Created {}", result.path.display());
+            eprintln!("Run `omamori test` to verify your setup.");
+            Ok(0)
+        }
+        Err(AppError::Config(msg)) if msg.contains("already exists") => {
+            eprintln!("omamori: {msg}");
+            Ok(2)
+        }
+        Err(AppError::Config(msg)) if msg.contains("symlink") => {
+            eprintln!("omamori: {msg}");
+            Ok(1)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 fn usage_text() -> &'static str {
@@ -373,7 +388,7 @@ fn usage_text() -> &'static str {
   omamori exec [--config PATH] -- <command> [args...]
   omamori install [--base-dir PATH] [--source PATH] [--hooks]
   omamori uninstall [--base-dir PATH]
-  omamori init
+  omamori init [--force] [--stdout]
 
 When installed as a PATH shim (for example via a symlink named `rm`), omamori
 uses the invoked binary name as the target command and evaluates its policies."

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,6 +3,16 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+fn unique_dir(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("omamori-{name}-{nanos}"));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
 fn unique_path(name: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -11,10 +21,13 @@ fn unique_path(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!("omamori-{name}-{nanos}.toml"))
 }
 
+fn binary() -> String {
+    env!("CARGO_BIN_EXE_omamori").to_string()
+}
+
 #[test]
 fn omamori_test_command_succeeds_with_defaults() {
-    let binary = env!("CARGO_BIN_EXE_omamori");
-    let output = Command::new(binary)
+    let output = Command::new(binary())
         .arg("test")
         .output()
         .expect("failed to run omamori test");
@@ -32,7 +45,6 @@ fn omamori_test_command_succeeds_with_defaults() {
 
 #[test]
 fn malformed_config_falls_back_to_defaults() {
-    let binary = env!("CARGO_BIN_EXE_omamori");
     let path = unique_path("broken");
     fs::write(&path, "[[rules]\nname = ").unwrap();
     #[cfg(unix)]
@@ -41,7 +53,7 @@ fn malformed_config_falls_back_to_defaults() {
         fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
     }
 
-    let output = Command::new(binary)
+    let output = Command::new(binary())
         .arg("test")
         .arg("--config")
         .arg(&path)
@@ -55,5 +67,295 @@ fn malformed_config_falls_back_to_defaults() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("using built-in default rules"));
+    assert!(
+        stderr.contains("Built-in default rules are active"),
+        "stderr should contain actionable warning: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// init tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_stdout_mode_prints_template() {
+    let output = Command::new(binary())
+        .args(["init", "--stdout"])
+        .output()
+        .expect("failed to run omamori init --stdout");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("# omamori config"));
+    assert!(stdout.contains("rm-recursive-to-trash"));
+    assert!(stdout.contains("git-push-force-block"));
+}
+
+#[test]
+fn init_creates_config_file() {
+    let dir = unique_dir("init-create");
+    let config_path = dir.join("omamori").join("config.toml");
+
+    let output = Command::new(binary())
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run omamori init");
+
+    assert!(
+        output.status.success(),
+        "exit={} stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(config_path.exists(), "config.toml should be created");
+
+    // Verify content is the commented template
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert!(content.contains("# omamori config"));
+    assert!(content.contains("# [[rules]]"));
+    // Should NOT contain uncommented [[rules]] (T4 safety)
+    assert!(
+        !content
+            .lines()
+            .any(|l| l.trim_start().starts_with("[[rules]]")),
+        "config should have all rules commented out"
+    );
+
+    // Verify permissions
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let mode = fs::metadata(&config_path).unwrap().mode() & 0o777;
+        assert_eq!(mode, 0o600, "config should be chmod 600, got {mode:o}");
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn init_refuses_overwrite_without_force() {
+    let dir = unique_dir("init-noforce");
+    let config_dir = dir.join("omamori");
+    fs::create_dir_all(&config_dir).unwrap();
+    let config_path = config_dir.join("config.toml");
+    fs::write(&config_path, "# existing config\n").unwrap();
+
+    let output = Command::new(binary())
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run omamori init");
+
+    // Should exit with code 2
+    assert_eq!(output.status.code(), Some(2));
+
+    // Existing file should be unchanged
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(content, "# existing config\n");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn init_force_overwrites_existing() {
+    let dir = unique_dir("init-force");
+    let config_dir = dir.join("omamori");
+    fs::create_dir_all(&config_dir).unwrap();
+    let config_path = config_dir.join("config.toml");
+    fs::write(&config_path, "# old config\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&config_path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    let output = Command::new(binary())
+        .args(["init", "--force"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run omamori init --force");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert!(
+        content.contains("# omamori config"),
+        "should be new template"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn init_refuses_symlink_target() {
+    let dir = unique_dir("init-symlink");
+    let config_dir = dir.join("omamori");
+    fs::create_dir_all(&config_dir).unwrap();
+
+    let real_file = dir.join("real.toml");
+    fs::write(&real_file, "# real\n").unwrap();
+
+    let config_path = config_dir.join("config.toml");
+    std::os::unix::fs::symlink(&real_file, &config_path).unwrap();
+
+    let output = Command::new(binary())
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run omamori init");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("symlink"),
+        "should mention symlink: {stderr}"
+    );
+
+    // Real file should be unchanged
+    let content = fs::read_to_string(&real_file).unwrap();
+    assert_eq!(content, "# real\n");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn init_refuses_symlinked_parent_directory() {
+    let dir = unique_dir("init-symlink-dir");
+    let real_dir = dir.join("real_omamori");
+    fs::create_dir_all(&real_dir).unwrap();
+
+    // Make "omamori" a symlink to "real_omamori"
+    let symlink_dir = dir.join("omamori");
+    std::os::unix::fs::symlink(&real_dir, &symlink_dir).unwrap();
+
+    let output = Command::new(binary())
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run omamori init");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("symlink"),
+        "should mention symlink: {stderr}"
+    );
+
+    // No config.toml should be created in real_dir
+    assert!(!real_dir.join("config.toml").exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn init_fails_without_home_and_xdg() {
+    let output = Command::new(binary())
+        .args(["init"])
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run omamori init");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("XDG_CONFIG_HOME") || stderr.contains("HOME"),
+        "should mention missing env: {stderr}"
+    );
+}
+
+#[test]
+fn init_written_config_loads_correctly() {
+    let dir = unique_dir("init-roundtrip");
+    let config_path = dir.join("omamori").join("config.toml");
+
+    // Create config via init
+    let output = Command::new(binary())
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run omamori init");
+    assert!(output.status.success());
+
+    // Use the created config with omamori test
+    let output = Command::new(binary())
+        .args(["test", "--config"])
+        .arg(&config_path)
+        .output()
+        .expect("failed to run omamori test");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("detection tests passed"));
+
+    // Should have no warnings (config exists and is valid)
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("warning"),
+        "should have no warnings: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+// ---------------------------------------------------------------------------
+// warning message tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn warning_config_not_found_is_actionable() {
+    let nonexistent = unique_path("nonexistent");
+    let output = Command::new(binary())
+        .args(["test", "--config"])
+        .arg(&nonexistent)
+        .output()
+        .expect("failed to run omamori test");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("config not found"));
+    assert!(
+        stderr.contains("omamori init"),
+        "warning should suggest omamori init: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn warning_bad_permissions_is_actionable() {
+    let path = unique_path("badperms");
+    fs::write(&path, "# ok\n").unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+    }
+
+    let output = Command::new(binary())
+        .args(["test", "--config"])
+        .arg(&path)
+        .output()
+        .expect("failed to run omamori test");
+
+    let _ = fs::remove_file(&path);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("permissions are too open"));
+    assert!(
+        stderr.contains("chmod 600"),
+        "warning should suggest chmod 600: {stderr}"
+    );
 }


### PR DESCRIPTION
## Summary

- `omamori init` now writes `config.toml` directly to `~/.config/omamori/` (or `$XDG_CONFIG_HOME/omamori/`) instead of stdout
- Backward compat via `--stdout` flag
- `--force` for overwriting existing config (atomic write with fsync)
- Warning messages improved with actionable 3-layer structure
- Security hardening: symlink rejection (file + parent dir + temp path), `O_NOFOLLOW`, `create_new(true)` for TOCTOU, directory chmod 700 / file chmod 600

## Motivation

Real user feedback: Cursor user ran `omamori install --hooks` → `omamori test` and got "config not found" warning. Didn't know what was missing. This PR is the foundation for PR 2 (install auto-config) which will eliminate this friction entirely.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Added `libc` crate (for `O_NOFOLLOW`) |
| `src/config.rs` | `write_default_config()`, `config_template()`, XDG support, warning improvement, symlink defense |
| `src/lib.rs` | `run_init_command()` rewrite (`--stdout`, `--force`, exit codes) |
| `tests/cli.rs` | 12 tests (8 init + 2 warning + 2 existing updated) |

## Security

- **T4 (DREAD 7.6)**: init output is all-commented — `init --force` cannot neutralize built-in rules
- **T1 (DREAD 7.2)**: symlink check on file, parent dir, and temp path + `O_NOFOLLOW`
- **T2 (DREAD 6.0)**: `create_new(true)` for TOCTOU; atomic write for `--force`
- Codex review: P1 (temp file symlink) and P2 (parent dir symlink) addressed

## Test plan

- [x] `cargo test` — 67 tests pass (53 unit + 12 cli + 2 integration)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Manual E2E: init creates file, --stdout works, --force overwrites, symlink rejected, permissions correct
- [x] Roundtrip: `init` → `test` with created config → no warnings, all PASS

Part of #9 (v0.3 milestone). PR 2 (`feat/install-autoconfig`) and PR 3 (`feat/config-enable-disable`) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)