### PR TITLE
feat(install): auto-generate config + auto-test + config list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run(args: &[OsString]) -> Result<i32, AppError> {
         Some("install") => run_install_command(args),
         Some("uninstall") => run_uninstall_command(args),
         Some("init") => run_init_command(args),
+        Some("config") => run_config_command(args),
         Some("help") | Some("--help") | Some("-h") | None => {
             print_usage();
             Ok(0)
@@ -195,22 +196,73 @@ fn run_install_command(args: &[OsString]) -> Result<i32, AppError> {
         generate_hooks,
     })?;
 
-    println!("Installed omamori shims in {}", result.shim_dir.display());
+    // --- Checklist output ---
+    println!("\nomamori setup complete:\n");
     println!(
-        "Add this directory to PATH manually:\n  export PATH=\"{}:$PATH\"",
-        result.shim_dir.display()
+        "  [done] Shims installed: {}",
+        result.linked_commands.join(", ")
     );
-    if let Some(script) = result.hook_script {
-        println!("Generated Claude Code hook script: {}", script.display());
+
+    if let Some(script) = &result.hook_script {
+        println!("  [done] Hook script generated: {}", script.display());
     }
-    if let Some(snippet) = result.settings_snippet {
+    if let Some(snippet) = &result.settings_snippet {
+        println!("  [done] Settings snippet generated: {}", snippet.display());
+    }
+
+    // Auto-generate config if it doesn't exist
+    let config_status = match config::default_config_path() {
+        Some(config_path) if !config_path.exists() => {
+            match config::write_default_config(&config_path, false) {
+                Ok(res) => format!("[done] Config created: {}", res.path.display()),
+                Err(e) => format!("[warn] Config not created: {e}"),
+            }
+        }
+        Some(config_path) => format!("[skip] Config already exists: {}", config_path.display()),
+        None => "[warn] Config not created: HOME/XDG_CONFIG_HOME not set".to_string(),
+    };
+    println!("  {config_status}");
+
+    // Auto-test
+    let load_result = load_config(None)?;
+    let test_results = run_policy_tests(&load_result);
+    let failures = test_results.iter().filter(|r| !r.passed).count();
+    let active_rules = load_result
+        .config
+        .rules
+        .iter()
+        .filter(|r| r.enabled)
+        .count();
+    if failures == 0 {
         println!(
-            "Generated Claude settings snippet (apply manually): {}",
-            snippet.display()
+            "  [done] All rules verified: {} active, {} detection tests passed",
+            active_rules,
+            test_results.len()
+        );
+    } else {
+        println!(
+            "  [FAIL] {} detection test(s) failed — run `omamori test` for details",
+            failures
         );
     }
-    println!("Linked commands: {}", result.linked_commands.join(", "));
 
+    // Remaining manual steps
+    println!(
+        "\n  [todo] Add to your shell profile (~/.zshrc or ~/.bashrc):\n\n    export PATH=\"{}:$PATH\"",
+        result.shim_dir.display()
+    );
+    if result.settings_snippet.is_some() {
+        println!(
+            "\n  [todo] Apply Claude Code hook (copy snippet to settings.json):\n\n    cat {}/claude-settings.snippet.json",
+            result
+                .hook_script
+                .as_ref()
+                .map(|p| p.parent().unwrap().display().to_string())
+                .unwrap_or_default()
+        );
+    }
+
+    println!();
     Ok(0)
 }
 
@@ -327,6 +379,87 @@ fn print_usage() {
     println!("{}", usage_text());
 }
 
+fn run_config_command(args: &[OsString]) -> Result<i32, AppError> {
+    match args.get(2).and_then(|item| item.to_str()) {
+        Some("list") => run_config_list(),
+        Some(other) => Err(AppError::Usage(format!(
+            "unknown config subcommand: {other}\n\n{}",
+            usage_text()
+        ))),
+        None => Err(AppError::Usage(format!(
+            "config requires a subcommand\n\n{}",
+            usage_text()
+        ))),
+    }
+}
+
+fn run_config_list() -> Result<i32, AppError> {
+    let load_result = load_config(None)?;
+    let config = &load_result.config;
+
+    // Emit any config warnings
+    emit_config_warnings(&load_result);
+
+    // Determine which rules were customized by user config
+    let default_rule_names: std::collections::HashSet<String> = config::default_rules()
+        .iter()
+        .map(|r| r.name.clone())
+        .collect();
+
+    println!(
+        "\n  {:<30} {:<16} {:<10} Source",
+        "Rule", "Action", "Status"
+    );
+    println!("  {}", "-".repeat(76));
+
+    for rule in &config.rules {
+        let status = if rule.enabled { "active" } else { "disabled" };
+        let source = if !default_rule_names.contains(&rule.name) {
+            "config"
+        } else if !rule.enabled {
+            "config (disabled)"
+        } else {
+            // Check if any field differs from default
+            "built-in"
+        };
+        let action_str = match &rule.action {
+            rules::ActionKind::MoveTo => {
+                let dest = rule.destination.as_deref().unwrap_or("?");
+                format!("move-to {dest}")
+            }
+            other => other.as_str().to_string(),
+        };
+        println!(
+            "  {:<30} {:<16} {:<10} {}",
+            rule.name, action_str, status, source
+        );
+    }
+
+    // Show config path
+    if let Some(path) = config::default_config_path() {
+        if path.exists() {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::MetadataExt;
+                if let Ok(meta) = std::fs::metadata(&path) {
+                    println!(
+                        "\n  Config: {} (permissions: {:o})",
+                        path.display(),
+                        meta.mode() & 0o777
+                    );
+                }
+            }
+            #[cfg(not(unix))]
+            println!("\n  Config: {}", path.display());
+        } else {
+            println!("\n  Config: not found (run `omamori init` to create)");
+        }
+    }
+
+    println!();
+    Ok(0)
+}
+
 fn run_init_command(args: &[OsString]) -> Result<i32, AppError> {
     let mut force = false;
     let mut stdout_mode = false;
@@ -389,6 +522,7 @@ fn usage_text() -> &'static str {
   omamori install [--base-dir PATH] [--source PATH] [--hooks]
   omamori uninstall [--base-dir PATH]
   omamori init [--force] [--stdout]
+  omamori config list
 
 When installed as a PATH shim (for example via a symlink named `rm`), omamori
 uses the invoked binary name as the target command and evaluates its policies."

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -36,7 +36,14 @@ fn install_creates_shims_without_touching_shell_config() {
     assert!(base_dir.join("hooks/claude-settings.snippet.json").exists());
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Add this directory to PATH manually"));
+    assert!(
+        stdout.contains("[todo] Add to your shell profile"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("[done] Shims installed"),
+        "stdout: {stdout}"
+    );
 
     let _ = fs::remove_dir_all(base_dir);
 }
@@ -71,4 +78,182 @@ fn uninstall_removes_generated_artifacts() {
     );
     assert!(!base_dir.join("shim/rm").exists());
     assert!(!base_dir.exists());
+}
+
+// ---------------------------------------------------------------------------
+// install auto-config tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn install_auto_creates_config_when_missing() {
+    let binary = env!("CARGO_BIN_EXE_omamori");
+    let base_dir = unique_dir("install-autoconfig");
+    let config_dir = unique_dir("install-autoconfig-xdg");
+
+    let output = Command::new(binary)
+        .arg("install")
+        .arg("--base-dir")
+        .arg(&base_dir)
+        .arg("--source")
+        .arg(binary)
+        .arg("--hooks")
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run install");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("[done] Config created"),
+        "should auto-create config: {stdout}"
+    );
+    assert!(
+        config_dir.join("omamori").join("config.toml").exists(),
+        "config.toml should exist"
+    );
+
+    let _ = fs::remove_dir_all(base_dir);
+    let _ = fs::remove_dir_all(config_dir);
+}
+
+#[test]
+fn install_skips_existing_config() {
+    let binary = env!("CARGO_BIN_EXE_omamori");
+    let base_dir = unique_dir("install-skipconfig");
+    let config_dir = unique_dir("install-skipconfig-xdg");
+    let omamori_dir = config_dir.join("omamori");
+    fs::create_dir_all(&omamori_dir).unwrap();
+    let config_path = omamori_dir.join("config.toml");
+    fs::write(&config_path, "# my custom config\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&config_path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    let output = Command::new(binary)
+        .arg("install")
+        .arg("--base-dir")
+        .arg(&base_dir)
+        .arg("--source")
+        .arg(binary)
+        .arg("--hooks")
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run install");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("[skip] Config already exists"),
+        "should skip existing config: {stdout}"
+    );
+
+    // Verify existing config wasn't modified
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(content, "# my custom config\n");
+
+    let _ = fs::remove_dir_all(base_dir);
+    let _ = fs::remove_dir_all(config_dir);
+}
+
+#[test]
+fn install_runs_auto_test() {
+    let binary = env!("CARGO_BIN_EXE_omamori");
+    let base_dir = unique_dir("install-autotest");
+    let config_dir = unique_dir("install-autotest-xdg");
+
+    let output = Command::new(binary)
+        .arg("install")
+        .arg("--base-dir")
+        .arg(&base_dir)
+        .arg("--source")
+        .arg(binary)
+        .arg("--hooks")
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run install");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("[done] All rules verified"),
+        "should show auto-test results: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(base_dir);
+    let _ = fs::remove_dir_all(config_dir);
+}
+
+// ---------------------------------------------------------------------------
+// config list tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_list_shows_all_rules() {
+    let binary = env!("CARGO_BIN_EXE_omamori");
+
+    let output = Command::new(binary)
+        .args(["config", "list"])
+        .output()
+        .expect("failed to run config list");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("rm-recursive-to-trash"));
+    assert!(stdout.contains("git-push-force-block"));
+    assert!(stdout.contains("chmod-777-block"));
+    assert!(stdout.contains("active"));
+    assert!(stdout.contains("built-in"));
+}
+
+#[test]
+fn config_list_shows_disabled_rule() {
+    let binary = env!("CARGO_BIN_EXE_omamori");
+    let config_dir = unique_dir("cfglist-disabled");
+    let omamori_dir = config_dir.join("omamori");
+    fs::create_dir_all(&omamori_dir).unwrap();
+    let config_path = omamori_dir.join("config.toml");
+    fs::write(
+        &config_path,
+        "[[rules]]\nname = \"git-push-force-block\"\nenabled = false\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&config_path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    let output = Command::new(binary)
+        .args(["config", "list"])
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run config list");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("disabled"),
+        "should show disabled: {stdout}"
+    );
+    assert!(
+        stdout.contains("config (disabled)"),
+        "source should be config (disabled): {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(config_dir);
 }


### PR DESCRIPTION
## Summary

- `omamori install --hooks` now auto-generates `config.toml` if missing (no separate `init` needed)
- Install runs policy tests automatically — users see verification results in the install output
- Install output uses `[done]`/`[skip]`/`[todo]` checklist format for clear setup status
- New subcommand: `omamori config list` displays all rules with Status and Source columns

## This is the PR that fixes 西本さん's experience

After this PR, the setup flow is:
```
brew install omamori
omamori install --hooks   # config auto-created + auto-verified
# just add PATH to .zshrc
```

No more "config not found" warning. No more guessing what's missing.

## Changes

| File | Change |
|------|--------|
| `src/lib.rs` | `run_install_command()` rewrite (auto-config + auto-test + checklist), `run_config_command()` + `run_config_list()` |
| `tests/integration.rs` | 5 new tests (auto-config, skip existing, auto-test, config list, disabled rule display) |

## Test plan

- [x] `cargo test` — 72 tests pass (53 unit + 12 cli + 7 integration)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Manual: install creates config, skips existing, shows checklist
- [x] Manual: `config list` shows rules with Source column

Depends on PR #15. Part of #9 (v0.3 milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)