### PR TITLE
feat: add find/rsync shim and rules

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -374,6 +374,31 @@ pub fn default_rules() -> Vec<RuleConfig> {
             vec!["777".to_string()],
             Some("omamori blocked chmod 777".to_string()),
         ),
+        RuleConfig::new(
+            "find-delete-block",
+            "find",
+            ActionKind::Block,
+            Vec::new(),
+            vec!["-delete".to_string(), "--delete".to_string()],
+            Some("omamori blocked find with -delete flag".to_string()),
+        ),
+        RuleConfig::new(
+            "rsync-delete-block",
+            "rsync",
+            ActionKind::Block,
+            Vec::new(),
+            vec![
+                "--delete".to_string(),
+                "--del".to_string(),
+                "--delete-before".to_string(),
+                "--delete-during".to_string(),
+                "--delete-after".to_string(),
+                "--delete-excluded".to_string(),
+                "--delete-delay".to_string(),
+                "--remove-source-files".to_string(),
+            ],
+            Some("omamori blocked rsync with destructive flags".to_string()),
+        ),
     ]
 }
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::AppError;
 
-const SHIM_COMMANDS: &[&str] = &["rm", "git", "chmod"];
+const SHIM_COMMANDS: &[&str] = &["rm", "git", "chmod", "find", "rsync"];
 
 #[derive(Debug, Clone)]
 pub struct InstallOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -971,8 +971,58 @@ pub fn run_policy_tests(load_result: &ConfigLoadResult) -> Vec<PolicyTestResult>
                 "git".to_string(),
                 vec!["push".to_string(), "--force".to_string()],
             ),
-            claude_env,
+            claude_env.clone(),
             Some("block"),
+            true,
+        ),
+        (
+            "find-delete-is-blocked",
+            CommandInvocation::new(
+                "find".to_string(),
+                vec![
+                    ".".to_string(),
+                    "-name".to_string(),
+                    "*.log".to_string(),
+                    "-delete".to_string(),
+                ],
+            ),
+            claude_env.clone(),
+            Some("block"),
+            true,
+        ),
+        (
+            "find-without-delete-passes",
+            CommandInvocation::new(
+                "find".to_string(),
+                vec![".".to_string(), "-name".to_string(), "*.txt".to_string()],
+            ),
+            claude_env.clone(),
+            None,
+            true,
+        ),
+        (
+            "rsync-delete-is-blocked",
+            CommandInvocation::new(
+                "rsync".to_string(),
+                vec![
+                    "--delete".to_string(),
+                    "-avz".to_string(),
+                    "src/".to_string(),
+                    "dest/".to_string(),
+                ],
+            ),
+            claude_env.clone(),
+            Some("block"),
+            true,
+        ),
+        (
+            "rsync-without-delete-passes",
+            CommandInvocation::new(
+                "rsync".to_string(),
+                vec!["-avz".to_string(), "src/".to_string(), "dest/".to_string()],
+            ),
+            claude_env,
+            None,
             true,
         ),
         (


### PR DESCRIPTION
## Summary

Expand omamori's coverage with find and rsync shim protection.

- `find -delete` / `find --delete` → **block** (AI context only)
- `rsync --delete` and 7 variants → **block** (AI context only)
- Normal `find . -name "*.txt"` and `rsync -avz` pass through unaffected

## Changes
| File | Change |
|------|--------|
| `src/installer.rs` | SHIM_COMMANDS: +find, +rsync |
| `src/config.rs` | default_rules(): +find-delete-block, +rsync-delete-block |
| `src/lib.rs` | 4 new policy test cases in run_policy_tests() |

## rsync flag coverage
`--delete`, `--del`, `--delete-before`, `--delete-during`, `--delete-after`, `--delete-excluded`, `--delete-delay`, `--remove-source-files`

## Test plan
- [x] `cargo test` — 81 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `omamori test` shows find/rsync rules as PASS + 4 new detection tests

Part of #10 (v0.3.1 milestone). PR 3 (env var + interpreter + docs) follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)