### PR TITLE
feat: add Gemini/Cline detectors and interpreter warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -320,6 +320,9 @@ fn default_detectors() -> Vec<DetectorConfig> {
         DetectorConfig::env_var("codex-cli", "CODEX_CI", "1"),
         // Provisional: based on Cursor Forum fix report (2025-08). Verify with future Cursor releases.
         DetectorConfig::env_var("cursor", "CURSOR_AGENT", "1"),
+        // Provisional: based on agents.md #136 reports. Verify with actual tool releases.
+        DetectorConfig::env_var("gemini-cli", "GEMINI_CLI", "1"),
+        DetectorConfig::env_var("cline", "CLINE_ACTIVE", "true"),
         DetectorConfig::env_var("ai-guard-fallback", "AI_GUARD", "1"),
     ]
 }
@@ -800,7 +803,7 @@ enabled = false
         assert!(user.detectors.is_none());
         let mut warnings = Vec::new();
         let config = build_merged_config(user, &mut warnings);
-        assert_eq!(config.detectors.len(), 4); // defaults
+        assert_eq!(config.detectors.len(), 6); // defaults (claude-code, codex-cli, cursor, gemini-cli, cline, ai-guard-fallback)
     }
 
     #[test]

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -170,9 +170,19 @@ case "$INPUT" in
   *"unset CLAUDECODE"*|*"env -u CLAUDECODE"*|*"CLAUDECODE="*|\
   *"unset CODEX_CI"*|*"env -u CODEX_CI"*|*"CODEX_CI="*|\
   *"unset CURSOR_AGENT"*|*"env -u CURSOR_AGENT"*|*"CURSOR_AGENT="*|\
+  *"unset GEMINI_CLI"*|*"env -u GEMINI_CLI"*|*"GEMINI_CLI="*|\
+  *"unset CLINE_ACTIVE"*|*"env -u CLINE_ACTIVE"*|*"CLINE_ACTIVE="*|\
   *"unset AI_GUARD"*|*"env -u AI_GUARD"*|*"AI_GUARD="*)
     echo "omamori hook: blocked attempt to unset a detector env var" >&2
     exit 2
+    ;;
+  *"python "*"-c "*"shutil.rmtree"*|*"python3 "*"-c "*"shutil.rmtree"*|\
+  *"python "*"-c "*"os.remove"*|*"python3 "*"-c "*"os.remove"*|\
+  *"python "*"-c "*"os.rmdir"*|*"python3 "*"-c "*"os.rmdir"*|\
+  *"node "*"-e "*"rmSync"*|*"node "*"-e "*"unlinkSync"*|\
+  *"bash "*"-c "*"rm -rf"*|*"sh "*"-c "*"rm -rf"*)
+    echo "omamori hook: warning — potentially destructive interpreter command detected" >&2
+    exit 0
     ;;
   *)
     exit 0
@@ -242,6 +252,27 @@ pub fn blocked_command_patterns() -> Vec<(&'static str, &'static str)> {
         ),
         (
             "CURSOR_AGENT=",
+            "blocked attempt to unset a detector env var",
+        ),
+        (
+            "unset GEMINI_CLI",
+            "blocked attempt to unset a detector env var",
+        ),
+        (
+            "env -u GEMINI_CLI",
+            "blocked attempt to unset a detector env var",
+        ),
+        ("GEMINI_CLI=", "blocked attempt to unset a detector env var"),
+        (
+            "unset CLINE_ACTIVE",
+            "blocked attempt to unset a detector env var",
+        ),
+        (
+            "env -u CLINE_ACTIVE",
+            "blocked attempt to unset a detector env var",
+        ),
+        (
+            "CLINE_ACTIVE=",
             "blocked attempt to unset a detector env var",
         ),
         (
@@ -320,13 +351,43 @@ mod tests {
     #[test]
     fn hook_script_blocks_all_detector_env_var_unsets() {
         let script = render_hook_script();
-        for var in &["CLAUDECODE", "CODEX_CI", "CURSOR_AGENT", "AI_GUARD"] {
+        for var in &[
+            "CLAUDECODE",
+            "CODEX_CI",
+            "CURSOR_AGENT",
+            "GEMINI_CLI",
+            "CLINE_ACTIVE",
+            "AI_GUARD",
+        ] {
             assert!(
                 script.contains(&format!(r#"*"unset {var}"*"#)),
                 "hook script should block unset of {var}"
             );
         }
         assert!(script.contains("blocked attempt to unset a detector env var"));
+    }
+
+    #[test]
+    fn hook_script_warns_on_interpreter_patterns() {
+        let script = render_hook_script();
+        // Should contain interpreter warning patterns (warn only, exit 0)
+        assert!(
+            script.contains("shutil.rmtree"),
+            "hook script should warn on shutil.rmtree"
+        );
+        assert!(
+            script.contains("os.remove"),
+            "hook script should warn on os.remove"
+        );
+        assert!(
+            script.contains("rmSync"),
+            "hook script should warn on rmSync"
+        );
+        // Should exit 0 for warnings (not exit 2)
+        assert!(
+            script.contains("potentially destructive interpreter command"),
+            "hook script should have interpreter warning message"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,6 +438,45 @@ fn run_cursor_hook() -> Result<i32, AppError> {
         }
     }
 
+    // Check for interpreter patterns (warn only, don't block)
+    let interpreter_patterns = [
+        ("shutil.rmtree", "python shutil.rmtree detected"),
+        ("os.remove", "python os.remove detected"),
+        ("os.rmdir", "python os.rmdir detected"),
+        ("rmSync", "node rmSync detected"),
+        ("unlinkSync", "node unlinkSync detected"),
+    ];
+    // Only check if command involves an interpreter with -c/-e flag
+    if (command.contains("python") && command.contains("-c"))
+        || (command.contains("node") && command.contains("-e"))
+        || (command.contains("bash") && command.contains("-c"))
+        || (command.contains("sh") && command.contains("-c"))
+    {
+        for (pattern, reason) in interpreter_patterns {
+            if command.contains(pattern) {
+                eprintln!("omamori cursor-hook: WARNING ({reason})");
+                print_cursor_response(
+                    true,
+                    "ask",
+                    Some(&format!("omamori warning: {reason}")),
+                    Some("This interpreter command may be destructive. Review before proceeding."),
+                );
+                return Ok(0);
+            }
+        }
+        // bash/sh -c "rm -rf" pattern
+        if command.contains("rm -rf") || command.contains("rm -r ") {
+            eprintln!("omamori cursor-hook: WARNING (shell rm -rf via interpreter)");
+            print_cursor_response(
+                true,
+                "ask",
+                Some("omamori warning: shell rm -rf via interpreter"),
+                Some("This interpreter command may be destructive. Review before proceeding."),
+            );
+            return Ok(0);
+        }
+    }
+
     // Allow
     print_cursor_response(true, "allow", None, None);
     Ok(0)
@@ -1042,6 +1081,26 @@ pub fn run_policy_tests(load_result: &ConfigLoadResult) -> Vec<PolicyTestResult>
                 vec!["-rf".to_string(), "target".to_string()],
             ),
             cursor_env,
+            Some("trash"),
+            true,
+        ),
+        (
+            "gemini-cli-is-protected",
+            CommandInvocation::new(
+                "rm".to_string(),
+                vec!["-rf".to_string(), "target".to_string()],
+            ),
+            vec![("GEMINI_CLI".to_string(), "1".to_string())],
+            Some("trash"),
+            true,
+        ),
+        (
+            "cline-is-protected",
+            CommandInvocation::new(
+                "rm".to_string(),
+                vec!["-rf".to_string(), "target".to_string()],
+            ),
+            vec![("CLINE_ACTIVE".to_string(), "true".to_string())],
             Some("trash"),
             true,
         ),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -452,3 +452,42 @@ fn cursor_hook_handles_malformed_stdin() {
     assert_eq!(parsed["continue"], true);
     assert_eq!(parsed["permission"], "allow");
 }
+
+// ---------------------------------------------------------------------------
+// cursor-hook interpreter warning tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cursor_hook_warns_python_rmtree() {
+    let (stdout, _, success) = run_cursor_hook(
+        r#"{"command":"python3 -c \"import shutil; shutil.rmtree('/tmp/test')\"","cwd":"/tmp"}"#,
+    );
+    assert!(success);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["continue"], true, "should not block, only warn");
+    assert_eq!(parsed["permission"], "ask");
+}
+
+#[test]
+fn cursor_hook_no_warn_safe_python() {
+    let (stdout, _, success) =
+        run_cursor_hook(r#"{"command":"python3 -c \"print('hello')\"","cwd":"/tmp"}"#);
+    assert!(success);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["continue"], true);
+    assert_eq!(parsed["permission"], "allow", "safe python should not warn");
+}
+
+#[test]
+fn cursor_hook_warns_node_rmsync() {
+    let (stdout, _, success) = run_cursor_hook(
+        r#"{"command":"node -e \"require('fs').rmSync('/tmp/test', {recursive: true})\"","cwd":"/tmp"}"#,
+    );
+    assert!(success);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["continue"], true);
+    assert_eq!(parsed["permission"], "ask");
+}


### PR DESCRIPTION
## Summary

Expand AI tool detection and add interpreter command warnings.

### New detectors
- `GEMINI_CLI=1` (Gemini CLI)
- `CLINE_ACTIVE=true` (Cline)
- Both provisional, per agents.md #136 reports

### Interpreter warnings (Layer 2)
- Claude Code hooks: `python -c "shutil.rmtree(...)"` etc → warn (exit 0, not block)
- Cursor hooks: same patterns → `permission: "ask"` (user confirmation)
- Patterns: python shutil.rmtree/os.remove/os.rmdir, node rmSync/unlinkSync, bash/sh rm -rf
- Honest limitation: obfuscated interpreter calls (base64, heredoc) cannot be detected

### Also
- Hook script env var unset protection expanded for GEMINI_CLI and CLINE_ACTIVE
- blocked_command_patterns() expanded for Cursor hook consistency

## Changes
| File | Change |
|------|--------|
| `src/config.rs` | 2 new detectors, test count update |
| `src/installer.rs` | Hook script patterns, env var unset protection, interpreter test |
| `src/lib.rs` | cursor-hook interpreter warnings, 2 new policy tests |
| `tests/cli.rs` | 3 new cursor-hook interpreter tests |

## Test plan
- [x] `cargo test` — 85 tests pass (54 unit + 20 cli + 11 integration)
- [x] `cargo clippy -- -D warnings` — clean

Part of #10 (v0.3.1 milestone). Docs + version bump to follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)