### PR TITLE
feat: AI config bypass guard (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.3.2] - 2026-03-17
+
+### Security
+
+- **AI config bypass guard** (#22): `config disable`, `config enable`, `uninstall`, and `init --force` are now blocked when AI detector environment variables are present (CLAUDECODE, CODEX_CI, CURSOR_AGENT, etc.). This prevents AI agents from disabling their own safety rules — a bypass observed in real-world testing with Gemini CLI.
+- **Hooks protection expanded**: Claude Code and Cursor hooks now block `config disable/enable`, `uninstall`, `init --force`, and direct `config.toml` file editing attempts.
+- **`default_detectors()` made public**: Guard logic reuses the same detector list as the PATH shim, ensuring consistency.
+
+### Changed
+
+- **Protection Coverage table** in README now shows per-tool breakdown including config guard and config.toml edit guard columns.
+- **SECURITY.md** updated with AI Config Bypass Guard section, per-attack-vector protection matrix, and design philosophy statement.
+- Existing tests updated with `clean_ai_env()` helper to prevent false failures in Claude Code sessions.
+
+### Important
+
+- **Existing users**: Run `omamori install --hooks` to update hook scripts with new protection patterns.
+- **Human users are not affected**: Config changes work as before when run directly in the terminal (no AI env var present).
+
 ## [0.3.1] - 2026-03-17
 
 ### Added
@@ -154,6 +173,7 @@ The format is based on Keep a Changelog.
 - Claude Code hook template generation via `omamori install --hooks`.
 - Expanded README and SECURITY documentation for protected and unprotected command coverage.
 
+[0.3.2]: https://github.com/yottayoshida/omamori/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/yottayoshida/omamori/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/yottayoshida/omamori/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/yottayoshida/omamori/compare/v0.2.0...v0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -19,17 +19,19 @@ Detection uses **exact value matching** (e.g. `CLAUDECODE=1` only, not `CLAUDECO
 
 ### Protection Coverage by Tool
 
-| Tool | Layer 1 (PATH shim) | Layer 2 (Hooks) | Full-path bypass protected | Interpreter warnings |
-|------|---------------------|-----------------|---------------------------|---------------------|
-| **Claude Code** | All rules | PreToolUse | Yes | Yes (warn) |
-| **Codex CLI** | All rules | Not available | **No** | No |
-| **Cursor** | All rules | beforeShellExecution | Yes | Yes (ask) |
-| **Gemini CLI** | All rules | Not available | **No** | No |
-| **Cline** | All rules | Not verified | Not verified | Not verified |
+| Tool | Layer 1 (PATH shim) | Layer 2 (Hooks) | Config guard | Full-path bypass | config.toml edit guard |
+|------|---------------------|-----------------|-------------|-----------------|----------------------|
+| **Claude Code** | All rules | PreToolUse | env var block | Hooks block | PreToolUse block |
+| **Codex CLI** | All rules | Not available | env var block | **No** | **No** |
+| **Cursor** | All rules | beforeShellExecution | env var block | Hooks block | Bash only |
+| **Gemini CLI** | All rules | Not available | env var block | **No** | **No** |
+| **Cline** | All rules | Not verified | env var block | Not verified | Not verified |
 
 - **Layer 1 (PATH shim)**: Blocks dangerous commands when AI sets its env var. Bypassable via `/bin/rm` full-path execution.
-- **Layer 2 (Hooks)**: Catches full-path bypass, env var unset attempts, and interpreter commands. Only available for tools with hook APIs.
-- Tools without Layer 2 have reduced protection — AI agents may discover and use bypass paths. See [SECURITY.md](SECURITY.md).
+- **Layer 2 (Hooks)**: Catches full-path bypass, env var unset attempts, interpreter commands, and `config disable`/`uninstall` attempts. Only available for tools with hook APIs.
+- **Config guard** (v0.3.2+): `config disable`, `config enable`, `uninstall`, and `init --force` are blocked when AI detector env vars are present. Works for all tools.
+- **config.toml edit guard**: PreToolUse hook blocks direct file editing of config.toml (Claude Code only). Cursor blocks Bash-based edits. Tools without hooks cannot prevent direct file editing.
+- See [SECURITY.md](SECURITY.md) for full details and known limitations.
 
 ## What It Does
 
@@ -218,8 +220,8 @@ omamori install [--base-dir PATH] [--hooks]           # Create shims + hooks + c
 omamori uninstall [--base-dir PATH]                   # Remove shims + hook files
 omamori init [--force] [--stdout]                     # Create/reset config file
 omamori config list                                   # Show all rules with status
-omamori config disable <rule>                         # Disable a built-in rule
-omamori config enable <rule>                          # Re-enable a disabled rule
+omamori config disable <rule>                         # Disable a rule (blocked by AI tools)
+omamori config enable <rule>                          # Re-enable a rule (blocked by AI tools)
 omamori cursor-hook                                   # Cursor beforeShellExecution handler
 ```
 
@@ -231,7 +233,7 @@ These are inherent to the PATH shim approach and documented honestly:
 - **`sudo`** changes PATH before the shim runs — omamori blocks when it detects elevated execution in-process
 - **Interpreter commands** (`python -c "shutil.rmtree(...)"`) — Layer 2 hooks **warn** on known destructive patterns, but obfuscated code (base64, heredoc, variable indirection) cannot be detected
 - **`find -exec /bin/rm`** bypasses the find shim because rm is invoked via absolute path — partially mitigated by Layer 2 hooks
-- **AI self-bypass**: AI agents without hooks may discover workarounds (full-path execution, `config disable`) — observed in real-world testing with Gemini CLI ([#22](https://github.com/yottayoshida/omamori/issues/22))
+- **AI self-bypass**: `config disable`, `uninstall`, and `init --force` are blocked when AI env vars are detected (v0.3.2+). AI agents may still attempt direct `config.toml` file editing — blocked by PreToolUse hooks in Claude Code only. See [#22](https://github.com/yottayoshida/omamori/issues/22)
 - **Cross-device moves** are not supported for `move-to` (use a destination on the same volume)
 
 For the full security model, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,33 @@ Hooks are **not a complete parser** and should be treated as partial coverage. P
 - Indirect execution via variables or heredocs
 - Commands constructed at runtime by the interpreter
 
+## AI Config Bypass Guard (v0.3.2+)
+
+Real-world testing ([#22](https://github.com/yottayoshida/omamori/issues/22)) showed that AI agents (Gemini CLI) can autonomously discover and use `omamori config disable` to remove protection rules before executing dangerous commands.
+
+### Protection
+
+- `config disable`, `config enable`, `uninstall`, and `init --force` are blocked when AI detector env vars are present
+- Uses the same detector logic as the PATH shim (`evaluate_detectors()`)
+- Hooks also block these commands as string patterns (Claude Code + Cursor)
+- Claude Code PreToolUse hooks block direct `config.toml` file editing via Edit/Write tools
+
+### Known limitations
+
+| Attack vector | Protected | Notes |
+|--------------|-----------|-------|
+| `omamori config disable` | Yes — env var guard | All tools with known env vars |
+| `omamori uninstall` | Yes — env var guard | All tools with known env vars |
+| Direct config.toml editing (Edit/Write) | Claude Code only | PreToolUse hook blocks file_path match |
+| Direct config.toml editing (Bash: sed, echo >>) | Claude Code + Cursor | Hooks block Bash patterns containing config.toml |
+| Direct config.toml editing (other tools) | **No** | Codex CLI, Gemini CLI cannot prevent file editing |
+| env var unset → config disable | Partially | Hooks block env var unset. Without hooks, this attack succeeds |
+| Unknown AI tool (no env var) | **No** | Guard depends on known env vars |
+
+### Design philosophy
+
+DCG (destructive_command_guard) explicitly states that adversarial AI bypass is out of scope. omamori chooses to address this attack surface, acknowledging that complete prevention is impossible in userspace but meaningful risk reduction is achievable through layered defense.
+
 ## Safe Defaults
 
 - Missing config → fail-close using built-in default rules

--- a/src/config.rs
+++ b/src/config.rs
@@ -314,7 +314,7 @@ pub fn default_config_path() -> Option<PathBuf> {
         .map(|home| home.join(".config").join("omamori").join("config.toml"))
 }
 
-fn default_detectors() -> Vec<DetectorConfig> {
+pub fn default_detectors() -> Vec<DetectorConfig> {
     vec![
         DetectorConfig::env_var("claude-code", "CLAUDECODE", "1"),
         DetectorConfig::env_var("codex-cli", "CODEX_CI", "1"),

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -176,6 +176,22 @@ case "$INPUT" in
     echo "omamori hook: blocked attempt to unset a detector env var" >&2
     exit 2
     ;;
+  *"config disable"*|*"config enable"*)
+    echo "omamori hook: blocked attempt to modify omamori rules" >&2
+    exit 2
+    ;;
+  *"omamori uninstall"*)
+    echo "omamori hook: blocked attempt to uninstall omamori" >&2
+    exit 2
+    ;;
+  *"omamori init --force"*)
+    echo "omamori hook: blocked attempt to overwrite omamori config" >&2
+    exit 2
+    ;;
+  *"omamori/config.toml"*|*"omamori"*"config.toml"*)
+    echo "omamori hook: blocked attempt to edit omamori config file directly" >&2
+    exit 2
+    ;;
   *"python "*"-c "*"shutil.rmtree"*|*"python3 "*"-c "*"shutil.rmtree"*|\
   *"python "*"-c "*"os.remove"*|*"python3 "*"-c "*"os.remove"*|\
   *"python "*"-c "*"os.rmdir"*|*"python3 "*"-c "*"os.rmdir"*|\
@@ -284,6 +300,14 @@ pub fn blocked_command_patterns() -> Vec<(&'static str, &'static str)> {
             "blocked attempt to unset a detector env var",
         ),
         ("AI_GUARD=", "blocked attempt to unset a detector env var"),
+        // Config modification protection (#22)
+        ("config disable", "blocked attempt to modify omamori rules"),
+        ("config enable", "blocked attempt to modify omamori rules"),
+        ("omamori uninstall", "blocked attempt to uninstall omamori"),
+        (
+            "omamori init --force",
+            "blocked attempt to overwrite omamori config",
+        ),
     ]
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,7 @@ fn run_install_command(args: &[OsString]) -> Result<i32, AppError> {
 }
 
 fn run_uninstall_command(args: &[OsString]) -> Result<i32, AppError> {
+    guard_ai_config_modification("uninstall")?;
     let mut base_dir = default_base_dir();
     let mut index = 2usize;
 
@@ -537,6 +538,23 @@ fn run_config_command(args: &[OsString]) -> Result<i32, AppError> {
     }
 }
 
+/// Guard against AI agents modifying omamori's own configuration.
+/// Blocks when any AI detector env var is present (exact match via evaluate_detectors).
+fn guard_ai_config_modification(operation: &str) -> Result<(), AppError> {
+    let detectors = config::default_detectors();
+    let env_pairs: Vec<(String, String)> = std::env::vars().collect();
+    let detection = evaluate_detectors(&detectors, &env_pairs);
+    if detection.protected {
+        return Err(AppError::Config(format!(
+            "{operation} blocked — AI agent environment detected ({}).\n  \
+             Protection rules cannot be modified by AI tools.\n  \
+             To modify, run this command directly in your terminal (not via AI).",
+            detection.matched_detectors.join(", ")
+        )));
+    }
+    Ok(())
+}
+
 fn validate_rule_name(name: &str) -> Result<(), AppError> {
     let known_names: Vec<String> = config::default_rules()
         .iter()
@@ -563,6 +581,7 @@ fn resolve_config_path_checked() -> Result<std::path::PathBuf, AppError> {
 }
 
 fn run_config_disable(rule_name: &str) -> Result<i32, AppError> {
+    guard_ai_config_modification("config disable")?;
     validate_rule_name(rule_name)?;
 
     let config_path = resolve_config_path_checked()?;
@@ -657,6 +676,7 @@ fn run_config_disable(rule_name: &str) -> Result<i32, AppError> {
 }
 
 fn run_config_enable(rule_name: &str) -> Result<i32, AppError> {
+    guard_ai_config_modification("config enable")?;
     validate_rule_name(rule_name)?;
 
     let config_path = resolve_config_path_checked()?;
@@ -821,6 +841,11 @@ fn run_init_command(args: &[OsString]) -> Result<i32, AppError> {
                 )));
             }
         }
+    }
+
+    // Guard: init --force can overwrite existing config → block in AI sessions
+    if force {
+        guard_ai_config_modification("init --force")?;
     }
 
     // --stdout: backward-compatible stdout output

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -25,6 +25,17 @@ fn binary() -> String {
     env!("CARGO_BIN_EXE_omamori").to_string()
 }
 
+/// Remove all AI detector env vars from a Command to prevent
+/// guard_ai_config_modification() from blocking during tests.
+fn clean_ai_env(cmd: &mut Command) -> &mut Command {
+    cmd.env_remove("CLAUDECODE")
+        .env_remove("CODEX_CI")
+        .env_remove("CURSOR_AGENT")
+        .env_remove("GEMINI_CLI")
+        .env_remove("CLINE_ACTIVE")
+        .env_remove("AI_GUARD")
+}
+
 #[test]
 fn omamori_test_command_succeeds_with_defaults() {
     let output = Command::new(binary())
@@ -171,7 +182,9 @@ fn init_force_overwrites_existing() {
         fs::set_permissions(&config_path, fs::Permissions::from_mode(0o600)).unwrap();
     }
 
-    let output = Command::new(binary())
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
         .args(["init", "--force"])
         .env("XDG_CONFIG_HOME", &dir)
         .env_remove("HOME")
@@ -490,4 +503,134 @@ fn cursor_hook_warns_node_rmsync() {
         serde_json::from_str(&stdout).expect("stdout must be valid JSON");
     assert_eq!(parsed["continue"], true);
     assert_eq!(parsed["permission"], "ask");
+}
+
+// ---------------------------------------------------------------------------
+// AI config bypass guard tests (#22)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_disable_blocked_in_ai_session() {
+    let dir = unique_dir("guard-disable");
+
+    // Init config first (no AI env var)
+    let mut init_cmd = Command::new(binary());
+    clean_ai_env(&mut init_cmd);
+    init_cmd
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    // Try config disable WITH AI env var → should be blocked
+    let output = Command::new(binary())
+        .args(["config", "disable", "git-push-force-block"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .env("CLAUDECODE", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "should be blocked, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("blocked"));
+    assert!(stderr.contains("CLAUDECODE") || stderr.contains("claude-code"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn config_enable_blocked_in_ai_session() {
+    let output = Command::new(binary())
+        .args(["config", "enable", "git-push-force-block"])
+        .env("CODEX_CI", "1")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("blocked"));
+}
+
+#[test]
+fn uninstall_blocked_in_ai_session() {
+    let output = Command::new(binary())
+        .args(["uninstall"])
+        .env("CURSOR_AGENT", "1")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("blocked"));
+}
+
+#[test]
+fn init_force_blocked_in_ai_session() {
+    let output = Command::new(binary())
+        .args(["init", "--force"])
+        .env("GEMINI_CLI", "1")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("blocked"));
+}
+
+#[test]
+fn config_disable_allowed_without_ai_env() {
+    let dir = unique_dir("guard-allow");
+
+    let mut init_cmd = Command::new(binary());
+    clean_ai_env(&mut init_cmd);
+    init_cmd
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["config", "disable", "git-push-force-block"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "should be allowed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Disabled"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn any_single_ai_env_var_blocks() {
+    // Even just CLINE_ACTIVE=true should block
+    let output = Command::new(binary())
+        .args(["config", "disable", "git-push-force-block"])
+        .env_remove("CLAUDECODE")
+        .env_remove("CODEX_CI")
+        .env_remove("CURSOR_AGENT")
+        .env_remove("GEMINI_CLI")
+        .env_remove("AI_GUARD")
+        .env("CLINE_ACTIVE", "true")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("blocked"));
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,6 +2,15 @@ use std::fs;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+fn clean_ai_env(cmd: &mut Command) -> &mut Command {
+    cmd.env_remove("CLAUDECODE")
+        .env_remove("CODEX_CI")
+        .env_remove("CURSOR_AGENT")
+        .env_remove("GEMINI_CLI")
+        .env_remove("CLINE_ACTIVE")
+        .env_remove("AI_GUARD")
+}
+
 fn unique_dir(name: &str) -> std::path::PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -64,7 +73,9 @@ fn uninstall_removes_generated_artifacts() {
         .expect("failed to run install");
     assert!(install_status.success());
 
-    let uninstall_output = Command::new(binary)
+    let mut uninstall_cmd = Command::new(binary);
+    clean_ai_env(&mut uninstall_cmd);
+    let uninstall_output = uninstall_cmd
         .arg("uninstall")
         .arg("--base-dir")
         .arg(&base_dir)
@@ -278,7 +289,9 @@ fn config_disable_adds_block() {
     assert!(output.status.success());
 
     // Disable a rule
-    let output = Command::new(binary)
+    let mut cmd = Command::new(binary);
+    clean_ai_env(&mut cmd);
+    let output = cmd
         .args(["config", "disable", "git-push-force-block"])
         .env("XDG_CONFIG_HOME", &config_dir)
         .env_remove("HOME")
@@ -316,15 +329,21 @@ fn config_enable_removes_block() {
         .env_remove("HOME")
         .output()
         .unwrap();
-    Command::new(binary)
-        .args(["config", "disable", "git-push-force-block"])
-        .env("XDG_CONFIG_HOME", &config_dir)
-        .env_remove("HOME")
-        .output()
-        .unwrap();
+    {
+        let mut c = Command::new(binary);
+        clean_ai_env(&mut c);
+        c
+    }
+    .args(["config", "disable", "git-push-force-block"])
+    .env("XDG_CONFIG_HOME", &config_dir)
+    .env_remove("HOME")
+    .output()
+    .unwrap();
 
     // Enable it back
-    let output = Command::new(binary)
+    let mut cmd = Command::new(binary);
+    clean_ai_env(&mut cmd);
+    let output = cmd
         .args(["config", "enable", "git-push-force-block"])
         .env("XDG_CONFIG_HOME", &config_dir)
         .env_remove("HOME")
@@ -357,15 +376,21 @@ fn config_disable_already_disabled_returns_2() {
         .env_remove("HOME")
         .output()
         .unwrap();
-    Command::new(binary)
-        .args(["config", "disable", "git-push-force-block"])
-        .env("XDG_CONFIG_HOME", &config_dir)
-        .env_remove("HOME")
-        .output()
-        .unwrap();
+    {
+        let mut c = Command::new(binary);
+        clean_ai_env(&mut c);
+        c
+    }
+    .args(["config", "disable", "git-push-force-block"])
+    .env("XDG_CONFIG_HOME", &config_dir)
+    .env_remove("HOME")
+    .output()
+    .unwrap();
 
     // Try to disable again
-    let output = Command::new(binary)
+    let mut cmd = Command::new(binary);
+    clean_ai_env(&mut cmd);
+    let output = cmd
         .args(["config", "disable", "git-push-force-block"])
         .env("XDG_CONFIG_HOME", &config_dir)
         .env_remove("HOME")
@@ -383,7 +408,9 @@ fn config_disable_already_disabled_returns_2() {
 fn config_disable_unknown_rule_fails() {
     let binary = env!("CARGO_BIN_EXE_omamori");
 
-    let output = Command::new(binary)
+    let mut cmd = Command::new(binary);
+    clean_ai_env(&mut cmd);
+    let output = cmd
         .args(["config", "disable", "nonexistent-rule"])
         .output()
         .unwrap();


### PR DESCRIPTION
## Summary

Prevent AI agents from disabling their own safety rules (#22).

### Blocked (when AI env var detected)
- `config disable/enable`, `uninstall`, `init --force`

### Not blocked
- `config list` (read-only), human terminal usage, CI

### Hooks expanded
- config disable/enable, uninstall, init --force, config.toml editing

91 tests pass. Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)