### PR TITLE
feat: add --version subcommand

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,10 @@ pub fn run(args: &[OsString]) -> Result<i32, AppError> {
         Some("init") => run_init_command(args),
         Some("config") => run_config_command(args),
         Some("cursor-hook") => run_cursor_hook(),
+        Some("version") | Some("--version") | Some("-V") => {
+            println!("omamori {}", env!("CARGO_PKG_VERSION"));
+            Ok(0)
+        }
         Some("help") | Some("--help") | Some("-h") | None => {
             print_usage();
             Ok(0)
@@ -881,6 +885,7 @@ fn run_init_command(args: &[OsString]) -> Result<i32, AppError> {
 
 fn usage_text() -> &'static str {
     "omamori usage:
+  omamori --version                                      # Show version
   omamori test [--config PATH]
   omamori exec [--config PATH] -- <command> [args...]
   omamori install [--base-dir PATH] [--source PATH] [--hooks]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -634,3 +634,47 @@ fn any_single_ai_env_var_blocks() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("blocked"));
 }
+
+// ---------------------------------------------------------------------------
+// --version subcommand
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_flag_prints_version() {
+    let output = Command::new(binary())
+        .arg("--version")
+        .output()
+        .expect("failed to run omamori --version");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.starts_with("omamori "),
+        "expected 'omamori <version>', got: {stdout}"
+    );
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "version mismatch: {stdout}"
+    );
+}
+
+#[test]
+fn version_short_flag_works() {
+    let output = Command::new(binary())
+        .arg("-V")
+        .output()
+        .expect("failed to run omamori -V");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.starts_with("omamori "));
+}
+
+#[test]
+fn version_subcommand_works() {
+    let output = Command::new(binary())
+        .arg("version")
+        .output()
+        .expect("failed to run omamori version");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.starts_with("omamori "));
+}


### PR DESCRIPTION
## Summary
- Add `omamori --version`, `-V`, and `version` subcommands
- Display version from `Cargo.toml` via `env!("CARGO_PKG_VERSION")`
- Update `usage_text()` to include `--version` in help output

## Part of v0.4.0 (#13)
PR 1/5 for context-aware rule evaluation release.

## Test plan
- [x] `omamori --version` prints `omamori 0.3.2`
- [x] `omamori -V` prints same output
- [x] `omamori version` prints same output
- [x] 94 tests pass (91 existing + 3 new)
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)