### PR TITLE
feat: git-aware rule evaluation (#13 Tier 2)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -269,6 +269,159 @@ pub fn evaluate_context(
 }
 
 // ---------------------------------------------------------------------------
+// Git-aware evaluation (Tier 2)
+// ---------------------------------------------------------------------------
+
+/// Git env vars that must be removed from subprocess to prevent spoofing (T4).
+const GIT_SPOOFABLE_ENV_VARS: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+];
+
+/// Query `git status --porcelain` with timeout and env var sanitization.
+/// Returns Ok(output) on success, Err(reason) on failure/timeout.
+fn git_status_porcelain(detector_env_keys: &[String], timeout_ms: u64) -> Result<String, String> {
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let mut cmd = Command::new("git");
+    cmd.args(["status", "--porcelain"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+    // Remove AI detector env vars (self-interference prevention)
+    for key in detector_env_keys {
+        cmd.env_remove(key);
+    }
+    // Remove git spoofable env vars (T4 defense)
+    for key in GIT_SPOOFABLE_ENV_VARS {
+        cmd.env_remove(key);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("failed to spawn git: {e}"))?;
+
+    let (tx, rx) = mpsc::channel();
+    let child_stdout = child.stdout.take();
+
+    std::thread::spawn(move || {
+        use std::io::Read;
+        let mut output = String::new();
+        if let Some(mut stdout) = child_stdout {
+            let _ = stdout.read_to_string(&mut output);
+        }
+        let _ = tx.send(output);
+    });
+
+    match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
+        Ok(output) => {
+            let _ = child.wait(); // reap
+            Ok(output)
+        }
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait(); // reap zombie
+            Err(format!("git status timed out after {}ms", timeout_ms))
+        }
+    }
+}
+
+/// Check if we're inside a git repository.
+fn is_inside_git_repo(detector_env_keys: &[String]) -> bool {
+    use std::process::{Command, Stdio};
+
+    let mut cmd = Command::new("git");
+    cmd.args(["rev-parse", "--is-inside-work-tree"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    for key in detector_env_keys {
+        cmd.env_remove(key);
+    }
+    for key in GIT_SPOOFABLE_ENV_VARS {
+        cmd.env_remove(key);
+    }
+
+    cmd.status().map(|s| s.success()).unwrap_or(false)
+}
+
+/// Evaluate git context for a matched rule.
+/// Only applies to git commands (reset --hard, clean).
+/// Returns None if git-aware is disabled or not applicable.
+pub fn evaluate_git_context(
+    invocation: &CommandInvocation,
+    config: &GitContextConfig,
+    detector_env_keys: &[String],
+) -> Option<ContextEvaluation> {
+    if !config.enabled {
+        return None;
+    }
+
+    // Only evaluate git commands
+    if invocation.program != "git" {
+        return None;
+    }
+
+    // Not inside a git repo → skip (avoid false positives)
+    if !is_inside_git_repo(detector_env_keys) {
+        return Some(ContextEvaluation {
+            action_override: None,
+            reason: "not inside a git repository; skipping git-aware evaluation".to_string(),
+        });
+    }
+
+    let args: Vec<&str> = invocation.args.iter().map(String::as_str).collect();
+
+    // git reset --hard: check for uncommitted changes
+    if args.contains(&"reset") && args.contains(&"--hard") {
+        return match git_status_porcelain(detector_env_keys, config.timeout_ms) {
+            Ok(output) if output.trim().is_empty() => Some(ContextEvaluation {
+                action_override: Some(ActionKind::LogOnly),
+                reason: "no uncommitted changes detected".to_string(),
+            }),
+            Ok(_) => Some(ContextEvaluation {
+                action_override: None,
+                reason: "uncommitted changes present; keeping original action".to_string(),
+            }),
+            Err(reason) => Some(ContextEvaluation {
+                action_override: None,
+                reason: format!("git status failed ({}); keeping original action", reason),
+            }),
+        };
+    }
+
+    // git clean -fd/-fdx: check for untracked files
+    if args.contains(&"clean") && (args.contains(&"-fd") || args.contains(&"-fdx")) {
+        return match git_status_porcelain(detector_env_keys, config.timeout_ms) {
+            Ok(output) => {
+                let has_untracked = output.lines().any(|line| line.starts_with("??"));
+                if has_untracked {
+                    Some(ContextEvaluation {
+                        action_override: None,
+                        reason: "untracked files present; keeping original action".to_string(),
+                    })
+                } else {
+                    Some(ContextEvaluation {
+                        action_override: Some(ActionKind::LogOnly),
+                        reason: "no untracked files detected".to_string(),
+                    })
+                }
+            }
+            Err(reason) => Some(ContextEvaluation {
+                action_override: None,
+                reason: format!("git status failed ({}); keeping original action", reason),
+            }),
+        };
+    }
+
+    None // Not a git command we evaluate
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,43 +422,84 @@ fn run_command(
         .map(|d| d.env_key.clone())
         .filter(|k| !k.is_empty() && !k.contains('='))
         .collect();
-    let mut executor = ActionExecutor::new(SystemOps::new(resolved_program, detector_env_keys));
+    let mut executor =
+        ActionExecutor::new(SystemOps::new(resolved_program, detector_env_keys.clone()));
     let audit_logger = AuditLogger::from_config(&load_result.config.audit);
 
     // Context-aware evaluation: compute effective rule (may differ from matched_rule)
-    let context_override: Option<RuleConfig> =
-        if let (Some(rule), Some(ctx_config)) = (matched_rule, &load_result.config.context) {
-            if detection.protected {
-                let ctx = context::evaluate_context(&invocation, rule, ctx_config);
-                if let Some(override_action) = ctx.action_override {
-                    eprintln!(
-                        "omamori: {} {} → {} ({}, original: {})",
-                        invocation.program,
-                        invocation.target_args().join(" "),
-                        override_action.as_str(),
-                        ctx.reason,
-                        rule.action.as_str(),
-                    );
-                    let mut overridden = rule.clone();
-                    overridden.action = override_action;
-                    if let Some(ref msg) = overridden.message {
-                        overridden.message = Some(format!("{} (context: {})", msg, ctx.reason));
+    let context_override: Option<RuleConfig> = if let (Some(rule), Some(ctx_config)) =
+        (matched_rule, &load_result.config.context)
+    {
+        if detection.protected {
+            // Tier 1: path-based evaluation
+            let ctx = context::evaluate_context(&invocation, rule, ctx_config);
+            let tier1_override = if let Some(override_action) = ctx.action_override {
+                eprintln!(
+                    "omamori: {} {} → {} ({}, original: {})",
+                    invocation.program,
+                    invocation.target_args().join(" "),
+                    override_action.as_str(),
+                    ctx.reason,
+                    rule.action.as_str(),
+                );
+                let mut overridden = rule.clone();
+                overridden.action = override_action;
+                if let Some(ref msg) = overridden.message {
+                    overridden.message = Some(format!("{} (context: {})", msg, ctx.reason));
+                }
+                Some(overridden)
+            } else {
+                if !ctx.reason.contains("no target paths")
+                    && !ctx.reason.contains("no context pattern")
+                {
+                    eprintln!("omamori warning: {}", ctx.reason);
+                }
+                None
+            };
+
+            // Tier 2: git-aware evaluation (skip if Tier 1 already escalated to Block)
+            let is_escalated = tier1_override
+                .as_ref()
+                .is_some_and(|r| matches!(r.action, rules::ActionKind::Block));
+
+            if !is_escalated {
+                if let Some(git_ctx) =
+                    context::evaluate_git_context(&invocation, &ctx_config.git, &detector_env_keys)
+                {
+                    if let Some(git_action) = git_ctx.action_override {
+                        eprintln!(
+                            "omamori: {} {} → {} ({}, original: {})",
+                            invocation.program,
+                            invocation.args.join(" "),
+                            git_action.as_str(),
+                            git_ctx.reason,
+                            rule.action.as_str(),
+                        );
+                        let mut overridden = rule.clone();
+                        overridden.action = git_action;
+                        if let Some(ref msg) = overridden.message {
+                            overridden.message =
+                                Some(format!("{} (context: {})", msg, git_ctx.reason));
+                        }
+                        Some(overridden)
+                    } else {
+                        if !git_ctx.reason.contains("skipping") {
+                            eprintln!("omamori: {}", git_ctx.reason);
+                        }
+                        tier1_override
                     }
-                    Some(overridden)
                 } else {
-                    if !ctx.reason.contains("no target paths")
-                        && !ctx.reason.contains("no context pattern")
-                    {
-                        eprintln!("omamori warning: {}", ctx.reason);
-                    }
-                    None
+                    tier1_override
                 }
             } else {
-                None
+                tier1_override
             }
         } else {
             None
-        };
+        }
+    } else {
+        None
+    };
 
     let effective_rule = match (&context_override, matched_rule) {
         (Some(overridden), _) => Some(overridden),


### PR DESCRIPTION
## Summary
- Opt-in git-aware context evaluation via `[context.git] enabled = true`
- `git reset --hard` with no uncommitted changes → downgrade to log-only
- `git clean -fd` with no untracked files → downgrade to log-only
- Git env var spoofing defense (T4): `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR` removed from subprocess
- Thread-based timeout (default 100ms) with fail-close on timeout/error
- Outside git repo → skip (avoid false positives)
- Tier 1 Block escalation prevents Tier 2 downgrade (action priority order)

## Part of v0.4.0 (#13)
PR 4/5 for context-aware rule evaluation release.

## Test plan
- [x] 114 tests pass (no new integration tests — git subprocess tests require real repo setup, planned for v0.4.1 bypass corpus)
- [x] `cargo clippy` with `-D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Backward compatible: `[context.git] enabled = false` (default) skips all git evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)