### PR TITLE
docs: v0.4.0 release — context-aware rule evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.4.0] - 2026-03-18
+
+### Added
+
+- **Context-aware rule evaluation** (#13): omamori now evaluates command target paths and git status to dynamically adjust protection actions, reducing false positives while strengthening defense against truly dangerous operations.
+  - **Tier 1 — Path-based risk scoring**: `regenerable_paths` (e.g., `target/`, `node_modules/`) downgrade to `log-only`; `protected_paths` (e.g., `src/`, `.git/`) escalate to `block`.
+  - **Tier 2 — Git-aware evaluation** (opt-in): `git reset --hard` with no uncommitted changes → `log-only`; `git clean -fd` with no untracked files → `log-only`. Default off, enable via `[context.git] enabled = true`.
+  - **NEVER_REGENERABLE safety list**: `src/`, `lib/`, `.git/`, `.env`, `.ssh/` etc. cannot be classified as regenerable even if misconfigured.
+  - **Symlink attack defense** (T2, DREAD 9.0): `canonicalize()` resolves symlinks before pattern matching. Canonicalize failure → no downgrade (fail-close).
+  - **Path traversal defense** (T1, DREAD 8.0): Lexical normalization before matching prevents `target/../src/` bypass.
+  - **Git env var spoofing defense** (T4, DREAD 7.2): `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` removed from git subprocess.
+  - **Multi-target evaluation**: All targets are checked; the most severe action wins (`rm -rf target/ src/` → block, not log-only).
+  - **`omamori test`** now shows a Context evaluation section when `[context]` is configured.
+  - All context decisions are reported via stderr for transparency.
+- **`--version` subcommand** (#31): `omamori --version`, `-V`, and `version` now display the current version.
+
+### Fixed
+
+- **config.default.toml sync** (#32): Updated to match `default_detectors()` and `default_rules()`. Fixed stale env vars (codex-cli: `AI_GUARD` → `CODEX_CI`, cursor: `AI_GUARD` → `CURSOR_AGENT`), added missing detectors (gemini-cli, cline, ai-guard-fallback) and rules (find-delete-block, rsync-delete-block).
+
+### Important
+
+- **Opt-in activation**: Context-aware evaluation is disabled by default. Add `[context]` to your `config.toml` to enable it. Without `[context]`, behavior is identical to v0.3.2.
+- **Existing users**: Run `omamori install --hooks` to update hook scripts.
+
 ## [0.3.2] - 2026-03-17
 
 ### Security

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -197,6 +197,50 @@ Summary: 7 rules (6 active, 1 disabled), 12 detection tests passed
 - Symlinks are rejected as destinations
 - `destination` directory must exist before use (omamori will not create it)
 
+## Context-Aware Evaluation (v0.4.0+)
+
+omamori can adjust protection actions based on command target paths and git status. This reduces false positives (e.g., `rm -rf target/` in a Rust project) while strengthening defense for critical paths.
+
+**Opt-in**: Add `[context]` to your `config.toml` to enable. Without it, behavior is identical to v0.3.
+
+### Quick setup
+
+```toml
+# Add to ~/.config/omamori/config.toml
+[context]
+# Built-in defaults activate:
+# - regenerable: target/, node_modules/, .next/, dist/, build/, __pycache__/, .cache/
+# - protected: src/, lib/, .git/, .env, .ssh/
+```
+
+### Custom paths
+
+```toml
+[context]
+regenerable_paths = ["my-cache/"]      # Added to built-in list
+protected_paths = ["secrets/"]          # Added to built-in list
+
+[context.git]
+enabled = true    # Check git status before acting (default: false)
+timeout_ms = 100  # Git status timeout in ms (default: 100)
+```
+
+### How it works
+
+| Command | Without context | With context |
+|---------|----------------|-------------|
+| `rm -rf target/` | trash | **log-only** (regenerable) |
+| `rm -rf src/` | trash | **block** (protected) |
+| `rm -rf data/` | trash | trash (unchanged) |
+| `git reset --hard` (no changes) | stash-then-exec | **log-only** (git-aware, opt-in) |
+
+### Security features
+
+- **Symlink defense**: `canonicalize()` resolves symlinks before matching — `ln -sf src/ target && rm -rf target` is caught
+- **Traversal defense**: `target/../src/` is normalized to `src/` before matching
+- **NEVER_REGENERABLE**: `src/`, `.git/`, `.env` etc. cannot be made regenerable even by misconfiguration
+- **Fail-close**: canonicalize failure or git timeout → original action preserved
+
 ## Available Actions
 
 | Action | Behavior |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 `omamori` is a PATH-shim safeguard for AI-triggered shell commands. It reduces risk for a narrow set of destructive commands, but it is not a sandbox and it does not claim complete mediation.
 
-## What It Protects (v0.3.1)
+## What It Protects (v0.4.0)
 
 - recursive `rm` variants matched by the default rules
 - `git reset --hard`
@@ -104,6 +104,34 @@ Real-world testing ([#22](https://github.com/yottayoshida/omamori/issues/22)) sh
 ### Design philosophy
 
 DCG (destructive_command_guard) explicitly states that adversarial AI bypass is out of scope. omamori chooses to address this attack surface, acknowledging that complete prevention is impossible in userspace but meaningful risk reduction is achievable through layered defense.
+
+## Context-Aware Evaluation (v0.4.0+)
+
+### Threat Model
+
+Context-aware evaluation introduces dynamic action adjustment based on target paths and git status. This changes the attack surface from "static rules only" to "static rules + contextual overrides."
+
+| Threat | DREAD | Mitigation |
+|--------|-------|------------|
+| **T2: Symlink downgrade** | 9.0 | `canonicalize()` resolves symlinks before matching. Failure → no downgrade (fail-close) |
+| **T1: Path traversal** | 8.0 | Lexical normalization (`.`, `..`, `//`, trailing `/`) before matching. Raw path matching prohibited |
+| **T10: TOCTOU** | 7.8 | Accepted residual risk. evaluate→execute window minimized. Cannot be eliminated in userspace |
+| **T4: Git status spoofing** | 7.2 | `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR` removed from git subprocess |
+| **T3: Config poisoning** | 7.0 | AI config bypass guard (v0.3.2) + NEVER_REGENERABLE hardcoded list |
+
+### NEVER_REGENERABLE
+
+The following paths cannot be classified as regenerable regardless of config: `src`, `lib`, `app`, `.git`, `.env`, `.ssh`. If a user adds these to `regenerable_paths`, the pattern is silently ignored and a config load warning is emitted.
+
+### Residual Risks
+
+| Risk | Reason for acceptance |
+|------|----------------------|
+| TOCTOU between evaluate and execute | Atomic path-check + delete is impossible in userspace |
+| `trash` crate symlink behavior | Upstream dependency; monitor CHANGELOG |
+| Unicode normalization differences | macOS HFS+/APFS normalizes to NFD; practical impact is limited |
+| AI continuous path generation attempts | No rate limiting; mitigated by hooks |
+| Git-aware disabled by default | Opt-in design; documented trade-off |
 
 ## Safe Defaults
 


### PR DESCRIPTION
## Summary
- Bump version `0.3.2` → `0.4.0`
- CHANGELOG: Full v0.4.0 entry covering context-aware features, --version, config sync
- SECURITY.md: Context-aware threat model (STRIDE/DREAD), NEVER_REGENERABLE, residual risks
- README: Context-Aware Evaluation section with quick setup, examples, security features

## Part of v0.4.0 (#13)
PR 5/5 — final release PR.

## After merge
1. `git tag v0.4.0 && git push origin v0.4.0`
2. `cargo publish`
3. Update Homebrew tap
4. GitHub Release

## Test plan
- [x] 114 tests pass
- [x] `cargo clippy` passes
- [x] Version shows `0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)