### PR TITLE
fix: context override message now matches actual action (#36)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,10 +443,8 @@ fn run_command(
                     rule.action.as_str(),
                 );
                 let mut overridden = rule.clone();
+                overridden.message = Some(override_action.context_message(&ctx.reason));
                 overridden.action = override_action;
-                if let Some(ref msg) = overridden.message {
-                    overridden.message = Some(format!("{} (context: {})", msg, ctx.reason));
-                }
                 Some(overridden)
             } else {
                 if !ctx.reason.contains("no target paths")
@@ -476,11 +474,8 @@ fn run_command(
                             rule.action.as_str(),
                         );
                         let mut overridden = rule.clone();
+                        overridden.message = Some(git_action.context_message(&git_ctx.reason));
                         overridden.action = git_action;
-                        if let Some(ref msg) = overridden.message {
-                            overridden.message =
-                                Some(format!("{} (context: {})", msg, git_ctx.reason));
-                        }
                         Some(overridden)
                     } else {
                         if !git_ctx.reason.contains("skipping") {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -47,6 +47,19 @@ impl ActionKind {
             Self::MoveTo => "move-to",
         }
     }
+
+    /// Generate a context-aware message that always matches the actual action.
+    /// Used when context evaluation overrides the original rule's action,
+    /// ensuring the user sees accurate feedback (e.g. "blocked" not "moved to Trash").
+    pub fn context_message(&self, reason: &str) -> String {
+        match self {
+            Self::Block => format!("omamori blocked this command ({})", reason),
+            Self::LogOnly => format!("omamori allowed this command ({})", reason),
+            Self::Trash => format!("omamori moved targets to Trash ({})", reason),
+            Self::StashThenExec => format!("omamori stashed changes first ({})", reason),
+            Self::MoveTo => format!("omamori moved targets to backup ({})", reason),
+        }
+    }
 }
 
 fn default_true() -> bool {
@@ -367,5 +380,39 @@ mod tests {
             ],
         );
         assert!(match_rule(&[rule], &inv).is_some());
+    }
+
+    // --- context_message tests (#36) ---
+
+    #[test]
+    fn context_message_matches_action_kind() {
+        let reason = "NEVER_REGENERABLE path";
+        assert_eq!(
+            ActionKind::Block.context_message(reason),
+            "omamori blocked this command (NEVER_REGENERABLE path)"
+        );
+        assert_eq!(
+            ActionKind::LogOnly.context_message(reason),
+            "omamori allowed this command (NEVER_REGENERABLE path)"
+        );
+        assert_eq!(
+            ActionKind::Trash.context_message(reason),
+            "omamori moved targets to Trash (NEVER_REGENERABLE path)"
+        );
+        assert_eq!(
+            ActionKind::StashThenExec.context_message(reason),
+            "omamori stashed changes first (NEVER_REGENERABLE path)"
+        );
+        assert_eq!(
+            ActionKind::MoveTo.context_message(reason),
+            "omamori moved targets to backup (NEVER_REGENERABLE path)"
+        );
+    }
+
+    #[test]
+    fn context_message_includes_reason() {
+        let msg = ActionKind::Block.context_message("git working tree has uncommitted changes");
+        assert!(msg.contains("blocked"));
+        assert!(msg.contains("git working tree has uncommitted changes"));
     }
 }


### PR DESCRIPTION
## Summary
- Add `ActionKind::context_message()` that generates user-facing messages matching the actual action
- Fix Tier 1 (path-based) and Tier 2 (git-aware) context override to always use `context_message()` instead of preserving the original rule's message
- Fixes message=None rules silently losing context information

Closes #36

## What changed
| File | Change |
|------|--------|
| `src/rules.rs` | Added `ActionKind::context_message(&self, reason)` + 2 tests |
| `src/lib.rs` | Replaced conditional message override with unconditional `context_message()` at L445-447 (Tier 1) and L477-479 (Tier 2) |

## Before / After
```
# Before: rm -rf src/ → context escalates trash → block
omamori: rm src/ → block (NEVER_REGENERABLE, original: trash)
# message shown to user: "moved to Trash (context: NEVER_REGENERABLE)"  ← WRONG

# After:
omamori: rm src/ → block (NEVER_REGENERABLE, original: trash)
# message: "omamori blocked this command (NEVER_REGENERABLE)"  ← CORRECT
```

## Test plan
- [x] 116 tests pass (74 unit + 29 cli + 11 integration + 2 new)
- [x] `RUSTFLAGS="-D warnings" cargo test` clean
- [x] `cargo fmt --check` clean
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)