### PR TITLE
test: add CI consistency checks for config/code sync

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -105,5 +105,16 @@ message = "omamori blocked rsync with destructive flags"
 # match_any = ["-r", "-rf", "-fr", "--recursive"]
 # message = "omamori moved targets to backup instead of deleting"
 
+# --- Context-aware evaluation (new in v0.4) ---
+# Uncomment to enable context-aware rule evaluation.
+# When present (even empty), built-in defaults for protected/regenerable paths activate.
+#
+# [context]
+# protected_paths = ["src/", "lib/", ".git/", ".env", ".ssh/"]
+# regenerable_paths = ["target/", "dist/", "node_modules/", "build/", "__pycache__/", ".cache/"]
+#
+# [context.git]
+# uncommitted_escalation = "block"
+
 [audit]
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -855,4 +855,42 @@ action = "block"
         let parsed: Wrapper = toml::from_str(toml_str).unwrap();
         assert!(parsed.rules[0].enabled);
     }
+
+    // --- CI consistency checks (PR 2: config.default.toml ↔ code sync) ---
+
+    #[test]
+    fn config_default_toml_rules_match_default_rules() {
+        let toml_str = include_str!("../config.default.toml");
+        let parsed: Config = toml::from_str(toml_str).unwrap();
+        let toml_names: HashSet<&str> = parsed.rules.iter().map(|r| r.name.as_str()).collect();
+        let code_rules = default_rules();
+        let code_names: HashSet<&str> = code_rules.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(
+            toml_names,
+            code_names,
+            "config.default.toml rules and default_rules() are out of sync.\n\
+             In TOML only: {:?}\n\
+             In code only: {:?}",
+            toml_names.difference(&code_names).collect::<Vec<_>>(),
+            code_names.difference(&toml_names).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn config_default_toml_detectors_match_default_detectors() {
+        let toml_str = include_str!("../config.default.toml");
+        let parsed: Config = toml::from_str(toml_str).unwrap();
+        let toml_names: HashSet<&str> = parsed.detectors.iter().map(|d| d.name.as_str()).collect();
+        let code_detectors = default_detectors();
+        let code_names: HashSet<&str> = code_detectors.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(
+            toml_names,
+            code_names,
+            "config.default.toml detectors and default_detectors() are out of sync.\n\
+             In TOML only: {:?}\n\
+             In code only: {:?}",
+            toml_names.difference(&code_names).collect::<Vec<_>>(),
+            code_names.difference(&toml_names).collect::<Vec<_>>(),
+        );
+    }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -678,4 +678,23 @@ mod tests {
         let result = evaluate_context(&inv, &test_rule(), &config);
         assert_eq!(result.action_override, Some(ActionKind::LogOnly));
     }
+
+    // --- CI consistency check: NEVER_REGENERABLE ⊃ default_protected_paths ---
+
+    #[test]
+    fn never_regenerable_covers_all_default_protected_paths() {
+        let protected = default_protected_paths();
+        let never: std::collections::HashSet<&str> = NEVER_REGENERABLE.iter().copied().collect();
+        let missing: Vec<&str> = protected
+            .iter()
+            .map(|p| p.trim_end_matches('/'))
+            .filter(|p| !never.contains(p))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "default_protected_paths() contains entries not in NEVER_REGENERABLE: {:?}\n\
+             Either add them to NEVER_REGENERABLE or remove from default_protected_paths()",
+            missing,
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add compile-time sync checks between `config.default.toml` and code defaults using `include_str!`
- Verify `NEVER_REGENERABLE` covers all `default_protected_paths()` entries
- Add commented `[context]` section template to `config.default.toml`

## What changed
| File | Change |
|------|--------|
| `src/config.rs` | +2 tests: rule names sync, detector names sync |
| `src/context.rs` | +1 test: NEVER_REGENERABLE ⊇ protected_paths |
| `config.default.toml` | +11 lines: commented `[context]` section |

## Test plan
- [x] 117 tests pass (77 unit + 29 cli + 11 integration)
- [x] `RUSTFLAGS="-D warnings" cargo test` clean
- [x] `cargo fmt --check` clean
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)