### PR TITLE
fix: shim symlinks survive brew upgrade + README redesign (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.4.2] - 2026-03-19
+
+### Fixed
+
+- **Shim symlinks survive `brew upgrade`** (#42): Shim symlinks now point to the stable Homebrew-linked path (e.g. `/opt/homebrew/bin/omamori`) instead of the versioned Cellar path. Previously, `brew upgrade` + `brew cleanup` caused dangling symlinks, silently disabling all protection until `install --hooks` was re-run.
+
+### Changed
+
+- **README redesigned**: Restructured for first-time visitors — tagline, Quick Start, and "What It Blocks" now appear before detailed configuration. Detection tables and version-specific notes moved to later sections.
+
 ## [0.4.1] - 2026-03-19
 
 ### Fixed
@@ -220,6 +230,7 @@ The format is based on Keep a Changelog.
 - Claude Code hook template generation via `omamori install --hooks`.
 - Expanded README and SECURITY documentation for protected and unprotected command coverage.
 
+[0.4.2]: https://github.com/yottayoshida/omamori/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/yottayoshida/omamori/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/yottayoshida/omamori/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/yottayoshida/omamori/compare/v0.3.1...v0.3.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,166 +1,122 @@
 # omamori
 
-> **Pre-1.0** — Breaking changes may occur between minor versions.
+[![CI](https://github.com/yottayoshida/omamori/actions/workflows/ci.yml/badge.svg)](https://github.com/yottayoshida/omamori/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/omamori.svg)](https://crates.io/crates/omamori)
+[![homebrew](https://img.shields.io/badge/homebrew-tap-blue)](https://github.com/yottayoshida/homebrew-tap)
+[![License](https://img.shields.io/crates/l/omamori)](LICENSE-MIT)
 
-AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools.
+> Safety guard for AI CLI tools. Blocks dangerous commands — and resists being disabled.
 
-### Support Tiers
+When AI tools like Claude Code, Codex, or Cursor run shell commands, omamori intercepts destructive operations and replaces them with safe alternatives. It also defends itself against AI agents attempting to disable or bypass its protection.
 
-| Tier | Tools | What it means |
-|------|-------|---------------|
-| **Supported** | Claude Code, Codex CLI, Cursor | E2E tested every release. Issues investigated and fixed. |
-| **Community** | Gemini CLI, Cline, others | Env var detection included but not tested. No guaranteed support. |
-| **Fallback** | Any tool setting `AI_GUARD=1` | Generic detection. No tool-specific integration. |
+**Terminal commands are never affected** — omamori only activates when it detects an AI tool's environment variable.
 
-### Detection Details
-
-| Tool | Environment Variable | Value |
-|------|---------------------|-------|
-| Claude Code | `CLAUDECODE` | `1` |
-| Codex CLI | `CODEX_CI` | `1` |
-| Cursor | `CURSOR_AGENT` | `1` |
-| Gemini CLI | `GEMINI_CLI` | `1` |
-| Cline | `CLINE_ACTIVE` | `true` |
-| Fallback | `AI_GUARD` | `1` |
-
-Detection uses **exact value matching** (e.g. `CLAUDECODE=1` only, not `CLAUDECODE=true`).
-
-### Protection Coverage (Supported Tools)
-
-| Protection | Claude Code | Codex CLI | Cursor |
-|-----------|------------|-----------|--------|
-| Layer 1 — PATH shim (all rules) | ✅ | ✅ | ✅ |
-| Layer 2 — Hooks (full-path bypass) | ✅ PreToolUse | ❌ | ✅ beforeShellExecution |
-| Layer 2 — Hooks (interpreter warnings) | ✅ warn | ❌ | ✅ ask |
-| Config guard (disable/uninstall blocked) | ✅ env var + hooks | ✅ env var | ✅ env var + hooks |
-| config.toml direct edit guard | ✅ PreToolUse | ❌ | Bash only |
-
-- **Layer 1 (PATH shim)**: Blocks dangerous commands when AI sets its env var. Bypassable via `/bin/rm` full-path execution.
-- **Layer 2 (Hooks)**: Catches full-path bypass, env var unset, interpreter commands, and `config disable`/`uninstall`. Available for Claude Code and Cursor only.
-- **Config guard** (v0.3.2+): `config disable`, `config enable`, `uninstall`, and `init --force` are blocked when AI detector env vars are present. Works for all detected tools.
-- **config.toml edit guard**: PreToolUse hook blocks direct file editing (Claude Code only). Cursor blocks Bash-based edits.
-- See [SECURITY.md](SECURITY.md) for full details and known limitations.
-
-## What It Does
-
-When an AI CLI tool (Claude Code, Codex, Cursor, etc.) runs a shell command, omamori intercepts dangerous operations and replaces them with safe alternatives. **Terminal direct execution is not affected.**
-
-```
-[AI CLI Tool] → CLAUDECODE=1 → rm -rf target/
-                                  ↓
-                            [omamori shim]
-                                  ↓
-                         moved to Trash instead
-```
-
-```
-[Terminal]    →              → rm -rf target/
-                                  ↓
-                            [/usr/bin/rm]
-                                  ↓
-                            deleted normally
-```
+<!-- TODO: add demo GIF here -->
 
 ## Quick Start
 
-### Install via Homebrew (macOS)
-
 ```bash
+# Install
 brew install yottayoshida/tap/omamori
-```
 
-### Or build from source
-
-```bash
-cargo install --path .
-```
-
-### Setup
-
-```bash
-# 1. Install shims + hooks + config (all in one command)
+# Setup (shims + hooks + config — all in one)
 omamori install --hooks
 
-# 2. Add shim directory to PATH (add to .zshrc / .bashrc)
+# Add to your shell profile (~/.zshrc or ~/.bashrc)
 export PATH="$HOME/.omamori/shim:$PATH"
 ```
 
-That's it. `install --hooks` auto-generates `config.toml`, runs verification, and shows a checklist:
+That's it. After `brew upgrade`, hooks are auto-updated on the next command.
 
-```
-omamori setup complete:
-
-Shims:
-  [done] rm, git, chmod, find, rsync
-
-Hooks:
-  [done] Claude Code hook script
-  [done] Cursor hook snippet
-
-Config:
-  [done] Created: ~/.config/omamori/config.toml
-  [done] 7 rules verified, 12 detection tests passed
-
-Next steps:
-  [todo] Add to your shell profile:
-    export PATH="$HOME/.omamori/shim:$PATH"
-  [todo] Merge Cursor hook into .cursor/hooks.json
-```
-
-## How It Works
-
-**Layer 1 — PATH shim**: Symlinks for `rm`, `git`, `chmod`, `find`, `rsync` point to the omamori binary. When invoked, omamori checks for AI tool environment variables (e.g. `CLAUDECODE=1`) and applies rules only if an AI tool is detected.
-
-**Layer 2 — Hooks** (optional):
-- **Claude Code**: A `PreToolUse` hook script catches bypass attempts like `/bin/rm` direct paths, `unset CLAUDECODE`, and warns on interpreter commands (`python -c "shutil.rmtree(...)"`).
-- **Cursor**: A Rust-native `beforeShellExecution` handler (`omamori cursor-hook`) provides the same protection via Cursor's hook protocol.
-
-**Hook auto-sync** (v0.4.1+): After `brew upgrade`, hooks are automatically updated on the next command invocation. No manual `install --hooks` needed.
-
-## Default Rules
+## What It Blocks
 
 | Command | Pattern | Action |
 |---------|---------|--------|
 | `rm` | `-r`, `-rf`, `-fr`, `--recursive` | **trash** — move to macOS Trash |
-| `git` | `reset --hard` | **stash-then-exec** — `git stash` first, then execute |
+| `git` | `reset --hard` | **stash-then-exec** — `git stash` first |
 | `git` | `push --force`, `push -f` | **block** |
 | `git` | `clean -fd`, `clean -fdx` | **block** |
 | `chmod` | `777` | **block** |
 | `find` | `-delete`, `--delete` | **block** |
 | `rsync` | `--delete` and 7 variants | **block** |
 
-Combined short flags are normalized: `rm -rfv` expands to match `-r` and `-rf` rules. The POSIX `--` separator is respected for target extraction.
+All rules are customizable via TOML config. See [Configuration](#configuration) below.
 
-rsync variants blocked: `--delete`, `--del`, `--delete-before`, `--delete-during`, `--delete-after`, `--delete-excluded`, `--delete-delay`, `--remove-source-files`.
+## How It Works
 
-## Configuration (v0.2+)
+```
+AI CLI tool → CLAUDECODE=1 → rm -rf src/
+                                ↓
+                          [omamori shim]
+                                ↓
+                        blocked (protected path)
 
-Built-in rules are always inherited. Config is auto-created by `install --hooks`. To regenerate manually:
-
-```bash
-omamori init              # Creates ~/.config/omamori/config.toml (chmod 600)
-omamori init --force      # Overwrite existing config
-omamori init --stdout     # Print template to stdout (backward compat)
+Terminal → rm -rf src/
+                ↓
+          [/usr/bin/rm]
+                ↓
+          deleted normally
 ```
 
-**Disable a rule** via CLI (v0.3+):
+**Layer 1 — PATH shim**: Symlinks for `rm`, `git`, `chmod`, `find`, `rsync` point to omamori. Rules apply only when an AI environment variable is detected.
 
-```bash
-omamori config disable git-push-force-block
-omamori config enable git-push-force-block    # restore built-in default
-omamori config list                           # show all rules with status
+**Layer 2 — Hooks**: Catches bypass attempts (`/bin/rm` direct paths, `unset CLAUDECODE`, interpreter commands). Available for Claude Code and Cursor.
+
+**Self-defense**: AI agents cannot `config disable`, `uninstall`, or edit `config.toml` while detected. See [SECURITY.md](SECURITY.md) for the full threat model.
+
+## Supported Tools
+
+| Tier | Tools | Coverage |
+|------|-------|----------|
+| **Supported** | Claude Code, Codex CLI, Cursor | E2E tested. Layer 1 + Layer 2 (where available). |
+| **Community** | Gemini CLI, Cline, others | Layer 1 only. Not E2E tested. |
+| **Fallback** | Any tool setting `AI_GUARD=1` | Layer 1 only. |
+
+## Context-Aware Evaluation
+
+omamori can adjust actions based on what the command targets:
+
+| Command | Without context | With context |
+|---------|----------------|-------------|
+| `rm -rf target/` | trash | **log-only** (regenerable) |
+| `rm -rf src/` | trash | **block** (protected) |
+| `git reset --hard` (no changes) | stash-then-exec | **log-only** (git-aware) |
+
+**Opt-in**: Add `[context]` to `~/.config/omamori/config.toml`. Built-in lists for regenerable (`target/`, `node_modules/`, etc.) and protected (`src/`, `.git/`, `.env`, etc.) paths activate automatically.
+
+```toml
+[context]
+# Built-in defaults activate. Customize:
+# regenerable_paths = ["my-cache/"]
+# protected_paths = ["secrets/"]
 ```
 
-Or edit `config.toml` directly:
+Security features: symlink defense via `canonicalize()`, path traversal normalization, NEVER_REGENERABLE hardcoded list, fail-close on errors.
 
+## Configuration
+
+Built-in rules are always inherited. Only write the rules you want to change:
+
+```bash
+omamori config list                          # show all rules
+omamori config disable git-push-force-block  # disable a rule
+omamori config enable git-push-force-block   # restore default
+omamori test                                 # verify policy
+```
+
+Or edit `~/.config/omamori/config.toml` directly. Config is auto-created by `install --hooks`. See `omamori init --stdout` for the full template.
+
+<details>
+<summary>Configuration examples</summary>
+
+**Disable a rule**:
 ```toml
 [[rules]]
 name = "git-push-force-block"
 enabled = false
 ```
 
-**Move files to a custom directory** instead of Trash:
-
+**Move files to a custom directory**:
 ```toml
 [[rules]]
 name = "rm-to-backup"
@@ -168,11 +124,9 @@ command = "rm"
 action = "move-to"
 destination = "/tmp/omamori-quarantine/"
 match_any = ["-r", "-rf", "-fr", "--recursive"]
-message = "omamori moved targets to quarantine instead of deleting"
 ```
 
-**Override an existing rule's action**:
-
+**Override an existing rule**:
 ```toml
 [[rules]]
 name = "rm-recursive-to-trash"
@@ -180,121 +134,38 @@ action = "move-to"
 destination = "/tmp/omamori-quarantine/"
 ```
 
-After editing, run `omamori test` to verify. Disabled rules show as `SKIP`:
+**Notes**: Config requires `chmod 600`. Destinations must be absolute paths on the same volume. System directories and symlinks are rejected.
+
+</details>
+
+## CLI Reference
 
 ```
-Rules:
-  PASS  rm-recursive-to-trash        rm -r|-rf|-fr|--recursive -> trash
-  SKIP  git-push-force-block         (disabled by user config)
-  ...
-Summary: 7 rules (6 active, 1 disabled), 12 detection tests passed
-```
-
-### Configuration notes
-
-- Config file requires `chmod 600` (permissions check enforced)
-- Only write rules you want to change — everything else is inherited
-- `destination` must be an absolute path on the same volume
-- System directories (`/usr`, `/etc`, `/System`, `/Library`, `/bin`, `/sbin`, `/var`, `/private`) are blocked as destinations
-- Symlinks are rejected as destinations
-- `destination` directory must exist before use (omamori will not create it)
-
-## Context-Aware Evaluation (v0.4.0+)
-
-omamori can adjust protection actions based on command target paths and git status. This reduces false positives (e.g., `rm -rf target/` in a Rust project) while strengthening defense for critical paths.
-
-**Opt-in**: Add `[context]` to your `config.toml` to enable. Without it, behavior is identical to v0.3.
-
-### Quick setup
-
-```toml
-# Add to ~/.config/omamori/config.toml
-[context]
-# Built-in defaults activate:
-# - regenerable: target/, node_modules/, .next/, dist/, build/, __pycache__/, .cache/
-# - protected: src/, lib/, .git/, .env, .ssh/
-```
-
-### Custom paths
-
-```toml
-[context]
-regenerable_paths = ["my-cache/"]      # Added to built-in list
-protected_paths = ["secrets/"]          # Added to built-in list
-
-[context.git]
-enabled = true    # Check git status before acting (default: false)
-timeout_ms = 100  # Git status timeout in ms (default: 100)
-```
-
-### How it works
-
-| Command | Without context | With context |
-|---------|----------------|-------------|
-| `rm -rf target/` | trash | **log-only** (regenerable) |
-| `rm -rf src/` | trash | **block** (protected) |
-| `rm -rf data/` | trash | trash (unchanged) |
-| `git reset --hard` (no changes) | stash-then-exec | **log-only** (git-aware, opt-in) |
-
-### Security features
-
-- **Symlink defense**: `canonicalize()` resolves symlinks before matching — `ln -sf src/ target && rm -rf target` is caught
-- **Traversal defense**: `target/../src/` is normalized to `src/` before matching
-- **NEVER_REGENERABLE**: `src/`, `.git/`, `.env` etc. cannot be made regenerable even by misconfiguration
-- **Fail-close**: canonicalize failure or git timeout → original action preserved
-
-## Available Actions
-
-| Action | Behavior |
-|--------|----------|
-| `trash` | Move targets to macOS Trash |
-| `move-to` | Move targets to a user-specified directory (requires `destination`) |
-| `stash-then-exec` | Run `git stash` first, then execute the original command |
-| `block` | Refuse to execute |
-| `log-only` | Log the event, then execute normally |
-
-## Safe Defaults
-
-| Scenario | Behavior |
-|----------|----------|
-| No AI env var detected | Pass through to real command (no interference) |
-| Config file missing | Fail-close: built-in default rules apply |
-| Config file broken | Fail-close: built-in default rules apply + warning |
-| Trash / move-to fails | Fail-close: refuse to run the original command |
-| `sudo` detected | Block the command |
-| Blocked destination | Fail-close: rule is disabled at config load time |
-| Shim binary crashes | Fail-open: real command runs |
-
-## CLI
-
-```
-omamori test [--config PATH]                          # Verify policy rules
-omamori exec [--config PATH] -- <command> [args...]   # Run through policy engine
-omamori install [--base-dir PATH] [--hooks]           # Create shims + hooks + config
-omamori uninstall [--base-dir PATH]                   # Remove shims + hook files
-omamori init [--force] [--stdout]                     # Create/reset config file
-omamori config list                                   # Show all rules with status
-omamori config disable <rule>                         # Disable a rule (blocked by AI tools)
-omamori config enable <rule>                          # Re-enable a rule (blocked by AI tools)
-omamori cursor-hook                                   # Cursor beforeShellExecution handler
+omamori install [--hooks]                # Setup shims + hooks + config
+omamori test [--config PATH]             # Verify policy rules
+omamori exec [--config PATH] -- CMD      # Run command through policy engine
+omamori config list                      # Show rules with status
+omamori config disable <rule>            # Disable a rule
+omamori config enable <rule>             # Re-enable a rule
+omamori init [--force] [--stdout]        # Create/reset config
+omamori uninstall                        # Remove shims + hooks
+omamori cursor-hook                      # Cursor hook handler
 ```
 
 ## Structural Limitations
 
 These are inherent to the PATH shim approach and documented honestly:
 
-- **Full-path execution** (`/bin/rm`, `/usr/bin/git`) bypasses the shim — mitigated by Layer 2 hooks (Claude Code + Cursor). Tools without hooks (Codex, Gemini) are vulnerable.
-- **`sudo`** changes PATH before the shim runs — omamori blocks when it detects elevated execution in-process
-- **Interpreter commands** (`python -c "shutil.rmtree(...)"`) — Layer 2 hooks **warn** on known destructive patterns, but obfuscated code (base64, heredoc, variable indirection) cannot be detected
-- **`find -exec /bin/rm`** bypasses the find shim because rm is invoked via absolute path — partially mitigated by Layer 2 hooks
-- **AI self-bypass**: `config disable`, `uninstall`, and `init --force` are blocked when AI env vars are detected (v0.3.2+). AI agents may still attempt direct `config.toml` file editing — blocked by PreToolUse hooks in Claude Code only. See [#22](https://github.com/yottayoshida/omamori/issues/22)
-- **Cross-device moves** are not supported for `move-to` (use a destination on the same volume)
+- **Full-path execution** (`/bin/rm`) bypasses the shim — mitigated by Layer 2 hooks
+- **`sudo`** changes PATH — omamori blocks when it detects elevated execution
+- **Interpreter commands** (`python -c "shutil.rmtree(...)"`) — hooks warn on known patterns, but obfuscated code cannot be detected
+- **AI self-bypass** — `config disable`/`uninstall` are blocked; direct file editing blocked by hooks (Claude Code only). See [#22](https://github.com/yottayoshida/omamori/issues/22)
 
-For the full security model, see [SECURITY.md](SECURITY.md).
+For the full security model, bypass corpus, and known limitations, see [SECURITY.md](SECURITY.md).
 
 ## Related
 
-- **[nanika](https://github.com/yottayoshida/nanika)** — explains what AI commands will do (detect + translate). Complementary to omamori (detect + replace).
+- **[nanika](https://github.com/yottayoshida/nanika)** — explains what AI commands will do. Complementary to omamori.
 
 ## License
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -32,10 +32,11 @@ pub fn install(options: &InstallOptions) -> Result<InstallResult, AppError> {
     let shim_dir = options.base_dir.join("shim");
     fs::create_dir_all(&shim_dir)?;
 
-    let source_exe = options
-        .source_exe
-        .canonicalize()
-        .unwrap_or_else(|_| options.source_exe.clone());
+    // Use the source path as-is (do not canonicalize). When installed via
+    // Homebrew, the source path is a stable symlink like /opt/homebrew/bin/omamori.
+    // Canonicalizing resolves it to /opt/homebrew/Cellar/omamori/<version>/bin/omamori,
+    // which breaks after `brew upgrade` + `brew cleanup` removes the old version (#42).
+    let source_exe = options.source_exe.clone();
     let mut linked_commands = Vec::new();
 
     for command in SHIM_COMMANDS {
@@ -72,10 +73,7 @@ pub fn install(options: &InstallOptions) -> Result<InstallResult, AppError> {
     let cursor_hook_snippet = if options.generate_hooks {
         let hooks_dir = options.base_dir.join("hooks");
         let cursor_snippet_path = hooks_dir.join("cursor-hooks.snippet.json");
-        let omamori_exe = options
-            .source_exe
-            .canonicalize()
-            .unwrap_or_else(|_| options.source_exe.clone());
+        let omamori_exe = options.source_exe.clone();
         atomic_write(
             &cursor_snippet_path,
             &render_cursor_hooks_snippet(&omamori_exe),


### PR DESCRIPTION
## Summary
- **Fix #42**: Stop `canonicalize()` on source_exe in `install()`. Use Homebrew's stable linked path instead of versioned Cellar path.
- **README redesign**: Restructured for first-time visitors based on market research of 9 OSS projects (dcg, ripgrep, bat, fd, starship, gitleaks, trivy, etc.)

Closes #42

## Bug fix
`install()` called `canonicalize()` on the source exe path, resolving `/opt/homebrew/bin/omamori` → `/opt/homebrew/Cellar/omamori/0.4.0/bin/omamori`. After `brew upgrade` + `brew cleanup`, the old Cellar is removed → dangling symlinks → silent protection loss.

Fix: use the source path as-is. Two `canonicalize()` calls removed.

## README changes
| Before | After |
|--------|-------|
| 300 lines | ~180 lines |
| First view: Pre-1.0 warning + 3 tables | First view: tagline + Quick Start |
| Install at L64 | Install at L30 |
| Detection details before "What It Does" | "What It Blocks" before detection |
| Config examples inline | Config examples in `<details>` |

## Test plan
- [x] 131 tests pass
- [x] `RUSTFLAGS="-D warnings" cargo test` clean
- [x] `cargo fmt --check` clean
- [ ] CI pass
- [ ] Manual: verify `install --hooks` creates symlinks to stable path

🤖 Generated with [Claude Code](https://claude.com/claude-code)