### PR TITLE
feat: core policy immutability — built-in rules cannot be weakened via config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -59,6 +59,9 @@ struct UserConfig {
     audit: AuditConfig,
     #[serde(default)]
     context: Option<ContextConfig>,
+    /// `[overrides]` section: `rule_name = false` allows disabling core rules.
+    #[serde(default)]
+    overrides: HashMap<String, bool>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -136,7 +139,7 @@ pub fn load_config(path: Option<&Path>) -> Result<ConfigLoadResult, AppError> {
 
 fn build_merged_config(user: UserConfig, warnings: &mut Vec<String>) -> Config {
     let detectors = user.detectors.unwrap_or_else(default_detectors);
-    let mut rules = merge_rules(default_rules(), &user.rules, warnings);
+    let mut rules = merge_rules(default_rules(), &user.rules, &user.overrides, warnings);
     validate_rules(&mut rules, warnings);
 
     // Validate context config if present
@@ -156,6 +159,7 @@ fn build_merged_config(user: UserConfig, warnings: &mut Vec<String>) -> Config {
 fn merge_rules(
     defaults: Vec<RuleConfig>,
     user_rules: &[UserRule],
+    overrides: &HashMap<String, bool>,
     warnings: &mut Vec<String>,
 ) -> Vec<RuleConfig> {
     // Check for duplicate names in user config
@@ -180,7 +184,7 @@ fn merge_rules(
 
         if let Some(existing) = merged.iter_mut().find(|r| r.name == ur.name) {
             // Override existing rule fields
-            apply_user_overrides(existing, ur);
+            apply_user_overrides(existing, ur, overrides, warnings);
         } else {
             // New rule — must have command + action
             match (&ur.command, &ur.action) {
@@ -211,10 +215,90 @@ fn merge_rules(
         }
     }
 
+    // Apply [overrides] section: disable core rules that have explicit override
+    for (rule_name, &enabled) in overrides {
+        if !enabled
+            && let Some(rule) = merged.iter_mut().find(|r| r.name == *rule_name)
+            && rule.is_builtin
+        {
+            rule.enabled = false;
+        }
+    }
+
     merged
 }
 
-fn apply_user_overrides(rule: &mut RuleConfig, ur: &UserRule) {
+fn apply_user_overrides(
+    rule: &mut RuleConfig,
+    ur: &UserRule,
+    overrides: &HashMap<String, bool>,
+    warnings: &mut Vec<String>,
+) {
+    if rule.is_builtin {
+        // Core rule immutability: only `message` can be customized.
+        // `enabled` immutability can be bypassed via [overrides] section.
+        let has_non_message = ur.command.is_some()
+            || ur.action.is_some()
+            || ur.match_all.is_some()
+            || ur.match_any.is_some()
+            || ur.destination.is_some();
+
+        let has_enabled_override = ur.enabled.is_some();
+
+        // Check if [overrides] section has an explicit entry for this rule
+        let has_overrides_entry = overrides.contains_key(&rule.name);
+
+        if has_non_message {
+            // Check action specifically for upgrade vs downgrade
+            if let Some(action) = &ur.action {
+                if action.defense_level() < rule.action.defense_level() {
+                    warnings.push(format!(
+                        "rule `{}` is a core safety rule — action downgrade from `{}` to `{}` \
+                         is not allowed. Override ignored.",
+                        rule.name,
+                        rule.action.as_str(),
+                        action.as_str()
+                    ));
+                } else if action.defense_level() >= rule.action.defense_level()
+                    && action != &rule.action
+                {
+                    // Same or higher defense level — allow action upgrade
+                    rule.action = action.clone();
+                }
+                // Same action — no warning needed
+            }
+
+            // Warn about other non-message field overrides
+            if ur.command.is_some()
+                || ur.match_all.is_some()
+                || ur.match_any.is_some()
+                || ur.destination.is_some()
+            {
+                warnings.push(format!(
+                    "rule `{}` is a core safety rule. Only `message` can be customized. \
+                     Other overrides (`command`, `match_all`, `match_any`, `destination`) are ignored.",
+                    rule.name
+                ));
+            }
+        }
+
+        if has_enabled_override && !has_overrides_entry && ur.enabled == Some(false) {
+            warnings.push(format!(
+                "rule `{}` is a core safety rule and cannot be disabled via config. \
+                 Ignored. To override: omamori override disable {}",
+                rule.name, rule.name
+            ));
+        }
+
+        // Only apply message override
+        if let Some(message) = &ur.message {
+            rule.message = Some(message.clone());
+        }
+
+        return;
+    }
+
+    // Non-core rules: apply all overrides as before
     if let Some(command) = &ur.command {
         rule.command = command.clone();
     }
@@ -360,7 +444,8 @@ pub fn default_rules() -> Vec<RuleConfig> {
                 "omamori moved the recursive rm targets to Trash instead of deleting them"
                     .to_string(),
             ),
-        ),
+        )
+        .with_builtin(true),
         RuleConfig::new(
             "git-reset-hard-stash",
             "git",
@@ -368,7 +453,8 @@ pub fn default_rules() -> Vec<RuleConfig> {
             vec!["reset".to_string(), "--hard".to_string()],
             Vec::new(),
             Some("omamori stashed changes before running git reset --hard".to_string()),
-        ),
+        )
+        .with_builtin(true),
         RuleConfig::new(
             "git-push-force-block",
             "git",
@@ -376,7 +462,8 @@ pub fn default_rules() -> Vec<RuleConfig> {
             vec!["push".to_string()],
             vec!["--force".to_string(), "-f".to_string()],
             Some("omamori blocked a force push".to_string()),
-        ),
+        )
+        .with_builtin(true),
         RuleConfig::new(
             "git-clean-force-block",
             "git",
@@ -384,7 +471,8 @@ pub fn default_rules() -> Vec<RuleConfig> {
             vec!["clean".to_string()],
             vec!["-fd".to_string(), "-fdx".to_string()],
             Some("omamori blocked git clean because it would remove untracked files".to_string()),
-        ),
+        )
+        .with_builtin(true),
         RuleConfig::new(
             "chmod-777-block",
             "chmod",
@@ -392,7 +480,8 @@ pub fn default_rules() -> Vec<RuleConfig> {
             Vec::new(),
             vec!["777".to_string()],
             Some("omamori blocked chmod 777".to_string()),
-        ),
+        )
+        .with_builtin(true),
         RuleConfig::new(
             "find-delete-block",
             "find",
@@ -400,7 +489,8 @@ pub fn default_rules() -> Vec<RuleConfig> {
             Vec::new(),
             vec!["-delete".to_string(), "--delete".to_string()],
             Some("omamori blocked find with -delete flag".to_string()),
-        ),
+        )
+        .with_builtin(true),
         RuleConfig::new(
             "rsync-delete-block",
             "rsync",
@@ -417,7 +507,21 @@ pub fn default_rules() -> Vec<RuleConfig> {
                 "--remove-source-files".to_string(),
             ],
             Some("omamori blocked rsync with destructive flags".to_string()),
-        ),
+        )
+        .with_builtin(true),
+    ]
+}
+
+/// Names of the 7 core (built-in) safety rules.
+pub fn core_rule_names() -> Vec<&'static str> {
+    vec![
+        "rm-recursive-to-trash",
+        "git-reset-hard-stash",
+        "git-push-force-block",
+        "git-clean-force-block",
+        "chmod-777-block",
+        "find-delete-block",
+        "rsync-delete-block",
     ]
 }
 
@@ -603,8 +707,13 @@ fn permissions_are_safe(_path: &Path) -> Result<bool, AppError> {
 mod tests {
     use super::*;
 
+    fn no_overrides() -> HashMap<String, bool> {
+        HashMap::new()
+    }
+
     #[test]
-    fn merge_override_disables_rule() {
+    fn merge_core_rule_ignores_disable_without_override() {
+        // Core rule `enabled = false` in config is ignored (immutability)
         let user_rules = vec![UserRule {
             name: "git-push-force-block".to_string(),
             command: None,
@@ -616,15 +725,45 @@ mod tests {
             message: None,
         }];
         let mut warnings = Vec::new();
-        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+        let merged = merge_rules(default_rules(), &user_rules, &no_overrides(), &mut warnings);
 
         let rule = merged
             .iter()
             .find(|r| r.name == "git-push-force-block")
             .unwrap();
-        assert!(!rule.enabled);
-        assert_eq!(rule.action, ActionKind::Block); // action preserved
-        assert!(warnings.is_empty());
+        assert!(rule.enabled); // core rule stays enabled
+        assert_eq!(rule.action, ActionKind::Block);
+        assert!(
+            warnings.iter().any(
+                |w: &String| w.contains("core safety rule") && w.contains("cannot be disabled")
+            ),
+            "expected immutability warning, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn merge_core_rule_disabled_via_overrides_section() {
+        // [overrides] section allows disabling core rules
+        let user_rules = vec![UserRule {
+            name: "git-push-force-block".to_string(),
+            command: None,
+            action: None,
+            enabled: Some(false),
+            destination: None,
+            match_all: None,
+            match_any: None,
+            message: None,
+        }];
+        let mut overrides = HashMap::new();
+        overrides.insert("git-push-force-block".to_string(), false);
+        let mut warnings = Vec::new();
+        let merged = merge_rules(default_rules(), &user_rules, &overrides, &mut warnings);
+
+        let rule = merged
+            .iter()
+            .find(|r| r.name == "git-push-force-block")
+            .unwrap();
+        assert!(!rule.enabled); // overrides section allows disable
     }
 
     #[test]
@@ -640,7 +779,7 @@ mod tests {
             message: Some("custom".to_string()),
         }];
         let mut warnings = Vec::new();
-        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+        let merged = merge_rules(default_rules(), &user_rules, &no_overrides(), &mut warnings);
 
         let rule = merged.iter().find(|r| r.name == "custom-rm").unwrap();
         assert_eq!(rule.action, ActionKind::MoveTo);
@@ -661,13 +800,13 @@ mod tests {
             message: None,
         }];
         let mut warnings = Vec::new();
-        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+        let merged = merge_rules(default_rules(), &user_rules, &no_overrides(), &mut warnings);
 
         assert!(merged.iter().all(|r| r.name != "bad-rule"));
         assert!(
             warnings
                 .iter()
-                .any(|w| w.contains("missing `command` or `action`"))
+                .any(|w: &String| w.contains("missing `command` or `action`"))
         );
     }
 
@@ -696,47 +835,106 @@ mod tests {
             },
         ];
         let mut warnings = Vec::new();
-        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+        let merged = merge_rules(default_rules(), &user_rules, &no_overrides(), &mut warnings);
 
         let rule = merged
             .iter()
             .find(|r| r.name == "git-push-force-block")
             .unwrap();
-        assert!(!rule.enabled); // first occurrence wins
-        assert!(warnings.iter().any(|w| w.contains("duplicate rule name")));
+        // Core rule: enabled = false is ignored, so it stays enabled
+        assert!(rule.enabled);
+        assert!(
+            warnings
+                .iter()
+                .any(|w: &String| w.contains("duplicate rule name"))
+        );
     }
 
     #[test]
     fn merge_preserves_all_defaults_when_no_user_rules() {
         let mut warnings = Vec::new();
-        let merged = merge_rules(default_rules(), &[], &mut warnings);
+        let merged = merge_rules(default_rules(), &[], &no_overrides(), &mut warnings);
         assert_eq!(merged.len(), default_rules().len());
         assert!(warnings.is_empty());
     }
 
     #[test]
-    fn merge_override_changes_action() {
+    fn merge_core_rule_action_downgrade_rejected() {
+        // Trying to downgrade rm-recursive-to-trash from trash to log-only
         let user_rules = vec![UserRule {
             name: "rm-recursive-to-trash".to_string(),
             command: None,
-            action: Some(ActionKind::MoveTo),
+            action: Some(ActionKind::LogOnly),
             enabled: None,
-            destination: Some("/tmp/quarantine".to_string()),
+            destination: None,
             match_all: None,
             match_any: None,
             message: None,
         }];
         let mut warnings = Vec::new();
-        let merged = merge_rules(default_rules(), &user_rules, &mut warnings);
+        let merged = merge_rules(default_rules(), &user_rules, &no_overrides(), &mut warnings);
 
         let rule = merged
             .iter()
             .find(|r| r.name == "rm-recursive-to-trash")
             .unwrap();
-        assert_eq!(rule.action, ActionKind::MoveTo);
-        assert_eq!(rule.destination.as_deref(), Some("/tmp/quarantine"));
-        // match_any is preserved from default
-        assert!(!rule.match_any.is_empty());
+        assert_eq!(rule.action, ActionKind::Trash); // stays at original
+        assert!(
+            warnings
+                .iter()
+                .any(|w: &String| w.contains("action downgrade")),
+            "expected downgrade warning, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn merge_core_rule_action_upgrade_allowed() {
+        // Upgrading rm-recursive-to-trash from trash to block is allowed
+        let user_rules = vec![UserRule {
+            name: "rm-recursive-to-trash".to_string(),
+            command: None,
+            action: Some(ActionKind::Block),
+            enabled: None,
+            destination: None,
+            match_all: None,
+            match_any: None,
+            message: None,
+        }];
+        let mut warnings = Vec::new();
+        let merged = merge_rules(default_rules(), &user_rules, &no_overrides(), &mut warnings);
+
+        let rule = merged
+            .iter()
+            .find(|r| r.name == "rm-recursive-to-trash")
+            .unwrap();
+        assert_eq!(rule.action, ActionKind::Block); // upgraded
+    }
+
+    #[test]
+    fn merge_core_rule_message_override_allowed() {
+        let user_rules = vec![UserRule {
+            name: "git-push-force-block".to_string(),
+            command: None,
+            action: None,
+            enabled: None,
+            destination: None,
+            match_all: None,
+            match_any: None,
+            message: Some("my custom message".to_string()),
+        }];
+        let mut warnings = Vec::new();
+        let merged = merge_rules(default_rules(), &user_rules, &no_overrides(), &mut warnings);
+
+        let rule = merged
+            .iter()
+            .find(|r| r.name == "git-push-force-block")
+            .unwrap();
+        assert_eq!(rule.message.as_deref(), Some("my custom message"));
+        // No warnings for message-only override
+        assert!(
+            warnings.is_empty(),
+            "no warnings for message override: {warnings:?}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub fn run(args: &[OsString]) -> Result<i32, AppError> {
         Some("uninstall") => run_uninstall_command(args),
         Some("init") => run_init_command(args),
         Some("config") => run_config_command(args),
+        Some("override") => run_override_command(args),
         Some("cursor-hook") => run_cursor_hook(),
         Some("version") | Some("--version") | Some("-V") => {
             println!("omamori {}", env!("CARGO_PKG_VERSION"));
@@ -109,6 +110,22 @@ fn run_policy_test_command(args: &[OsString]) -> Result<i32, AppError> {
                 "  PASS  {:<28} {:<24} -> {}",
                 rule.name, pattern, action_display
             );
+        }
+    }
+
+    // Core Policy section
+    println!("\nCore Policy:");
+    let core_rules: Vec<&RuleConfig> = config.rules.iter().filter(|r| r.is_builtin).collect();
+    let mut core_overridden = 0;
+    for rule in &core_rules {
+        if rule.enabled {
+            println!("  PASS  {:<28} core rule active", rule.name);
+        } else {
+            println!(
+                "  WARN  {:<28} core rule overridden (disabled by user)",
+                rule.name
+            );
+            core_overridden += 1;
         }
     }
 
@@ -194,11 +211,21 @@ fn run_policy_test_command(args: &[OsString]) -> Result<i32, AppError> {
     } else {
         String::new()
     };
+    let core_summary = if core_overridden > 0 {
+        format!(
+            ", {} core rules ({} overridden)",
+            core_rules.len(),
+            core_overridden
+        )
+    } else {
+        format!(", {} core rules active", core_rules.len())
+    };
     println!(
-        "\nSummary: {} rules ({} active, {} disabled){}, {} detection tests {}",
+        "\nSummary: {} rules ({} active, {} disabled){}{}, {} detection tests {}",
         config.rules.len(),
         active_count,
         disabled_count,
+        core_summary,
         context_summary,
         results.len(),
         if failures == 0 { "passed" } else { "FAILED" }
@@ -773,9 +800,22 @@ fn resolve_config_path_checked() -> Result<std::path::PathBuf, AppError> {
     Ok(path)
 }
 
+fn is_core_rule(name: &str) -> bool {
+    config::core_rule_names().contains(&name)
+}
+
 fn run_config_disable(rule_name: &str) -> Result<i32, AppError> {
     guard_ai_config_modification("config disable")?;
     validate_rule_name(rule_name)?;
+
+    // Core rules cannot be disabled via `config disable`
+    if is_core_rule(rule_name) {
+        return Err(AppError::Config(format!(
+            "`{rule_name}` is a core safety rule and cannot be disabled.\n\n  \
+             To override: omamori override disable {rule_name}\n  \
+             To see core vs custom rules: omamori config list"
+        )));
+    }
 
     let config_path = resolve_config_path_checked()?;
 
@@ -937,6 +977,148 @@ fn run_config_enable(rule_name: &str) -> Result<i32, AppError> {
     run_config_list()
 }
 
+fn run_override_command(args: &[OsString]) -> Result<i32, AppError> {
+    match args.get(2).and_then(|item| item.to_str()) {
+        Some("disable") => {
+            let rule_name = args.get(3).and_then(|item| item.to_str()).ok_or_else(|| {
+                AppError::Usage("override disable requires a rule name".to_string())
+            })?;
+            run_override_disable(rule_name)
+        }
+        Some("enable") => {
+            let rule_name = args.get(3).and_then(|item| item.to_str()).ok_or_else(|| {
+                AppError::Usage("override enable requires a rule name".to_string())
+            })?;
+            run_override_enable(rule_name)
+        }
+        Some(other) => Err(AppError::Usage(format!(
+            "unknown override subcommand: {other}\n\n{}",
+            usage_text()
+        ))),
+        None => Err(AppError::Usage(format!(
+            "override requires a subcommand (disable|enable)\n\n{}",
+            usage_text()
+        ))),
+    }
+}
+
+fn run_override_disable(rule_name: &str) -> Result<i32, AppError> {
+    guard_ai_config_modification("override disable")?;
+    validate_rule_name(rule_name)?;
+
+    if !is_core_rule(rule_name) {
+        return Err(AppError::Config(format!(
+            "`{rule_name}` is not a core rule. Use `omamori config disable {rule_name}` instead."
+        )));
+    }
+
+    let config_path = resolve_config_path_checked()?;
+
+    // Auto-create config if it doesn't exist
+    if !config_path.exists() {
+        config::write_default_config(&config_path, false)?;
+    }
+
+    let content = std::fs::read_to_string(&config_path)?;
+
+    // Check if [overrides] section exists
+    let new_content = if content.contains("[overrides]") {
+        // Check if already has this rule
+        if content.contains(&format!("{rule_name} = false"))
+            || content.contains(&format!("{rule_name}=false"))
+        {
+            eprintln!("Rule `{rule_name}` is already overridden (disabled).");
+            return Ok(2);
+        }
+        // Add entry after [overrides] line
+        content.replace("[overrides]", &format!("[overrides]\n{rule_name} = false"))
+    } else {
+        // Append [overrides] section
+        let mut new = content;
+        if !new.ends_with('\n') {
+            new.push('\n');
+        }
+        new.push_str(&format!("\n[overrides]\n{rule_name} = false\n"));
+        new
+    };
+
+    // Validate TOML
+    if toml::from_str::<toml::Value>(&new_content).is_err() {
+        return Err(AppError::Config(
+            "modifying config would create invalid TOML; aborting".to_string(),
+        ));
+    }
+
+    std::fs::write(&config_path, &new_content)?;
+    eprintln!("Override: disabled core rule `{rule_name}`");
+    eprintln!("To restore: omamori override enable {rule_name}");
+
+    run_config_list()
+}
+
+fn run_override_enable(rule_name: &str) -> Result<i32, AppError> {
+    guard_ai_config_modification("override enable")?;
+    validate_rule_name(rule_name)?;
+
+    if !is_core_rule(rule_name) {
+        return Err(AppError::Config(format!(
+            "`{rule_name}` is not a core rule. Use `omamori config enable {rule_name}` instead."
+        )));
+    }
+
+    let config_path = resolve_config_path_checked()?;
+
+    if !config_path.exists() {
+        eprintln!("Rule `{rule_name}` is already active (core default).");
+        return Ok(2);
+    }
+
+    let content = std::fs::read_to_string(&config_path)?;
+
+    // Remove the override entry
+    let patterns = [
+        format!("{rule_name} = false\n"),
+        format!("{rule_name}=false\n"),
+        format!("{rule_name} = false"),
+        format!("{rule_name}=false"),
+    ];
+
+    let mut new_content = content.clone();
+    for pat in &patterns {
+        new_content = new_content.replace(pat, "");
+    }
+
+    // Clean up empty [overrides] section
+    let new_content = new_content
+        .replace("[overrides]\n\n", "[overrides]\n")
+        .trim_end()
+        .to_string()
+        + "\n";
+
+    // Check if [overrides] section is now empty and remove it
+    let new_content = if new_content.contains("[overrides]\n")
+        && !new_content
+            .split("[overrides]\n")
+            .nth(1)
+            .unwrap_or("")
+            .lines()
+            .any(|l| {
+                let t = l.trim();
+                !t.is_empty() && !t.starts_with('#') && !t.starts_with('[')
+            }) {
+        new_content.replace("[overrides]\n", "")
+    } else {
+        new_content
+    };
+
+    let new_content = new_content.trim_end().to_string() + "\n";
+
+    std::fs::write(&config_path, &new_content)?;
+    eprintln!("Restored: core rule `{rule_name}` is active again.");
+
+    run_config_list()
+}
+
 fn run_config_list() -> Result<i32, AppError> {
     let load_result = load_config(None)?;
     let config = &load_result.config;
@@ -958,7 +1140,13 @@ fn run_config_list() -> Result<i32, AppError> {
 
     for rule in &config.rules {
         let status = if rule.enabled { "active" } else { "disabled" };
-        let source = if let Some(default) = defaults.get(&rule.name) {
+        let source = if rule.is_builtin {
+            if !rule.enabled {
+                "core (overridden)"
+            } else {
+                "core"
+            }
+        } else if let Some(default) = defaults.get(&rule.name) {
             if !rule.enabled {
                 "config (disabled)"
             } else if rule.action != default.action
@@ -1083,6 +1271,8 @@ fn usage_text() -> &'static str {
   omamori config list
   omamori config disable <rule>
   omamori config enable <rule>
+  omamori override disable <rule>                        # Override a core safety rule
+  omamori override enable <rule>                         # Restore a core safety rule
   omamori cursor-hook                                   # Cursor beforeShellExecution handler
 
 When installed as a PATH shim (for example via a symlink named `rm`), omamori

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -48,6 +48,16 @@ impl ActionKind {
         }
     }
 
+    /// Defense level: higher = stronger protection.
+    /// Used to prevent downgrade of core rules' action via config.
+    pub fn defense_level(&self) -> u8 {
+        match self {
+            Self::LogOnly => 0,
+            Self::Trash | Self::MoveTo | Self::StashThenExec => 1,
+            Self::Block => 2,
+        }
+    }
+
     /// Generate a context-aware message that always matches the actual action.
     /// Used when context evaluation overrides the original rule's action,
     /// ensuring the user sees accurate feedback (e.g. "blocked" not "moved to Trash").
@@ -80,6 +90,9 @@ pub struct RuleConfig {
     pub enabled: bool,
     #[serde(default)]
     pub destination: Option<String>,
+    /// True for the 7 built-in core safety rules. Cannot be injected via config.toml.
+    #[serde(skip)]
+    pub is_builtin: bool,
 }
 
 impl RuleConfig {
@@ -100,6 +113,7 @@ impl RuleConfig {
             message,
             enabled: true,
             destination: None,
+            is_builtin: false,
         }
     }
 
@@ -110,6 +124,11 @@ impl RuleConfig {
 
     pub fn with_destination(mut self, destination: String) -> Self {
         self.destination = Some(destination);
+        self
+    }
+
+    pub fn with_builtin(mut self, is_builtin: bool) -> Self {
+        self.is_builtin = is_builtin;
         self
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -584,8 +584,8 @@ fn init_force_blocked_in_ai_session() {
 }
 
 #[test]
-fn config_disable_allowed_without_ai_env() {
-    let dir = unique_dir("guard-allow");
+fn config_disable_core_rule_rejected() {
+    let dir = unique_dir("guard-core-reject");
 
     let mut init_cmd = Command::new(binary());
     clean_ai_env(&mut init_cmd);
@@ -596,10 +596,52 @@ fn config_disable_allowed_without_ai_env() {
         .output()
         .unwrap();
 
+    // `config disable` on a core rule should fail with actionable error
     let mut cmd = Command::new(binary());
     clean_ai_env(&mut cmd);
     let output = cmd
         .args(["config", "disable", "git-push-force-block"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "should be rejected, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("core safety rule"),
+        "should mention core safety rule: {stderr}"
+    );
+    assert!(
+        stderr.contains("omamori override disable"),
+        "should suggest override command: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn override_disable_core_rule_works() {
+    let dir = unique_dir("override-allow");
+
+    let mut init_cmd = Command::new(binary());
+    clean_ai_env(&mut init_cmd);
+    init_cmd
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    // `override disable` on a core rule should succeed
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["override", "disable", "git-push-force-block"])
         .env("XDG_CONFIG_HOME", &dir)
         .env_remove("HOME")
         .output()
@@ -611,7 +653,81 @@ fn config_disable_allowed_without_ai_env() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Disabled"));
+    assert!(stderr.contains("Override"));
+
+    // Config list should show the rule as overridden
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("core (overridden)"),
+        "should show core (overridden) in config list: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn override_disable_blocked_in_ai_session() {
+    let output = Command::new(binary())
+        .args(["override", "disable", "git-push-force-block"])
+        .env("CLAUDECODE", "1")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("blocked"));
+}
+
+#[test]
+fn override_enable_restores_core_rule() {
+    let dir = unique_dir("override-restore");
+
+    let mut init_cmd = Command::new(binary());
+    clean_ai_env(&mut init_cmd);
+    init_cmd
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    // First disable
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    cmd.args(["override", "disable", "git-push-force-block"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    // Then re-enable
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["override", "enable", "git-push-force-block"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "should be allowed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Restored"));
+
+    // Config list should show the rule as core (active), not overridden
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let push_force_line = stdout
+        .lines()
+        .find(|l| l.contains("git-push-force-block"))
+        .unwrap_or("");
+    assert!(
+        push_force_line.contains("core") && !push_force_line.contains("overridden"),
+        "should show core (active): {push_force_line}"
+    );
 
     let _ = fs::remove_dir_all(&dir);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -227,21 +227,18 @@ fn config_list_shows_all_rules() {
     assert!(stdout.contains("git-push-force-block"));
     assert!(stdout.contains("chmod-777-block"));
     assert!(stdout.contains("active"));
-    assert!(stdout.contains("built-in"));
+    assert!(stdout.contains("core"));
 }
 
 #[test]
-fn config_list_shows_disabled_rule() {
+fn config_list_shows_overridden_core_rule() {
     let binary = env!("CARGO_BIN_EXE_omamori");
-    let config_dir = unique_dir("cfglist-disabled");
+    let config_dir = unique_dir("cfglist-overridden");
     let omamori_dir = config_dir.join("omamori");
     fs::create_dir_all(&omamori_dir).unwrap();
     let config_path = omamori_dir.join("config.toml");
-    fs::write(
-        &config_path,
-        "[[rules]]\nname = \"git-push-force-block\"\nenabled = false\n",
-    )
-    .unwrap();
+    // Core rule disabled via [overrides] section
+    fs::write(&config_path, "[overrides]\ngit-push-force-block = false\n").unwrap();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -262,8 +259,56 @@ fn config_list_shows_disabled_rule() {
         "should show disabled: {stdout}"
     );
     assert!(
-        stdout.contains("config (disabled)"),
-        "source should be config (disabled): {stdout}"
+        stdout.contains("core (overridden)"),
+        "source should be core (overridden): {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(config_dir);
+}
+
+#[test]
+fn config_list_ignores_core_rule_disabled_in_rules_section() {
+    let binary = env!("CARGO_BIN_EXE_omamori");
+    let config_dir = unique_dir("cfglist-core-ignore");
+    let omamori_dir = config_dir.join("omamori");
+    fs::create_dir_all(&omamori_dir).unwrap();
+    let config_path = omamori_dir.join("config.toml");
+    // Core rule with enabled = false in [[rules]] but no [overrides] entry
+    fs::write(
+        &config_path,
+        "[[rules]]\nname = \"git-push-force-block\"\nenabled = false\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&config_path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    let output = Command::new(binary)
+        .args(["config", "list"])
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env_remove("HOME")
+        .output()
+        .expect("failed to run config list");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Core rule should still show as active (immutability)
+    let push_force_line = stdout
+        .lines()
+        .find(|l| l.contains("git-push-force-block"))
+        .unwrap_or("");
+    assert!(
+        push_force_line.contains("active") && push_force_line.contains("core"),
+        "core rule should stay active: {push_force_line}"
+    );
+
+    // Should have a warning about the ignored override
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("core safety rule"),
+        "should warn about ignored override: {stderr}"
     );
 
     let _ = fs::remove_dir_all(config_dir);
@@ -274,12 +319,10 @@ fn config_list_shows_disabled_rule() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn config_disable_adds_block() {
+fn config_disable_core_rule_rejected_with_hint() {
     let binary = env!("CARGO_BIN_EXE_omamori");
-    let config_dir = unique_dir("cfg-disable");
-    let config_path = config_dir.join("omamori").join("config.toml");
+    let config_dir = unique_dir("cfg-disable-core");
 
-    // Init a fresh config
     let output = Command::new(binary)
         .args(["init"])
         .env("XDG_CONFIG_HOME", &config_dir)
@@ -288,7 +331,7 @@ fn config_disable_adds_block() {
         .unwrap();
     assert!(output.status.success());
 
-    // Disable a rule
+    // Try to disable a core rule via `config disable` — should fail
     let mut cmd = Command::new(binary);
     clean_ai_env(&mut cmd);
     let output = cmd
@@ -298,110 +341,91 @@ fn config_disable_adds_block() {
         .output()
         .unwrap();
 
+    assert!(
+        !output.status.success(),
+        "should be rejected, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("core safety rule"));
+    assert!(stderr.contains("omamori override disable"));
+
+    let _ = fs::remove_dir_all(&config_dir);
+}
+
+#[test]
+fn override_disable_then_enable_roundtrip() {
+    let binary = env!("CARGO_BIN_EXE_omamori");
+    let config_dir = unique_dir("cfg-override-roundtrip");
+
+    Command::new(binary)
+        .args(["init"])
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    // Override disable
+    let mut cmd = Command::new(binary);
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["override", "disable", "git-push-force-block"])
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
     assert!(
         output.status.success(),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Disabled: git-push-force-block"));
 
-    // Verify config file contains the disable block
-    let content = fs::read_to_string(&config_path).unwrap();
-    assert!(content.contains("[[rules]]\nname = \"git-push-force-block\"\nenabled = false"));
-
-    // config list should show disabled
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("disabled"));
-
-    let _ = fs::remove_dir_all(&config_dir);
-}
-
-#[test]
-fn config_enable_removes_block() {
-    let binary = env!("CARGO_BIN_EXE_omamori");
-    let config_dir = unique_dir("cfg-enable");
-
-    // Init + disable
-    Command::new(binary)
-        .args(["init"])
-        .env("XDG_CONFIG_HOME", &config_dir)
-        .env_remove("HOME")
-        .output()
-        .unwrap();
-    {
-        let mut c = Command::new(binary);
-        clean_ai_env(&mut c);
-        c
-    }
-    .args(["config", "disable", "git-push-force-block"])
-    .env("XDG_CONFIG_HOME", &config_dir)
-    .env_remove("HOME")
-    .output()
-    .unwrap();
-
-    // Enable it back
-    let mut cmd = Command::new(binary);
-    clean_ai_env(&mut cmd);
-    let output = cmd
-        .args(["config", "enable", "git-push-force-block"])
-        .env("XDG_CONFIG_HOME", &config_dir)
-        .env_remove("HOME")
-        .output()
-        .unwrap();
-
-    assert!(output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Enabled: git-push-force-block"));
-
-    // Verify the active disable block is removed (commented lines may still have "enabled = false")
+    // Verify config has [overrides] section
     let config_path = config_dir.join("omamori").join("config.toml");
     let content = fs::read_to_string(&config_path).unwrap();
     assert!(
-        !content.contains("[[rules]]\nname = \"git-push-force-block\"\nenabled = false"),
-        "disable block should be removed from config"
+        content.contains("[overrides]") && content.contains("git-push-force-block = false"),
+        "should have overrides section: {content}"
+    );
+
+    // Override enable (restore)
+    let mut cmd = Command::new(binary);
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["override", "enable", "git-push-force-block"])
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    // Verify override entry is removed
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert!(
+        !content.contains("git-push-force-block = false"),
+        "override entry should be removed: {content}"
     );
 
     let _ = fs::remove_dir_all(&config_dir);
 }
 
 #[test]
-fn config_disable_already_disabled_returns_2() {
+fn config_disable_already_disabled_returns_error_for_core() {
     let binary = env!("CARGO_BIN_EXE_omamori");
-    let config_dir = unique_dir("cfg-disable-dup");
 
-    Command::new(binary)
-        .args(["init"])
-        .env("XDG_CONFIG_HOME", &config_dir)
-        .env_remove("HOME")
-        .output()
-        .unwrap();
-    {
-        let mut c = Command::new(binary);
-        clean_ai_env(&mut c);
-        c
-    }
-    .args(["config", "disable", "git-push-force-block"])
-    .env("XDG_CONFIG_HOME", &config_dir)
-    .env_remove("HOME")
-    .output()
-    .unwrap();
-
-    // Try to disable again
+    // For core rules, `config disable` always returns an error (not exit 2)
     let mut cmd = Command::new(binary);
     clean_ai_env(&mut cmd);
     let output = cmd
         .args(["config", "disable", "git-push-force-block"])
-        .env("XDG_CONFIG_HOME", &config_dir)
-        .env_remove("HOME")
         .output()
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(2));
+    assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("already disabled"));
+    assert!(stderr.contains("core safety rule"));
 
-    let _ = fs::remove_dir_all(&config_dir);
+    // No cleanup needed
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- 7 built-in safety rules are now structurally protected against config tampering
- `enabled = false` in config.toml is ignored for core rules (with warning)
- `action` downgrades (e.g. trash → log-only) are rejected; upgrades are allowed
- `command`, `match_all`, `match_any` overrides are rejected
- Only `message` customization is allowed
- New `omamori override disable/enable` commands for legitimate override (blocked in AI context)
- `config list` and `test` output updated with core/config source distinction
- `ActionKind::defense_level()` defines action strength ordering

## Design decisions

- **Immutability scope**: all fields except `message` (Security: `action=log-only` bypass is DREAD 9.0)
- **Action downgrade only**: `defense_level()` ordering prevents weakening but allows strengthening
- **Override exists**: "AI cannot remove armor" ≠ "user cannot remove armor". `[overrides]` section in config.toml
- **`config disable` = error**: silent ignore is worst UX. Immediate error with actionable hint

Inspired by Jozu Agent Guard's "Embedded Policy" concept.

## Context

- Plan: `.claude/plans/2026-03-21-v050-integrity-monitoring.md`
- Investigation: `investigation/v05-shell-shim-investigation.md`

## Test plan

- [ ] `cargo test` — all tests pass (94 unit + 32 CLI + 12 integration)
- [ ] Core rule `enabled = false` in config.toml is ignored
- [ ] Core rule `action = "log-only"` rejected (downgrade)
- [ ] Core rule `action = "block"` accepted (upgrade)
- [ ] `omamori config disable <core-rule>` returns error with hint
- [ ] `omamori override disable <rule>` works in non-AI context
- [ ] `omamori override disable <rule>` blocked in AI context
- [ ] `config list` shows `core` / `core (overridden)` distinction

🤖 Generated with [Claude Code](https://claude.com/claude-code)