### PR TITLE
docs: v0.5.0 changelog, security docs, and README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.5.0] - 2026-03-21
+
+### Added
+
+- **Integrity monitoring** (#28): Two-tier defense layer verification that detects tampering of omamori's own infrastructure.
+  - **Canary check** (every shim invocation): `stat` + `readlink` (~0.05ms) verifies `.integrity.json` exists and shim symlink points to omamori binary.
+  - **Full check** (`omamori status`): Verifies all shims, hook content hash, config permissions, core policy state, PATH order, and baseline integrity.
+  - **`.integrity.json` baseline**: SHA-256 hashes of hooks and config, shim symlink targets, stored with chmod 600 + O_NOFOLLOW + atomic write.
+  - **Auto-update**: Baseline refreshes after hook regen, config changes, install, and init. No false positives from legitimate operations.
+  - **v0.4 migration**: First shim invocation auto-generates baseline with stderr info message.
+- **`omamori status [--refresh]`**: Health check subcommand with grouped output (Shims / Hooks / Config / Core Policy / PATH / Baseline). Exit codes: 0=healthy, 1=FAIL, 2=WARN. `--refresh` regenerates baseline from current state.
+- **Core policy immutability** (#48): 7 built-in safety rules cannot be disabled or weakened via `config.toml`. All fields except `message` are enforced. `config disable` on a core rule returns an error with guidance.
+  - **`omamori override disable/enable <rule>`**: Explicit override mechanism for legitimate use cases (CI, solo dev). Blocked by AI guard + hooks.
+  - **`[overrides]` section** in config.toml for persistent overrides.
+  - **`config list`** now shows `core` vs `config` source and `(overridden)` status.
+  - **`omamori test`** now includes Core Policy section.
+- **Hook content hash verification** (#49, T2 fix, DREAD 9.0): `ensure_hooks_current()` now compares SHA-256 of `render_hook_script()` output against the actual file — detects AI attacks that keep the version comment but rewrite hook body (e.g. `exit 2` → `exit 0`).
+- **Self-defense**: `.integrity.json` protected by hook block list (Claude Code + Cursor) and `blocked_command_patterns()`. `omamori override` blocked by hooks.
+- 29 new tests (total: 160). Covers integrity canary, status output, baseline roundtrip, install baseline generation, hook block patterns, core policy immutability, override mechanism.
+
+### Changed
+
+- `SHIM_COMMANDS` visibility changed from `const` to `pub const` (needed by integrity module).
+- `render_hook_script()`, `hook_content_hash()`, `parse_hook_version()` visibility changed from `pub(crate)` to `pub`.
+- `ensure_hooks_current()` now returns `bool` indicating whether hooks were regenerated.
+- `uninstall` now removes `.integrity.json`.
+
+### Security
+
+- **Implementation-derived hash**: Hook integrity uses `render_hook_script()` output as source of truth, not stored baseline. Eliminates baseline tampering as an attack vector for hook verification.
+- **Trusted transitions only**: Baseline auto-updates restricted to omamori-initiated operations (install, hook regen, config CLI commands). External edits produce WARN, not auto-update.
+- **TOCTOU**: Canary checks point-in-time state. Tampering between checks is not detected until the next invocation. Accepted structural limitation of no-daemon design.
+
+### Important
+
+- **Existing users**: Run `omamori install --hooks` to generate `.integrity.json` baseline and update hooks with new block patterns. Or simply use any shim command — baseline auto-generates on first invocation.
+- **Core rules can no longer be disabled via config**: Use `omamori override disable <rule>` for legitimate overrides. AI agents cannot use this command.
+
 ## [0.4.2] - 2026-03-19
 
 ### Fixed
@@ -230,6 +268,7 @@ The format is based on Keep a Changelog.
 - Claude Code hook template generation via `omamori install --hooks`.
 - Expanded README and SECURITY documentation for protected and unprotected command coverage.
 
+[0.5.0]: https://github.com/yottayoshida/omamori/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/yottayoshida/omamori/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/yottayoshida/omamori/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/yottayoshida/omamori/compare/v0.3.2...v0.4.0

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Terminal → rm -rf src/
 
 **Auto-sync**: After `brew upgrade`, the shim detects version mismatch and auto-regenerates hooks on the next invocation. No manual intervention needed.
 
+**Core policy**: The 7 built-in rules cannot be disabled via `config.toml` — an AI agent setting `enabled = false` is silently ignored. For legitimate overrides, see `omamori override` in [CLI Reference](#cli-reference).
+
+**Integrity monitoring** (`omamori status`): Verifies all defense layers are intact — shims, hooks, config, core policy, PATH order. Detects tampering including subtle hook edits where the version comment is preserved but the body is rewritten.
+
 ## Supported Tools
 
 | Tier | Tools | Coverage |
@@ -155,10 +159,15 @@ destination = "/tmp/omamori-quarantine/"
 ```
 omamori install [--hooks]                # Setup shims + hooks + config
 omamori test [--config PATH]             # Verify policy rules
+omamori status [--refresh]               # Health check all defense layers
 omamori exec [--config PATH] -- CMD      # Run command through policy engine
+
 omamori config list                      # Show rules with status
 omamori config disable <rule>            # Disable a rule
 omamori config enable <rule>             # Re-enable a rule
+omamori override disable <rule>          # Override a core safety rule
+omamori override enable <rule>           # Restore a core safety rule
+
 omamori init [--force] [--stdout]        # Create/reset config
 omamori uninstall                        # Remove shims + hooks
 omamori cursor-hook                      # Cursor hook handler

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 `omamori` is a PATH-shim safeguard for AI-triggered shell commands. It reduces risk for a narrow set of destructive commands, but it is not a sandbox and it does not claim complete mediation.
 
-## What It Protects (v0.4.1)
+## What It Protects (v0.5.0)
 
 - recursive `rm` variants matched by the default rules
 - `git reset --hard`
@@ -31,6 +31,70 @@
 - **Basename collision avoidance**: When `move-to` processes multiple targets, a dedup suffix (`_2`, `_3`, ...) prevents same-named files from overwriting each other.
 
 - **Cross-device move rejection**: `move-to` uses `rename(2)` which is atomic on the same filesystem. Cross-device moves (`EXDEV`) are rejected to avoid the TOCTOU window that copy+delete would introduce.
+
+## Integrity Monitoring (v0.5.0+)
+
+omamori verifies that its own defense layers are intact. This addresses the question: "who guards the guard?"
+
+### Two-Tier Check
+
+| Tier | When | What | Cost | Catches |
+|------|------|------|------|---------|
+| **Canary** | Every shim invocation | `.integrity.json` exists + own symlink target = omamori binary | ~0.05ms (stat + readlink) | Shim deletion/replacement |
+| **Full check** (`omamori status`) | On-demand | All shims, hook content hash, config perms + hash, core policy, PATH order | ~5-10ms | All tampering including subtle hook edits |
+
+### `.integrity.json` Baseline
+
+- **Location**: `~/.omamori/.integrity.json`
+- **Protection**: chmod 600, `O_NOFOLLOW`, atomic write (temp → fsync → rename), hook block list
+- **Contents**: SHA-256 hashes of hooks and config, shim symlink targets, version, timestamp
+- **Trusted transitions**: Auto-updates only from omamori-initiated operations (install, hook regen, config CLI). External edits produce WARN on next check, not auto-update
+
+### Hook Content Hash (T2 fix, DREAD 9.0)
+
+`ensure_hooks_current()` compares the SHA-256 of `render_hook_script()` (implementation-derived expected content) against the actual file on disk. This detects attacks where the version comment is preserved but the hook body is rewritten (e.g. `exit 2` → `exit 0`).
+
+Using implementation-derived content as source of truth (not stored baseline) eliminates baseline tampering as an attack vector for hook verification.
+
+### TOCTOU Risk (accepted)
+
+Canary checks point-in-time state. Tampering between checks is not detected until the next shim invocation. This is a structural limitation of the no-daemon design. A filesystem watcher or daemon would eliminate this gap but contradicts omamori's zero-daemon philosophy.
+
+### Self-Defense for Baseline
+
+| Attack | Protection |
+|--------|-----------|
+| AI edits `.integrity.json` (Claude Code Edit/Write) | Hook block pattern: `".integrity.json"` |
+| AI edits `.integrity.json` (Cursor Bash) | `blocked_command_patterns()` match |
+| AI deletes `.integrity.json` | Canary detects missing file; auto-regenerates on next shim invocation |
+| AI tampers baseline to match tampered state | Implementation-derived hook hash ignores baseline for hook verification |
+
+## Core Policy Immutability (v0.5.0+)
+
+The 7 built-in safety rules are structurally enforced in the binary. Config.toml cannot disable or weaken them.
+
+### Immutability Scope
+
+| Field | User can override? | Rationale |
+|-------|-------------------|-----------|
+| `enabled` | **No** | Core purpose of immutability |
+| `action` | **No** (downgrade blocked; upgrade allowed) | `log-only` downgrade = effective disable |
+| `command` | **No** | Changed command = rule never matches |
+| `match_all` / `match_any` | **No** | Empty arrays = unexpected match behavior |
+| `destination` | **No** | Tied to action semantics |
+| `message` | **Yes** | Localization / customization. No security impact |
+
+### Override Mechanism
+
+For legitimate use cases (CI environments, solo developers), `omamori override disable <rule>`:
+- Writes to `[overrides]` section in config.toml
+- Blocked by `guard_ai_config_modification()` in AI context
+- Blocked by hook patterns (`omamori override` string match)
+- Restores with `omamori override enable <rule>`
+
+### Design Decision: Structural > Detection
+
+Core immutability uses structural enforcement (binary ignores config overrides for core rules) rather than detection-based approaches (HMAC signing of config). "Tampering is meaningless" is stronger than "tampering is detected."
 
 ## Structural Limits
 


### PR DESCRIPTION
## Summary

- CHANGELOG.md: v0.5.0 entry covering integrity monitoring (#28), core policy immutability (#48), hook content hash (#49), and `omamori status`
- SECURITY.md: new sections for Integrity Monitoring (two-tier check, baseline, T2 fix, TOCTOU) and Core Policy Immutability (scope, override, design rationale)
- README.md: core policy + integrity monitoring added to How It Works, `status`/`override` added to CLI Reference, commands grouped visually

PR 4 of 4 for v0.5.0. Docs only — no code changes.

## Test plan

- [x] No code changes — CI should pass trivially
- [x] UX Designer reviewed README: core policy description shortened, CLI Reference grouped by function
- [x] CHANGELOG follows existing Keep a Changelog format
- [x] SECURITY.md maintains existing section structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)