### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Cargo.toml version: 0.4.2 → 0.5.0

Version bump for release. All feature PRs (#48, #49, #50) and docs (#51) already merged.

## Test plan

- [x] 160 tests pass with v0.5.0
- [x] Clippy clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)