### PR TITLE
feat: hook-check subcommand + unified hook pipeline

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -55,6 +55,15 @@ pub struct AuditEvent {
     pub result: String,
     pub target_count: usize,
     pub target_hash: String,
+    /// Detection layer: "layer1" (PATH shim) or "layer2" (hook).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detection_layer: Option<String>,
+    /// Unwrap chain showing how the command was extracted (e.g., ["sudo", "bash -c", "rm -rf /"]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unwrap_chain: Option<Vec<String>>,
+    /// SHA-256 hash of the raw hook input (before parsing), for non-repudiation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_input_hash: Option<String>,
 }
 
 impl AuditEvent {
@@ -81,6 +90,9 @@ impl AuditEvent {
             result: outcome.label().to_string(),
             target_count: targets.len(),
             target_hash: hash_targets(&targets),
+            detection_layer: Some("layer1".to_string()),
+            unwrap_chain: None,
+            raw_input_hash: None,
         }
     }
 }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -258,64 +258,14 @@ pub fn regenerate_hooks(base_dir: &Path) -> Result<(), std::io::Error> {
 pub fn render_hook_script() -> String {
     format!(
         r#"#!/bin/sh
-# omamori hook v{}
-set -eu"#,
-        env!("CARGO_PKG_VERSION")
-    ) + r#"
-
-INPUT="$(cat)"
-
-case "$INPUT" in
-  *"/bin/rm "*|*"/bin/rm\""*|*"/usr/bin/rm "*|*"/usr/bin/rm\""*)
-    echo "omamori hook: blocked direct rm path that bypasses PATH shim" >&2
-    exit 2
-    ;;
-  *"unset CLAUDECODE"*|*"env -u CLAUDECODE"*|*"CLAUDECODE="*|\
-  *"unset CODEX_CI"*|*"env -u CODEX_CI"*|*"CODEX_CI="*|\
-  *"unset CURSOR_AGENT"*|*"env -u CURSOR_AGENT"*|*"CURSOR_AGENT="*|\
-  *"unset GEMINI_CLI"*|*"env -u GEMINI_CLI"*|*"GEMINI_CLI="*|\
-  *"unset CLINE_ACTIVE"*|*"env -u CLINE_ACTIVE"*|*"CLINE_ACTIVE="*|\
-  *"unset AI_GUARD"*|*"env -u AI_GUARD"*|*"AI_GUARD="*)
-    echo "omamori hook: blocked attempt to unset a detector env var" >&2
-    exit 2
-    ;;
-  *"config disable"*|*"config enable"*)
-    echo "omamori hook: blocked attempt to modify omamori rules" >&2
-    exit 2
-    ;;
-  *"omamori uninstall"*)
-    echo "omamori hook: blocked attempt to uninstall omamori" >&2
-    exit 2
-    ;;
-  *"omamori init --force"*)
-    echo "omamori hook: blocked attempt to overwrite omamori config" >&2
-    exit 2
-    ;;
-  *"omamori override"*)
-    echo "omamori hook: blocked attempt to override omamori core rules" >&2
-    exit 2
-    ;;
-  *"omamori/config.toml"*|*"omamori"*"config.toml"*)
-    echo "omamori hook: blocked attempt to edit omamori config file directly" >&2
-    exit 2
-    ;;
-  *".integrity.json"*)
-    echo "omamori hook: blocked attempt to edit integrity baseline" >&2
-    exit 2
-    ;;
-  *"python "*"-c "*"shutil.rmtree"*|*"python3 "*"-c "*"shutil.rmtree"*|\
-  *"python "*"-c "*"os.remove"*|*"python3 "*"-c "*"os.remove"*|\
-  *"python "*"-c "*"os.rmdir"*|*"python3 "*"-c "*"os.rmdir"*|\
-  *"node "*"-e "*"rmSync"*|*"node "*"-e "*"unlinkSync"*|\
-  *"bash "*"-c "*"rm -rf"*|*"sh "*"-c "*"rm -rf"*)
-    echo "omamori hook: warning — potentially destructive interpreter command detected" >&2
-    exit 0
-    ;;
-  *)
-    exit 0
-    ;;
-esac
-"#
+# omamori hook v{version}
+# Thin wrapper: delegates all detection to `omamori hook-check`
+set -eu
+cat | omamori hook-check --provider claude-code
+exit $?
+"#,
+        version = env!("CARGO_PKG_VERSION")
+    )
 }
 
 /// Blocked command patterns shared between Claude Code hooks and Cursor hooks.
@@ -489,54 +439,16 @@ mod tests {
     }
 
     #[test]
-    fn hook_script_blocks_bin_rm_but_not_rmdir() {
+    fn hook_script_is_thin_wrapper() {
         let script = render_hook_script();
-        // Should match /bin/rm followed by space
-        assert!(script.contains(r#"*"/bin/rm "*"#));
-        assert!(script.contains(r#"*"/usr/bin/rm "*"#));
-        // Should NOT have unbounded /bin/rm that matches /bin/rmdir
-        assert!(!script.contains(r#"*"/bin/rm"*"#) || script.contains(r#"*"/bin/rm "*"#));
-    }
-
-    #[test]
-    fn hook_script_blocks_all_detector_env_var_unsets() {
-        let script = render_hook_script();
-        for var in &[
-            "CLAUDECODE",
-            "CODEX_CI",
-            "CURSOR_AGENT",
-            "GEMINI_CLI",
-            "CLINE_ACTIVE",
-            "AI_GUARD",
-        ] {
-            assert!(
-                script.contains(&format!(r#"*"unset {var}"*"#)),
-                "hook script should block unset of {var}"
-            );
-        }
-        assert!(script.contains("blocked attempt to unset a detector env var"));
-    }
-
-    #[test]
-    fn hook_script_warns_on_interpreter_patterns() {
-        let script = render_hook_script();
-        // Should contain interpreter warning patterns (warn only, exit 0)
         assert!(
-            script.contains("shutil.rmtree"),
-            "hook script should warn on shutil.rmtree"
+            script.contains("omamori hook-check"),
+            "hook script should delegate to omamori hook-check"
         );
+        // Thin wrapper should NOT contain case statements
         assert!(
-            script.contains("os.remove"),
-            "hook script should warn on os.remove"
-        );
-        assert!(
-            script.contains("rmSync"),
-            "hook script should warn on rmSync"
-        );
-        // Should exit 0 for warnings (not exit 2)
-        assert!(
-            script.contains("potentially destructive interpreter command"),
-            "hook script should have interpreter warning message"
+            !script.contains("case \"$INPUT\""),
+            "hook script should not contain case statements (now a thin wrapper)"
         );
     }
 
@@ -548,28 +460,11 @@ mod tests {
         assert!(!snippet.contains(r#"" "path""#));
     }
 
-    // --- Bypass corpus: P1 (highest priority) ---
+    // --- Meta-pattern tests (blocked_command_patterns, Phase 1) ---
 
     #[test]
-    fn hook_script_covers_rm_path_core_variants() {
-        let script = render_hook_script();
-        // Hook script (shell case) covers space and quote boundaries
-        for path in &["/bin/rm", "/usr/bin/rm"] {
-            assert!(
-                script.contains(&format!("{path} ")),
-                "hook script should block '{path} '"
-            );
-            assert!(
-                script.contains(&format!("{path}\\\"")),
-                "hook script should block '{path}\\\"'"
-            );
-        }
-    }
-
-    #[test]
-    fn blocked_command_patterns_cover_all_rm_boundaries() {
+    fn meta_patterns_cover_rm_path_boundaries() {
         let patterns = blocked_command_patterns();
-        // blocked_command_patterns (used by cursor-hook) covers all boundary variants
         for path in &["/bin/rm", "/usr/bin/rm"] {
             for boundary in &[" ", "\"", "\t", "'"] {
                 let needle = format!("{path}{boundary}");
@@ -582,66 +477,54 @@ mod tests {
     }
 
     #[test]
-    fn hook_script_covers_all_env_var_unset_patterns() {
-        let script = render_hook_script();
-        let detector_vars = [
+    fn meta_patterns_cover_all_detector_env_vars() {
+        let patterns = blocked_command_patterns();
+        for var in &[
             "CLAUDECODE",
             "CODEX_CI",
             "CURSOR_AGENT",
             "GEMINI_CLI",
             "CLINE_ACTIVE",
             "AI_GUARD",
-        ];
-        for var in &detector_vars {
+        ] {
             assert!(
-                script.contains(&format!("unset {var}")),
-                "hook script should block 'unset {var}'"
+                patterns
+                    .iter()
+                    .any(|(p, _)| p.contains(&format!("unset {var}"))),
+                "should block unset {var}"
             );
             assert!(
-                script.contains(&format!("env -u {var}")),
-                "hook script should block 'env -u {var}'"
+                patterns
+                    .iter()
+                    .any(|(p, _)| p.contains(&format!("env -u {var}"))),
+                "should block env -u {var}"
             );
             assert!(
-                script.contains(&format!("{var}=")),
-                "hook script should block '{var}=' reassignment"
+                patterns.iter().any(|(p, _)| p.contains(&format!("{var}="))),
+                "should block {var}= reassignment"
             );
         }
     }
 
-    // --- Bypass corpus: P2 ---
-
     #[test]
-    fn hook_script_covers_config_modification_patterns() {
-        let script = render_hook_script();
-        assert!(script.contains("config disable"));
-        assert!(script.contains("config enable"));
-        assert!(script.contains("omamori uninstall"));
-        assert!(script.contains("omamori init --force"));
-        assert!(script.contains("config.toml"));
-    }
-
-    // --- Bypass corpus: P3 ---
-
-    #[test]
-    fn hook_script_warns_bash_c_rm() {
-        let script = render_hook_script();
-        assert!(
-            script.contains(r#"*"bash "*"-c "*"rm -rf"*"#),
-            "hook script should warn on bash -c rm -rf"
-        );
-        assert!(
-            script.contains(r#"*"sh "*"-c "*"rm -rf"*"#),
-            "hook script should warn on sh -c rm -rf"
-        );
-    }
-
-    // --- Bypass corpus: P4 (boundary variants) ---
-
-    #[test]
-    fn hook_script_does_not_false_positive_on_rmdir() {
+    fn meta_patterns_cover_config_modification() {
         let patterns = blocked_command_patterns();
-        // None of the patterns should match "rmdir" without also requiring
-        // a boundary char after "rm"
+        for keyword in &[
+            "config disable",
+            "config enable",
+            "omamori uninstall",
+            "omamori init --force",
+        ] {
+            assert!(
+                patterns.iter().any(|(p, _)| p.contains(keyword)),
+                "should block: {keyword}"
+            );
+        }
+    }
+
+    #[test]
+    fn meta_patterns_do_not_false_positive_on_rmdir() {
+        let patterns = blocked_command_patterns();
         for (pattern, _) in &patterns {
             assert!(
                 !pattern.contains("/bin/rmdir"),
@@ -762,13 +645,13 @@ mod tests {
         let original = render_hook_script();
         let original_hash = hook_content_hash(&original);
 
-        // Simulate T2 attack: keep version comment but change exit codes
-        let tampered = original.replace("exit 2", "exit 0");
+        // Simulate T2 attack: keep version comment but bypass hook-check
+        let tampered = original.replace("omamori hook-check", "true");
         let tampered_hash = hook_content_hash(&tampered);
 
         assert_ne!(
             original_hash, tampered_hash,
-            "T2 attack (exit 2 → exit 0) should be detected by hash mismatch"
+            "T2 attack (hook-check → true) should be detected by hash mismatch"
         );
 
         // Verify version comment is still intact (attacker preserved it)
@@ -793,15 +676,11 @@ mod tests {
     // --- omamori override block pattern tests ---
 
     #[test]
-    fn hook_script_blocks_omamori_override() {
-        let script = render_hook_script();
+    fn meta_patterns_block_omamori_override() {
+        let patterns = blocked_command_patterns();
         assert!(
-            script.contains("omamori override"),
-            "hook script should block 'omamori override'"
-        );
-        assert!(
-            script.contains("blocked attempt to override omamori core rules"),
-            "hook script should have override block message"
+            patterns.iter().any(|(p, _)| p.contains("omamori override")),
+            "meta-patterns should block 'omamori override'"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub fn run(args: &[OsString]) -> Result<i32, AppError> {
         Some("override") => run_override_command(args),
         Some("status") => run_status_command(args),
         Some("cursor-hook") => run_cursor_hook(),
+        Some("hook-check") => run_hook_check(args),
         Some("version") | Some("--version") | Some("-V") => {
             println!("omamori {}", env!("CARGO_PKG_VERSION"));
             Ok(0)
@@ -773,7 +774,7 @@ fn run_status_command(args: &[OsString]) -> Result<i32, AppError> {
 }
 
 /// Cursor `beforeShellExecution` hook handler.
-/// Reads JSON from stdin, checks command against blocked patterns,
+/// Reads JSON from stdin, checks command via shared hook pipeline,
 /// writes JSON response to stdout. All logs go to stderr only.
 fn run_cursor_hook() -> Result<i32, AppError> {
     use std::io::Read;
@@ -781,7 +782,6 @@ fn run_cursor_hook() -> Result<i32, AppError> {
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
 
-    // Extract "command" field from JSON input
     let command = match serde_json::from_str::<serde_json::Value>(&input) {
         Ok(v) => v
             .get("command")
@@ -789,73 +789,256 @@ fn run_cursor_hook() -> Result<i32, AppError> {
             .unwrap_or("")
             .to_string(),
         Err(_) => {
-            // Can't parse → allow (don't block on malformed input)
             eprintln!("omamori cursor-hook: failed to parse stdin JSON");
             print_cursor_response(true, "allow", None, None);
             return Ok(0);
         }
     };
 
+    if command.is_empty() {
+        print_cursor_response(true, "allow", None, None);
+        return Ok(0);
+    }
+
     eprintln!("omamori cursor-hook: command={command}");
 
-    // Check against shared blocked patterns
-    for (pattern, reason) in installer::blocked_command_patterns() {
-        if command.contains(pattern) {
+    match check_command_for_hook(&command) {
+        HookCheckResult::Allow => {
+            print_cursor_response(true, "allow", None, None);
+        }
+        HookCheckResult::BlockMeta(reason) => {
             eprintln!("omamori cursor-hook: BLOCKED ({reason})");
             print_cursor_response(
                 false,
                 "deny",
                 Some(&format!("omamori hook: {reason}")),
                 Some(&format!(
-                    "This command was blocked by omamori safety guard: {reason}. Use a safer alternative."
+                    "This command was blocked by omamori: {reason}. Use a safer alternative."
                 )),
             );
-            return Ok(0);
         }
-    }
-
-    // Check for interpreter patterns (warn only, don't block)
-    let interpreter_patterns = [
-        ("shutil.rmtree", "python shutil.rmtree detected"),
-        ("os.remove", "python os.remove detected"),
-        ("os.rmdir", "python os.rmdir detected"),
-        ("rmSync", "node rmSync detected"),
-        ("unlinkSync", "node unlinkSync detected"),
-    ];
-    // Only check if command involves an interpreter with -c/-e flag
-    if (command.contains("python") && command.contains("-c"))
-        || (command.contains("node") && command.contains("-e"))
-        || (command.contains("bash") && command.contains("-c"))
-        || (command.contains("sh") && command.contains("-c"))
-    {
-        for (pattern, reason) in interpreter_patterns {
-            if command.contains(pattern) {
-                eprintln!("omamori cursor-hook: WARNING ({reason})");
-                print_cursor_response(
-                    true,
-                    "ask",
-                    Some(&format!("omamori warning: {reason}")),
-                    Some("This interpreter command may be destructive. Review before proceeding."),
-                );
-                return Ok(0);
-            }
-        }
-        // bash/sh -c "rm -rf" pattern
-        if command.contains("rm -rf") || command.contains("rm -r ") {
-            eprintln!("omamori cursor-hook: WARNING (shell rm -rf via interpreter)");
+        HookCheckResult::BlockRule {
+            message,
+            unwrap_chain,
+            ..
+        } => {
+            let chain_str = unwrap_chain
+                .as_deref()
+                .map(|c| format!(" ({c})"))
+                .unwrap_or_default();
+            eprintln!("omamori cursor-hook: BLOCKED ({message}{chain_str})");
             print_cursor_response(
-                true,
-                "ask",
-                Some("omamori warning: shell rm -rf via interpreter"),
-                Some("This interpreter command may be destructive. Review before proceeding."),
+                false,
+                "deny",
+                Some(&format!("omamori hook: blocked — {message}{chain_str}")),
+                Some("This command was blocked by omamori safety guard. Use a safer alternative."),
             );
-            return Ok(0);
+        }
+        HookCheckResult::BlockStructural(message) => {
+            eprintln!("omamori cursor-hook: BLOCKED ({message})");
+            print_cursor_response(
+                false,
+                "deny",
+                Some(&message),
+                Some("This command was blocked by omamori safety guard. Use a safer alternative."),
+            );
         }
     }
 
-    // Allow
-    print_cursor_response(true, "allow", None, None);
     Ok(0)
+}
+
+// ---------------------------------------------------------------------------
+// Shared hook check logic (used by both hook-check and cursor-hook)
+// ---------------------------------------------------------------------------
+
+/// Result of checking a command string through the hook pipeline.
+enum HookCheckResult {
+    /// Command is allowed.
+    Allow,
+    /// Command is blocked by a meta-pattern (string-level).
+    BlockMeta(&'static str),
+    /// Command is blocked by the unwrap stack (token-level rule match).
+    BlockRule {
+        rule_name: String,
+        message: String,
+        unwrap_chain: Option<String>,
+    },
+    /// Command is blocked by the unwrap stack (structural block: pipe-to-shell, etc.).
+    BlockStructural(String),
+}
+
+/// Two-phase hook check:
+/// Phase 1: Meta-pattern string-level check (env var unset, config tamper, /bin/rm, etc.)
+/// Phase 2: Token-level unwrap stack → rule matching
+fn check_command_for_hook(command: &str) -> HookCheckResult {
+    // Phase 1: Meta-patterns (string-level, intentionally broad)
+    for (pattern, reason) in installer::blocked_command_patterns() {
+        if command.contains(pattern) {
+            return HookCheckResult::BlockMeta(reason);
+        }
+    }
+
+    // Phase 2: Unwrap stack → rule matching
+    let parse_result = unwrap::parse_command_string(command);
+
+    match parse_result {
+        unwrap::ParseResult::Block(reason) => HookCheckResult::BlockStructural(format!(
+            "omamori hook: blocked — {}",
+            reason.message()
+        )),
+        unwrap::ParseResult::Commands(invocations) => {
+            // Load config to get rules
+            let load_result = match load_config(None) {
+                Ok(r) => r,
+                Err(_) => {
+                    // Config load failure → use default rules (fail-safe, not fail-open)
+                    ConfigLoadResult {
+                        config: config::Config::default(),
+                        warnings: vec![],
+                    }
+                }
+            };
+
+            for inv in &invocations {
+                if let Some(rule) = match_rule(&load_result.config.rules, inv) {
+                    let chain_desc = format_unwrap_chain(command, inv);
+                    let msg = rule
+                        .message
+                        .clone()
+                        .unwrap_or_else(|| format!("matched rule: {}", rule.name));
+                    return HookCheckResult::BlockRule {
+                        rule_name: rule.name.clone(),
+                        message: msg,
+                        unwrap_chain: chain_desc,
+                    };
+                }
+            }
+
+            HookCheckResult::Allow
+        }
+    }
+}
+
+/// Format the unwrap chain for display: "rm -rf / (via bash -c)"
+fn format_unwrap_chain(original: &str, invocation: &CommandInvocation) -> Option<String> {
+    // If the original command doesn't start with the matched program,
+    // there was unwrapping involved — show the wrapper context
+    let trimmed = original.trim();
+    if !trimmed.starts_with(&invocation.program) {
+        // Extract the first word of the original as the outermost wrapper
+        let outer = trimmed.split_whitespace().next().unwrap_or("");
+        let outer_base = outer.rsplit('/').next().unwrap_or(outer);
+        // Check if bash -c style
+        if trimmed.contains("-c") {
+            Some(format!("via {} -c", outer_base))
+        } else {
+            Some(format!("via {}", outer_base))
+        }
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// hook-check subcommand (Claude Code PreToolUse thin wrapper target)
+// ---------------------------------------------------------------------------
+
+/// `omamori hook-check [--provider NAME]`
+/// Reads command string from stdin, checks against meta-patterns + unwrap stack + rules.
+/// Exit 0 = allow, exit 2 = block.
+fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
+    use std::io::Read;
+
+    let provider = parse_provider_flag(args);
+
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input)?;
+
+    // Claude Code sends JSON with tool_input.command; extract it
+    let command = extract_command_from_hook_input(&input);
+
+    if command.is_empty() {
+        return Ok(0); // empty command = allow
+    }
+
+    let verbose = std::env::var("OMAMORI_VERBOSE").is_ok();
+
+    match check_command_for_hook(&command) {
+        HookCheckResult::Allow => Ok(0),
+        HookCheckResult::BlockMeta(reason) => {
+            eprintln!("omamori hook: blocked — {reason}");
+            if verbose {
+                eprintln!("  provider: {provider}");
+                eprintln!("  layer: meta-pattern (string-level)");
+            }
+            Ok(2)
+        }
+        HookCheckResult::BlockRule {
+            rule_name,
+            message,
+            unwrap_chain,
+        } => {
+            let chain_str = unwrap_chain
+                .as_deref()
+                .map(|c| format!(" ({c})"))
+                .unwrap_or_default();
+            eprintln!("omamori hook: blocked — {message}{chain_str}");
+            if verbose {
+                eprintln!("  provider: {provider}");
+                eprintln!("  rule: {rule_name}");
+                eprintln!("  layer: unwrap-stack (token-level)");
+            }
+            eprintln!(
+                "  hint: if intentional, run the command directly in your terminal (not via AI agent)"
+            );
+            Ok(2)
+        }
+        HookCheckResult::BlockStructural(message) => {
+            eprintln!("{message}");
+            if verbose {
+                eprintln!("  provider: {provider}");
+                eprintln!("  layer: unwrap-stack (structural)");
+            }
+            eprintln!(
+                "  hint: if intentional, run the command directly in your terminal (not via AI agent)"
+            );
+            Ok(2)
+        }
+    }
+}
+
+/// Extract the command string from Claude Code's PreToolUse hook JSON input.
+/// Falls back to treating the entire input as the command if JSON parsing fails.
+fn extract_command_from_hook_input(input: &str) -> String {
+    // Claude Code PreToolUse sends: { "tool_name": "Bash", "tool_input": { "command": "..." } }
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(input) {
+        if let Some(cmd) = v
+            .get("tool_input")
+            .and_then(|ti| ti.get("command"))
+            .and_then(|c| c.as_str())
+        {
+            return cmd.to_string();
+        }
+        // Cursor format: { "command": "..." }
+        if let Some(cmd) = v.get("command").and_then(|c| c.as_str()) {
+            return cmd.to_string();
+        }
+    }
+    // Fallback: treat raw input as command
+    input.trim().to_string()
+}
+
+/// Parse --provider flag from args. Defaults to "unknown".
+fn parse_provider_flag(args: &[OsString]) -> String {
+    for (i, arg) in args.iter().enumerate() {
+        if arg.to_str() == Some("--provider")
+            && let Some(val) = args.get(i + 1)
+        {
+            return val.to_string_lossy().to_string();
+        }
+    }
+    "unknown".to_string()
 }
 
 fn print_cursor_response(
@@ -1434,6 +1617,7 @@ fn usage_text() -> &'static str {
   omamori status [--refresh]                              # Health check all defense layers
   omamori override disable <rule>                        # Override a core safety rule
   omamori override enable <rule>                         # Restore a core safety rule
+  omamori hook-check [--provider NAME]                   # Hook detection engine (stdin → exit code)
   omamori cursor-hook                                   # Cursor beforeShellExecution handler
 
 When installed as a PATH shim (for example via a symlink named `rm`), omamori

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -471,15 +471,18 @@ fn cursor_hook_handles_malformed_stdin() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn cursor_hook_warns_python_rmtree() {
+fn cursor_hook_allows_python_rmtree() {
+    // python interpreter patterns are not blocked by meta-patterns or unwrap stack.
+    // The old warn-only (exit 0, ask) behavior was security theater.
+    // Future: python -c detection via interpreter-aware unwrap.
     let (stdout, _, success) = run_cursor_hook(
         r#"{"command":"python3 -c \"import shutil; shutil.rmtree('/tmp/test')\"","cwd":"/tmp"}"#,
     );
     assert!(success);
     let parsed: serde_json::Value =
         serde_json::from_str(&stdout).expect("stdout must be valid JSON");
-    assert_eq!(parsed["continue"], true, "should not block, only warn");
-    assert_eq!(parsed["permission"], "ask");
+    assert_eq!(parsed["continue"], true);
+    assert_eq!(parsed["permission"], "allow");
 }
 
 #[test]
@@ -494,7 +497,9 @@ fn cursor_hook_no_warn_safe_python() {
 }
 
 #[test]
-fn cursor_hook_warns_node_rmsync() {
+fn cursor_hook_allows_node_rmsync() {
+    // node interpreter patterns are not blocked by meta-patterns or unwrap stack.
+    // Future: node -e detection via interpreter-aware unwrap.
     let (stdout, _, success) = run_cursor_hook(
         r#"{"command":"node -e \"require('fs').rmSync('/tmp/test', {recursive: true})\"","cwd":"/tmp"}"#,
     );
@@ -502,7 +507,7 @@ fn cursor_hook_warns_node_rmsync() {
     let parsed: serde_json::Value =
         serde_json::from_str(&stdout).expect("stdout must be valid JSON");
     assert_eq!(parsed["continue"], true);
-    assert_eq!(parsed["permission"], "ask");
+    assert_eq!(parsed["permission"], "allow");
 }
 
 // ---------------------------------------------------------------------------
@@ -892,12 +897,13 @@ fn install_generates_integrity_baseline() {
 }
 
 #[test]
-fn hook_block_list_includes_integrity_json() {
-    // Verify the hook script blocks .integrity.json editing
-    let script = omamori::installer::render_hook_script();
+fn hook_check_blocks_integrity_json() {
+    // Verify meta-patterns block .integrity.json editing
+    // (previously checked in hook script, now delegated to hook-check via meta-patterns)
+    let patterns = omamori::installer::blocked_command_patterns();
     assert!(
-        script.contains(".integrity.json"),
-        "hook script should block .integrity.json editing"
+        patterns.iter().any(|(p, _)| p.contains(".integrity.json")),
+        "meta-patterns should block .integrity.json editing"
     );
 }
 

--- a/tests/poc_integrity.rs
+++ b/tests/poc_integrity.rs
@@ -175,8 +175,8 @@ fn poc3b_tampered_hook_detected_by_hash() {
     let expected = omamori::installer::render_hook_script();
     let expected_hash = sha256_hex(&expected);
 
-    // Simulate T2 attack: keep version comment, change exit codes
-    let tampered = expected.replace("exit 2", "exit 0");
+    // Simulate T2 attack: keep version comment, bypass hook-check
+    let tampered = expected.replace("omamori hook-check", "true");
     let tampered_hash = sha256_hex(&tampered);
 
     // Version comment is preserved


### PR DESCRIPTION
## Summary

- Add `omamori hook-check` subcommand — unified hook detection engine (stdin → exit code)
- Convert Claude Code hook to thin wrapper delegating to `hook-check`
- Refactor `cursor-hook` to use shared `check_command_for_hook()` pipeline
- Extend `AuditEvent` with `detection_layer`, `unwrap_chain`, `raw_input_hash` fields

## Behavior changes (warn → block)

| Pattern | Before (v0.5.0) | After |
|---|---|---|
| `bash -c "rm -rf /"` | warn (exit 0) | **BLOCK (exit 2)** |
| `sudo env bash -c "rm -rf /"` | pass-through | **BLOCK** |
| `curl ... \| bash` | pass-through | **BLOCK** |
| `echo "rm -rf" > memo.txt` | false warning | **ALLOW (FP fixed)** |
| python/node interpreter warns | warn (exit 0, ask) | allow (removed security theater) |

## Architecture

```
Claude Code hook (thin wrapper):
  cat | omamori hook-check --provider claude-code
  exit $?

hook-check pipeline:
  Phase 1: Meta-patterns (string-level) — env var unset, /bin/rm, config tamper
  Phase 2: Unwrap Stack (token-level) — wrapper strip → shell launcher extract → rule match
```

## Test plan

- [x] 226 tests pass (172 unit + 37 cli + 12 integration + 5 poc)
- [x] Clippy clean, cargo fmt clean
- [x] Existing meta-pattern coverage maintained (blocked_command_patterns unchanged)
- [x] T2 attack test updated for thin wrapper format
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)