### PR TITLE
fix: resolve Homebrew Cellar path in cursor hooks snippet (#56)

### DIFF
--- a/src/installer.rs
+++ b/src/installer.rs
@@ -11,6 +11,8 @@ pub const SHIM_COMMANDS: &[&str] = &["rm", "git", "chmod", "find", "rsync"];
 #[derive(Debug, Clone)]
 pub struct InstallOptions {
     pub base_dir: PathBuf,
+    /// Path to the omamori binary. Must be a stable path (not a versioned Cellar path).
+    /// Callers should pass the result of `resolve_stable_exe_path()` when using `current_exe()`.
     pub source_exe: PathBuf,
     pub generate_hooks: bool,
 }
@@ -182,9 +184,21 @@ fn atomic_write(target: &Path, content: &str) -> Result<(), std::io::Error> {
 }
 
 /// Create a named temp file in the given directory.
-/// Returns a wrapper that tracks the path for rename.
+/// Uses O_NOFOLLOW on Unix to prevent symlink-following attacks on the predictable
+/// temp path (symmetric with integrity.rs write_new_file). See: #56, T7.
 fn tempfile_in(dir: &Path) -> Result<AtomicTempFile, std::io::Error> {
     let path = dir.join(format!(".omamori-tmp-{}", std::process::id()));
+    #[cfg(unix)]
+    let file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&path)?
+    };
+    #[cfg(not(unix))]
     let file = fs::File::create(&path)?;
     Ok(AtomicTempFile { file, path })
 }
@@ -246,10 +260,11 @@ pub fn regenerate_hooks(base_dir: &Path) -> Result<(), std::io::Error> {
     let snippet_path = hooks_dir.join("claude-settings.snippet.json");
     atomic_write(&snippet_path, &render_settings_snippet(&script_path))?;
 
-    // Cursor hooks need the omamori exe path; use current_exe as best effort
+    // Cursor hooks: resolve to stable Homebrew path to survive brew upgrade (#56)
     if let Ok(exe) = std::env::current_exe() {
+        let stable_exe = resolve_stable_exe_path(&exe);
         let cursor_path = hooks_dir.join("cursor-hooks.snippet.json");
-        atomic_write(&cursor_path, &render_cursor_hooks_snippet(&exe))?;
+        atomic_write(&cursor_path, &render_cursor_hooks_snippet(&stable_exe))?;
     }
 
     Ok(())
@@ -380,7 +395,42 @@ pub fn blocked_command_patterns() -> Vec<(&'static str, &'static str)> {
     ]
 }
 
-fn render_cursor_hooks_snippet(omamori_exe: &Path) -> String {
+/// Extract the stable Homebrew-linked path from a versioned Cellar path.
+/// Pure function — no filesystem access. Returns `None` for non-Cellar paths.
+///
+/// Pattern: `<prefix>/Cellar/<formula>/<version>/bin/<binary>` → `<prefix>/bin/<binary>`
+fn cellar_to_stable_path(exe: &Path) -> Option<PathBuf> {
+    let s = exe.to_string_lossy();
+    let cellar_idx = s.find("/Cellar/")?;
+    let prefix = &s[..cellar_idx];
+    let bin_idx = s.rfind("/bin/")?;
+    let binary = &s[bin_idx + 5..];
+    (!binary.is_empty()).then(|| PathBuf::from(format!("{prefix}/bin/{binary}")))
+}
+
+/// Resolve a stable executable path for generated config files.
+///
+/// On Homebrew installs, `std::env::current_exe()` resolves symlinks to the versioned
+/// Cellar path, which breaks after `brew upgrade` + `brew cleanup`. This function
+/// converts it to the stable symlink path. See: #42 (shim fix), #56 (cursor hooks fix).
+///
+/// The `exists()` check has a TOCTOU window; this is acceptable because the worst case
+/// is writing a Cellar path — the same as pre-fix behavior, caught by `omamori status`.
+pub(crate) fn resolve_stable_exe_path(exe: &Path) -> PathBuf {
+    if let Some(stable) = cellar_to_stable_path(exe) {
+        if stable.exists() {
+            return stable;
+        }
+        eprintln!(
+            "omamori warning: Cellar path detected but stable path {} does not exist; \
+             using versioned path (may break after brew upgrade)",
+            stable.display()
+        );
+    }
+    exe.to_path_buf()
+}
+
+pub(crate) fn render_cursor_hooks_snippet(omamori_exe: &Path) -> String {
     // Use serde_json to generate correct JSON (handles path escaping properly)
     let command = format!("\"{}\" cursor-hook", omamori_exe.display());
     let snippet = serde_json::json!({
@@ -671,6 +721,99 @@ mod tests {
             hash.chars().all(|c| c.is_ascii_hexdigit()),
             "hash should contain only hex characters"
         );
+    }
+
+    // --- Cellar path resolution tests (#56) ---
+
+    #[test]
+    fn cellar_to_stable_apple_silicon() {
+        let p = Path::new("/opt/homebrew/Cellar/omamori/0.6.0/bin/omamori");
+        assert_eq!(
+            cellar_to_stable_path(p).unwrap(),
+            PathBuf::from("/opt/homebrew/bin/omamori")
+        );
+    }
+
+    #[test]
+    fn cellar_to_stable_intel() {
+        let p = Path::new("/usr/local/Cellar/omamori/0.6.0/bin/omamori");
+        assert_eq!(
+            cellar_to_stable_path(p).unwrap(),
+            PathBuf::from("/usr/local/bin/omamori")
+        );
+    }
+
+    #[test]
+    fn cellar_to_stable_linuxbrew() {
+        let p = Path::new("/home/linuxbrew/.linuxbrew/Cellar/omamori/0.6.0/bin/omamori");
+        assert_eq!(
+            cellar_to_stable_path(p).unwrap(),
+            PathBuf::from("/home/linuxbrew/.linuxbrew/bin/omamori")
+        );
+    }
+
+    #[test]
+    fn cellar_to_stable_cargo_install_returns_none() {
+        assert!(cellar_to_stable_path(Path::new("/Users/dev/.cargo/bin/omamori")).is_none());
+    }
+
+    #[test]
+    fn cellar_to_stable_manual_copy_returns_none() {
+        assert!(cellar_to_stable_path(Path::new("/usr/local/bin/omamori")).is_none());
+    }
+
+    #[test]
+    fn cellar_to_stable_formula_name_irrelevant() {
+        // Binary name is extracted from /bin/<binary>, not from formula dir
+        let p = Path::new("/opt/homebrew/Cellar/some-other-formula/1.0/bin/omamori");
+        assert_eq!(
+            cellar_to_stable_path(p).unwrap(),
+            PathBuf::from("/opt/homebrew/bin/omamori")
+        );
+    }
+
+    #[test]
+    fn cellar_to_stable_relative_path_returns_none() {
+        assert!(cellar_to_stable_path(Path::new("Cellar/omamori/0.6.0/bin/omamori")).is_none());
+    }
+
+    #[test]
+    fn cellar_to_stable_empty_path_returns_none() {
+        assert!(cellar_to_stable_path(Path::new("")).is_none());
+    }
+
+    #[test]
+    fn cellar_to_stable_incomplete_cellar_returns_none() {
+        // Has /Cellar/ but no /bin/
+        assert!(cellar_to_stable_path(Path::new("/opt/homebrew/Cellar/omamori/0.6.0/")).is_none());
+    }
+
+    #[test]
+    fn resolve_stable_uses_cellar_path_when_stable_missing() {
+        // Stable path won't exist → should fall back to input
+        let cellar = PathBuf::from("/nonexistent/Cellar/omamori/0.6.0/bin/omamori");
+        assert_eq!(resolve_stable_exe_path(&cellar), cellar);
+    }
+
+    #[test]
+    fn resolve_stable_passes_through_non_cellar() {
+        let cargo = PathBuf::from("/Users/dev/.cargo/bin/omamori");
+        assert_eq!(resolve_stable_exe_path(&cargo), cargo);
+    }
+
+    #[test]
+    fn resolve_stable_returns_stable_when_exists() {
+        let dir = std::env::temp_dir().join(format!("omamori-stable-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let bin_dir = dir.join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("omamori"), "binary").unwrap();
+
+        let cellar = dir.join("Cellar/omamori/0.6.0/bin/omamori");
+        let expected = bin_dir.join("omamori");
+        assert_eq!(resolve_stable_exe_path(&cellar), expected);
+
+        let _ = fs::remove_dir_all(dir);
     }
 
     // --- omamori override block pattern tests ---

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -108,9 +108,9 @@ pub fn generate_baseline(base_dir: &Path) -> Result<IntegrityBaseline, AppError>
     let shim_dir = base_dir.join("shim");
     let hooks_dir = base_dir.join("hooks");
 
-    // Resolve omamori exe path (stable symlink, not canonicalized)
+    // Resolve omamori exe path: use stable Homebrew path, not versioned Cellar path (#56)
     let omamori_exe = std::env::current_exe()
-        .map(|p| p.display().to_string())
+        .map(|p| installer::resolve_stable_exe_path(&p).display().to_string())
         .unwrap_or_default();
 
     // Shims
@@ -255,6 +255,77 @@ pub fn canary(base_dir: &Path, program: &str) -> Option<String> {
 // Full check (omamori status)
 // ---------------------------------------------------------------------------
 
+/// Extract the omamori exe path embedded in a cursor hooks snippet.
+fn cursor_snippet_exe_path(content: &str) -> Option<PathBuf> {
+    let v: serde_json::Value = serde_json::from_str(content).ok()?;
+    let cmd = v["hooks"]["beforeShellExecution"][0]["command"].as_str()?;
+    let path = cmd.strip_prefix('"')?.split('"').next()?;
+    (!path.is_empty()).then(|| PathBuf::from(path))
+}
+
+/// Validate cursor hooks snippet: hash comparison + dangling path detection.
+/// Byte-exact comparison against `render_cursor_hooks_snippet()` output;
+/// any difference (including formatting) is treated as a mismatch (#56, T8).
+fn check_cursor_snippet(path: &Path) -> CheckItem {
+    let name = "cursor-hooks.snippet.json".to_string();
+    let category = "Hooks";
+
+    if !path.exists() {
+        return CheckItem {
+            category,
+            name,
+            status: CheckStatus::Warn,
+            detail: "(not installed — run `omamori install --hooks`)".to_string(),
+        };
+    }
+
+    let actual = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => {
+            return CheckItem {
+                category,
+                name,
+                status: CheckStatus::Fail,
+                detail: "(unreadable)".to_string(),
+            };
+        }
+    };
+
+    // Hash comparison: generate expected content from current stable exe path
+    let hash_ok = std::env::current_exe().ok().map(|exe| {
+        let stable = installer::resolve_stable_exe_path(&exe);
+        let expected = installer::render_cursor_hooks_snippet(&stable);
+        installer::hook_content_hash(&expected) == installer::hook_content_hash(&actual)
+    });
+
+    // Dangling path detection: check if the exe in the snippet actually exists
+    let dangling = cursor_snippet_exe_path(&actual).is_some_and(|p| !p.exists());
+
+    let (status, detail) = match (hash_ok, dangling) {
+        (Some(true), false) => (CheckStatus::Ok, "(hash match)"),
+        (Some(true), true) => (
+            CheckStatus::Warn,
+            "(path dangling — run `omamori install --hooks`)",
+        ),
+        (Some(false), _) => (
+            CheckStatus::Fail,
+            "(hash MISMATCH — run `omamori install --hooks`)",
+        ),
+        (None, false) => (CheckStatus::Warn, "(present, hash check skipped)"),
+        (None, true) => (
+            CheckStatus::Warn,
+            "(path dangling — run `omamori install --hooks`)",
+        ),
+    };
+
+    CheckItem {
+        category,
+        name,
+        status,
+        detail: detail.to_string(),
+    }
+}
+
 /// Run a full integrity check of all defense layers.
 pub fn full_check(base_dir: &Path) -> IntegrityReport {
     let mut items = Vec::new();
@@ -333,25 +404,27 @@ pub fn full_check(base_dir: &Path) -> IntegrityReport {
         });
     }
 
-    // Check snippet files exist (content correctness is less critical)
-    for snippet in &["claude-settings.snippet.json", "cursor-hooks.snippet.json"] {
-        let path = hooks_dir.join(snippet);
-        if path.exists() {
-            items.push(CheckItem {
-                category: "Hooks",
-                name: snippet.to_string(),
-                status: CheckStatus::Ok,
-                detail: "(present)".to_string(),
-            });
-        } else {
-            items.push(CheckItem {
-                category: "Hooks",
-                name: snippet.to_string(),
-                status: CheckStatus::Warn,
-                detail: "(not installed)".to_string(),
-            });
+    // claude-settings.snippet.json — existence check only
+    let settings_snippet = hooks_dir.join("claude-settings.snippet.json");
+    items.push(if settings_snippet.exists() {
+        CheckItem {
+            category: "Hooks",
+            name: "claude-settings.snippet.json".to_string(),
+            status: CheckStatus::Ok,
+            detail: "(present)".to_string(),
         }
-    }
+    } else {
+        CheckItem {
+            category: "Hooks",
+            name: "claude-settings.snippet.json".to_string(),
+            status: CheckStatus::Warn,
+            detail: "(not installed)".to_string(),
+        }
+    });
+
+    // cursor-hooks.snippet.json — hash comparison + dangling path detection (#56, T8)
+    let cursor_snippet = hooks_dir.join("cursor-hooks.snippet.json");
+    items.push(check_cursor_snippet(&cursor_snippet));
 
     // --- Config ---
     if let Some(entry) = read_config_entry() {
@@ -680,5 +753,91 @@ mod tests {
         assert!(shim_items.iter().all(|i| i.status == CheckStatus::Fail));
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    // --- Cursor snippet validation tests (#56) ---
+
+    #[test]
+    fn cursor_snippet_exe_path_extracts_path() {
+        let snippet =
+            installer::render_cursor_hooks_snippet(Path::new("/opt/homebrew/bin/omamori"));
+        let exe = cursor_snippet_exe_path(&snippet).unwrap();
+        assert_eq!(exe, PathBuf::from("/opt/homebrew/bin/omamori"));
+    }
+
+    #[test]
+    fn cursor_snippet_exe_path_returns_none_for_invalid_json() {
+        assert!(cursor_snippet_exe_path("not json").is_none());
+    }
+
+    #[test]
+    fn cursor_snippet_exe_path_returns_none_for_empty_command() {
+        let json = r#"{"hooks":{"beforeShellExecution":[{"command":""}]}}"#;
+        assert!(cursor_snippet_exe_path(json).is_none());
+    }
+
+    #[test]
+    fn check_cursor_snippet_detects_hash_match() {
+        let dir = std::env::temp_dir().join(format!("omamori-cursor-t1-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Write snippet using the same resolved path that check_cursor_snippet uses
+        let exe = installer::resolve_stable_exe_path(&std::env::current_exe().unwrap());
+        let content = installer::render_cursor_hooks_snippet(&exe);
+        let path = dir.join("cursor-hooks.snippet.json");
+        fs::write(&path, &content).unwrap();
+
+        let item = check_cursor_snippet(&path);
+        assert_eq!(item.status, CheckStatus::Ok);
+        assert!(item.detail.contains("hash match"));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn check_cursor_snippet_detects_tampered_content() {
+        let dir = std::env::temp_dir().join(format!("omamori-cursor-t2-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("cursor-hooks.snippet.json");
+        fs::write(
+            &path,
+            r#"{"hooks":{"beforeShellExecution":[{"command":"exit 0"}]}}"#,
+        )
+        .unwrap();
+
+        let item = check_cursor_snippet(&path);
+        assert_eq!(item.status, CheckStatus::Fail);
+        assert!(item.detail.contains("MISMATCH"));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn check_cursor_snippet_detects_dangling_path() {
+        let dir = std::env::temp_dir().join(format!("omamori-cursor-t3-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Write snippet pointing to a nonexistent binary
+        let content = installer::render_cursor_hooks_snippet(Path::new("/nonexistent/bin/omamori"));
+        let path = dir.join("cursor-hooks.snippet.json");
+        fs::write(&path, &content).unwrap();
+
+        let item = check_cursor_snippet(&path);
+        // Either FAIL (hash mismatch) or WARN (dangling) — either way, not Ok
+        assert_ne!(item.status, CheckStatus::Ok);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn check_cursor_snippet_missing_returns_warn() {
+        let path = Path::new("/nonexistent/cursor-hooks.snippet.json");
+        let item = check_cursor_snippet(path);
+        assert_eq!(item.status, CheckStatus::Warn);
+        assert!(item.detail.contains("not installed"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ fn run_exec_command(args: &[OsString]) -> Result<i32, AppError> {
 
 fn run_install_command(args: &[OsString]) -> Result<i32, AppError> {
     let mut base_dir = default_base_dir();
-    let mut source_exe = env::current_exe()?;
+    let mut source_exe = installer::resolve_stable_exe_path(&env::current_exe()?);
     let mut generate_hooks = false;
     let mut index = 2usize;
 


### PR DESCRIPTION
## Summary

- **Cellar path resolution**: `cellar_to_stable_path()` + `resolve_stable_exe_path()` convert versioned Homebrew Cellar paths to stable symlink paths, preventing Cursor Layer 2 hook from silently breaking after `brew upgrade`
- **Cursor snippet integrity hardening**: `check_cursor_snippet()` upgrades existence-only check to SHA-256 hash comparison + dangling path detection (T8, DREAD 7.0)
- **O_NOFOLLOW on atomic_write**: Prevents symlink-following attacks on predictable temp file paths, symmetric with `integrity.rs::write_new_file()` (T7, DREAD 5.0)
- **Stable baseline path**: `generate_baseline()` now uses resolved stable path instead of raw `current_exe()`
- **19 new tests** (245 total, all passing): 9 cellar path cases + 3 resolve cases + 7 integrity cases

## Changed files

| File | Change |
|------|--------|
| `src/installer.rs` | `cellar_to_stable_path()`, `resolve_stable_exe_path()`, O_NOFOLLOW, `regenerate_hooks()` fix |
| `src/integrity.rs` | `check_cursor_snippet()` hash+dangling, `generate_baseline()` stable path |
| `src/lib.rs` | `run_install_command()` stable path resolution (1 line) |

## Test plan

- [x] 245 tests passing (191 unit + 37 cli + 12 integration + 5 poc)
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTFLAGS="-D warnings" cargo check` clean
- [ ] Manual E2E: `omamori install --hooks` on Homebrew → verify snippet uses `<brew-prefix>/bin/omamori`
- [ ] Manual E2E: `omamori status` → verify cursor snippet shows `(hash match)`

## Review context

- Plan: `.claude/plans/2026-03-23-v061-cursor-hook-stability.md`
- Closes #56
- Part 1 of 2 PRs for v0.6.1 (PR-2: demo.svg + README + CHANGELOG + bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)