### PR TITLE
docs: v0.6.1 changelog, README clarity, and version bump (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.6.1] - 2026-03-23
+
+### Fixed
+
+- **Cursor hook Cellar path resolution** (#56): `render_cursor_hooks_snippet()` and `regenerate_hooks()` now use `resolve_stable_exe_path()` to convert versioned Homebrew Cellar paths to stable symlink paths. Previously, `brew upgrade` + `brew cleanup` would silently break Cursor Layer 2 protection.
+- **`omamori install` Cellar path**: `run_install_command()` now resolves the stable path before passing to `InstallOptions`.
+- **`generate_baseline()` Cellar path**: Baseline `omamori_exe` field now records the stable path instead of the versioned Cellar path.
+
+### Security
+
+- **Cursor snippet integrity check** (T8): Upgraded from existence-only to SHA-256 hash comparison + dangling path detection. `omamori status` now reports FAIL on tampered snippets and WARN on dangling executable paths.
+- **`atomic_write` O_NOFOLLOW** (T7): Temp file creation now uses `O_NOFOLLOW` to prevent symlink-following attacks on the predictable temp path, symmetric with `integrity.rs::write_new_file()`.
+
+### Changed
+
+- README: Clarified that Cursor hooks require manual re-merge after `brew upgrade`, unlike Claude Code hooks which auto-sync.
+
 ## [0.6.0] - 2026-03-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ omamori install --hooks
 export PATH="$HOME/.omamori/shim:$PATH"
 ```
 
-That's it. After `brew upgrade`, hooks and shims are auto-updated on the next command — no manual re-install needed.
+That's it. After `brew upgrade`, shims and Claude Code hooks auto-update on the next command. **Cursor users**: re-merge the hook snippet after upgrades (see [Auto-sync](#how-it-works)).
 
 ## What It Blocks
 
@@ -71,7 +71,10 @@ Terminal → rm -rf src/
 
 **Self-defense** ([#22](https://github.com/yottayoshida/omamori/issues/22)): AI agents cannot `config disable`, `uninstall`, or edit `config.toml` while detected. Hooks block env var unsetting and direct config file editing. This is a key differentiator from other CLI guards — omamori assumes adversarial AI behavior and defends against it.
 
-**Auto-sync**: After `brew upgrade`, the shim detects version mismatch and auto-regenerates hooks on the next invocation. No manual intervention needed.
+**Auto-sync**: After `brew upgrade`, the shim detects version mismatch and auto-regenerates hook files on the next invocation.
+
+- **Claude Code**: Hooks are applied automatically. No action needed.
+- **Cursor**: Run `omamori install --hooks` to regenerate the snippet, then merge `~/.omamori/hooks/cursor-hooks.snippet.json` into your `.cursor/hooks.json`.
 
 **Core policy**: The 7 built-in rules cannot be disabled via `config.toml` — an AI agent setting `enabled = false` is silently ignored. For legitimate overrides, see `omamori override` in [CLI Reference](#cli-reference).
 
@@ -157,7 +160,7 @@ destination = "/tmp/omamori-quarantine/"
 ## CLI Reference
 
 ```
-omamori install [--hooks]                # Setup shims + hooks + config
+omamori install [--hooks]                # Setup shims + hooks + config (re-run after brew upgrade for Cursor)
 omamori test [--config PATH]             # Verify policy rules
 omamori status [--refresh]               # Health check all defense layers
 omamori exec [--config PATH] -- CMD      # Run command through policy engine


### PR DESCRIPTION
## Summary

- **CHANGELOG**: v0.6.1 entry with Fixed, Security, Changed sections
- **README**: Clarify Cursor hooks require manual re-merge after `brew upgrade`
  - Removed contradictory "no manual re-install needed" phrasing (UX Designer review)
  - Added Claude Code / Cursor bullet list in Auto-sync section
  - Added Cursor hint in CLI Reference
- **Cargo.toml**: version bump 0.6.0 → 0.6.1

## Test plan

- [x] 245 tests passing
- [x] `cargo clippy` clean
- [x] No code changes (docs + version only)

## Context

PR-2 of 2 for v0.6.1. Follows #57 (fix: Cellar path resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)