### PR TITLE
docs: v0.6.3 changelog, README, and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.6.3] - 2026-03-30
+
+### Added
+
+- **Codex CLI hook support** (#66): Full Tier 1 support for OpenAI Codex CLI (v0.117.0+) PreToolUse hooks.
+  - **hooks.json auto-merge**: `omamori install --hooks` auto-detects `~/.codex/` and merges omamori's PreToolUse entry into `~/.codex/hooks.json`. Existing entries (UserPromptSubmit, etc.) are preserved.
+  - **config.toml auto-write**: Sets `[features] codex_hooks = true` using `toml_edit` (preserves comments and formatting). Explicit `false` is respected (user intent).
+  - **fail-close wrapper**: Codex CLI treats exit 1 as ALLOW (fail-open), unlike Claude Code which blocks on any non-zero exit. The wrapper script converts all non-zero exits to exit 2 for fail-close safety.
+  - **shim auto-setup**: When `CODEX_CI` env is detected but the Codex wrapper doesn't exist, omamori auto-configures hooks on the first shim invocation. Users who install Codex after omamori get automatic protection.
+  - **self-defense**: `blocked_command_patterns` now protects `.codex/hooks.json`, `.codex/config.toml`, `config.toml.bak`, and the `codex_hooks` feature flag from AI agent tampering.
+  - **symlink checks**: Refuses to read/write hooks.json and config.toml if they are symlinks (consistent with existing O_NOFOLLOW pattern).
+  - `omamori status` Layer 2 coverage now shows "Claude Code + Codex CLI + Cursor".
+  - Codex wrapper included in integrity baseline.
+  - `toml_edit` v0.22 dependency added.
+  - 20 new tests (273 total).
+
 ## [0.6.2] - 2026-03-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ omamori install --hooks
 export PATH="$HOME/.omamori/shim:$PATH"
 ```
 
-That's it. Works with Claude Code Auto mode — no extra config needed. After `brew upgrade`, shims and Claude Code hooks auto-update on the next command. **Cursor users**: re-merge the hook snippet after upgrades (see [Auto-sync](#how-it-works)).
+That's it. Works with Claude Code Auto mode — no extra config needed. After `brew upgrade`, shims and hooks auto-update on the next command. **Cursor users**: re-merge the hook snippet after upgrades (see [Auto-sync](#how-it-works)).
 
 ## What It Blocks
 
@@ -76,6 +76,7 @@ Terminal → rm -rf src/
 **Auto-sync**: After `brew upgrade`, the shim detects version mismatch and auto-regenerates hook files on the next invocation.
 
 - **Claude Code**: Hooks are applied automatically. No action needed.
+- **Codex CLI**: Hooks and config are auto-configured during install (v0.6.3+). If you install Codex later, the shim sets up hooks on first invocation. Auto-sync regenerates the wrapper on upgrade.
 - **Cursor**: Run `omamori install --hooks` to regenerate the snippet, then merge `~/.omamori/hooks/cursor-hooks.snippet.json` into your `.cursor/hooks.json`.
 
 **Core policy**: The 7 built-in rules cannot be disabled via `config.toml` — an AI agent setting `enabled = false` is silently ignored. For legitimate overrides, see `omamori override` in [CLI Reference](#cli-reference).


### PR DESCRIPTION
## Summary

- CHANGELOG: v0.6.3 entry (Codex CLI hook support)
- README: Codex CLI notes in Quick Start and Auto-sync sections
- Cargo.toml: version bump 0.6.2 → 0.6.3

Follows #67 (feat PR).

## Test plan

- [x] 273 tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)