### PR TITLE
docs: v0.6.4 changelog, README sandbox positioning, and version bump (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.6.4] - 2026-03-31
+
+### Fixed
+
+- **`move_to_dir` canonicalize fail-close** (#69): Two-stage path resolution for blocked prefix check. Previously, `canonicalize()` failure silently skipped the check, allowing symlink-based bypass to system paths. Now uses dest-first canonicalize with parent fallback; any failure is rejected (fail-close).
+
+### Changed
+
+- **`ensure_hooks_current_at` testability**: Extracted `ensure_hooks_current_at(base_dir)` from `ensure_hooks_current()` for dependency injection in tests. No behavior change.
+- README: Added sandbox complementarity section explaining omamori (semantic layer) vs. filesystem sandbox (OS boundary) and their defense-in-depth relationship.
+
+### Added
+
+- **39 new tests** (273 → 312): Comprehensive coverage for 8 previously untested gaps identified via QA Report-Only mapping, plus 1 adversarial scenario.
+  - `evaluate_git_context` (7): real git repos, GIT_DIR spoof defense (T4), timeout fail-close.
+  - `ensure_hooks_current_at` (5): version mismatch, T2 hash tampering, read-only dir failure.
+  - `should_block_for_sudo` (1): non-root negative path.
+  - `SystemOps::move_to_dir` (10+1 ignored): real FS operations — symlink rejection, blocked prefix, basename dedup, canonicalize fail-close, EXDEV.
+  - `write_default_config` (4): permissions 600/700, symlink rejection, atomic write, no-force guard.
+  - `load_config` (2): insecure/secure permission handling.
+  - `AuditLogger` (4): from_config enable/disable, JSONL append integrity, I/O error path.
+  - `write_baseline` (3): symlink rejection, atomic update, O_NOFOLLOW.
+  - `auto_setup_codex_if_needed` (2): env-absent skip, wrapper-exists skip.
+  - Adversarial: hooks symlink attack → hash mismatch detection and regeneration (ADV-01).
+- `serial_test` v3 dev-dependency for CWD-sensitive git context tests.
+
 ## [0.6.3] - 2026-03-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Terminal → rm -rf src/
 
 **Integrity monitoring** (`omamori status`): Verifies all defense layers are intact — shims, hooks, config, core policy, PATH order. Detects tampering including subtle hook edits where the version comment is preserved but the body is rewritten.
 
+**Sandbox complementarity**: omamori operates at the semantic layer — it understands *what* a command does (Layer 1: shim, Layer 2: hooks). A filesystem sandbox (e.g., sandbox-exec, container isolation) operates at the OS boundary — it restricts *where* processes can read and write. These are complementary: omamori catches `rm -rf src/` before it runs; a sandbox prevents damage if something slips through. For defense in depth, use both. omamori plans to add optional sandbox integration in a future release ([#61](https://github.com/yottayoshida/omamori/issues/61)).
+
 ## Supported Tools
 
 | Tier | Tools | Coverage |


### PR DESCRIPTION
## Summary
- CHANGELOG: v0.6.4 entry documenting canonicalize fix, 39 new tests, serial_test dep
- README: sandbox complementarity section — explains omamori (semantic layer) vs. filesystem sandbox (OS boundary) with defense-in-depth recommendation
- Cargo.toml: version bump 0.6.3 → 0.6.4

## Context
- Follows PR #70 (fix + test)
- README section reviewed by UX Designer agent (insertion point, framing as "complementary" not "limitation")

## Test plan
- [x] No code changes — docs and version only
- [ ] CI passes (fmt, clippy, test, publish dry-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)