### PR TITLE
feat: audit verify + show CLI, status Layer 3 (#29)

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{BufRead, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use hmac::{Hmac, Mac};
@@ -334,7 +334,22 @@ fn flock_exclusive(file: &fs::File) -> Result<(), std::io::Error> {
 
 #[cfg(not(unix))]
 fn flock_exclusive(_file: &fs::File) -> Result<(), std::io::Error> {
-    Ok(()) // No-op on non-Unix (omamori is Unix-only, but keeps compilation clean)
+    Ok(())
+}
+
+#[cfg(unix)]
+fn flock_shared(file: &fs::File) -> Result<(), std::io::Error> {
+    use std::os::unix::io::AsRawFd;
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_SH) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn flock_shared(_file: &fs::File) -> Result<(), std::io::Error> {
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -437,6 +452,236 @@ fn default_audit_path() -> PathBuf {
         .join("share")
         .join("omamori")
         .join("audit.jsonl")
+}
+
+// ---------------------------------------------------------------------------
+// CLI: verify, show, summary
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum AuditError {
+    SecretUnavailable,
+    FileNotFound,
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for AuditError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SecretUnavailable => write!(f, "HMAC secret unavailable"),
+            Self::FileNotFound => write!(f, "audit log not found"),
+            Self::Io(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for AuditError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+pub struct VerifyResult {
+    pub chain_entries: u64,
+    pub legacy_entries: u64,
+    pub torn_lines: u64,
+    pub broken_at: Option<u64>,
+}
+
+pub struct ShowOptions {
+    pub last: Option<usize>,
+    pub rule: Option<String>,
+    pub provider: Option<String>,
+    pub json: bool,
+}
+
+pub struct AuditSummary {
+    pub enabled: bool,
+    pub entry_count: u64,
+    pub secret_available: bool,
+}
+
+pub fn verify_chain(config: &AuditConfig) -> Result<VerifyResult, AuditError> {
+    let path = config.path.clone().unwrap_or_else(default_audit_path);
+    let secret = read_secret(&secret_path_for(&path)).map_err(|_| AuditError::SecretUnavailable)?;
+
+    let file = fs::File::open(&path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => AuditError::FileNotFound,
+        _ => AuditError::Io(e),
+    })?;
+    flock_shared(&file)?;
+
+    let reader = std::io::BufReader::new(&file);
+    let genesis = genesis_hash(Some(&secret));
+
+    let mut result = VerifyResult {
+        chain_entries: 0,
+        legacy_entries: 0,
+        torn_lines: 0,
+        broken_at: None,
+    };
+    let mut expected_prev = genesis;
+    let mut expected_seq: u64 = 0;
+
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let event: AuditEvent = match serde_json::from_str(trimmed) {
+            Ok(e) => e,
+            Err(_) => {
+                result.torn_lines += 1;
+                continue;
+            }
+        };
+
+        if event.chain_version.is_none() {
+            result.legacy_entries += 1;
+            continue;
+        }
+
+        let seq = event.seq.unwrap_or(0);
+        let prev_hash = event.prev_hash.as_deref().unwrap_or("");
+        let recorded_hash = event.entry_hash.as_deref().unwrap_or("");
+
+        if result.chain_entries > 0 && seq != expected_seq {
+            result.broken_at = Some(seq);
+            break;
+        }
+        if prev_hash != expected_prev {
+            result.broken_at = Some(seq);
+            break;
+        }
+
+        let recomputed = compute_entry_hash(Some(&secret), &event);
+        if recomputed != recorded_hash {
+            result.broken_at = Some(seq);
+            break;
+        }
+
+        expected_prev = recorded_hash.to_string();
+        expected_seq = seq + 1;
+        result.chain_entries += 1;
+    }
+
+    Ok(result)
+}
+
+pub fn show_entries(
+    config: &AuditConfig,
+    opts: &ShowOptions,
+    out: &mut impl Write,
+) -> Result<(), AuditError> {
+    use std::collections::VecDeque;
+
+    let path = config.path.clone().unwrap_or_else(default_audit_path);
+    let file = fs::File::open(&path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => AuditError::FileNotFound,
+        _ => AuditError::Io(e),
+    })?;
+
+    let reader = std::io::BufReader::new(&file);
+    let capacity = opts.last.unwrap_or(usize::MAX);
+    let mut entries: VecDeque<AuditEvent> = VecDeque::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let event: AuditEvent = match serde_json::from_str(trimmed) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        if let Some(ref filter) = opts.rule {
+            match &event.rule_id {
+                Some(rule) if rule.contains(filter.as_str()) => {}
+                _ => continue,
+            }
+        }
+        if opts
+            .provider
+            .as_ref()
+            .is_some_and(|f| !event.provider.contains(f.as_str()))
+        {
+            continue;
+        }
+
+        entries.push_back(event);
+        if entries.len() > capacity {
+            entries.pop_front();
+        }
+    }
+
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    if opts.json {
+        for event in &entries {
+            serde_json::to_writer(&mut *out, event).map_err(std::io::Error::from)?;
+            writeln!(out)?;
+        }
+    } else {
+        writeln!(
+            out,
+            "{:<20} {:<12} {:<8} {:<15} {:<8} RULE",
+            "TIMESTAMP", "PROVIDER", "COMMAND", "ACTION", "RESULT"
+        )?;
+        for event in &entries {
+            let rule = event.rule_id.as_deref().unwrap_or("\u{2014}");
+            let ts = display_timestamp(&event.timestamp);
+            writeln!(
+                out,
+                "{:<20} {:<12} {:<8} {:<15} {:<8} {rule}",
+                ts, event.provider, event.command, event.action, event.result
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn audit_summary(config: &AuditConfig) -> AuditSummary {
+    if !config.enabled {
+        return AuditSummary {
+            enabled: false,
+            entry_count: 0,
+            secret_available: false,
+        };
+    }
+
+    let path = config.path.clone().unwrap_or_else(default_audit_path);
+    let secret_available = read_secret(&secret_path_for(&path)).is_ok();
+
+    let entry_count = fs::File::open(&path)
+        .ok()
+        .map(|f| {
+            std::io::BufReader::new(f)
+                .lines()
+                .filter(|l| l.as_ref().is_ok_and(|s| !s.trim().is_empty()))
+                .count() as u64
+        })
+        .unwrap_or(0);
+
+    AuditSummary {
+        enabled: true,
+        entry_count,
+        secret_available,
+    }
+}
+
+fn display_timestamp(ts: &str) -> String {
+    // "2026-04-04T03:31:02.54814Z" → "2026-04-04T03:31:02Z"
+    match ts.find('.') {
+        Some(dot) => format!("{}Z", &ts[..dot]),
+        None => ts.to_string(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -707,7 +952,7 @@ mod tests {
 
     // --- Verify chain integrity (helper for tests) ---
 
-    fn verify_chain(events: &[serde_json::Value], secret: Option<&[u8; 32]>) -> bool {
+    fn check_chain_manual(events: &[serde_json::Value], secret: Option<&[u8; 32]>) -> bool {
         let genesis = genesis_hash(secret);
         let mut expected_prev = genesis;
 
@@ -743,7 +988,7 @@ mod tests {
         logger.append(make_event("echo")).unwrap();
 
         let events = read_events(&logger.path);
-        assert!(verify_chain(&events, Some(&TEST_SECRET)));
+        assert!(check_chain_manual(&events, Some(&TEST_SECRET)));
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -764,7 +1009,7 @@ mod tests {
 
         let events = read_events(&logger.path);
         assert!(
-            !verify_chain(&events, Some(&TEST_SECRET)),
+            !check_chain_manual(&events, Some(&TEST_SECRET)),
             "tamper should be detected"
         );
 
@@ -996,5 +1241,304 @@ mod tests {
             secret: Some([0u8; 32]),
         };
         assert!(logger.append(make_event("rm")).is_err());
+    }
+
+    // --- verify_chain ---
+
+    fn verify_config(dir: &Path) -> AuditConfig {
+        AuditConfig {
+            enabled: true,
+            path: Some(dir.join("audit.jsonl")),
+        }
+    }
+
+    #[test]
+    fn verify_clean_chain() {
+        let dir = test_dir("verify-clean");
+        let logger = test_logger(&dir);
+        logger.append(make_event("ls")).unwrap();
+        logger.append(make_event("cat")).unwrap();
+        logger.append(make_event("echo")).unwrap();
+
+        let result = verify_chain(&verify_config(&dir)).unwrap();
+        assert_eq!(result.chain_entries, 3);
+        assert_eq!(result.legacy_entries, 0);
+        assert!(result.broken_at.is_none());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_tampered_chain() {
+        let dir = test_dir("verify-tamper");
+        let logger = test_logger(&dir);
+        logger.append(make_event("ls")).unwrap();
+        logger.append(make_event("rm")).unwrap();
+        logger.append(make_event("cat")).unwrap();
+
+        let path = dir.join("audit.jsonl");
+        let content = fs::read_to_string(&path).unwrap();
+        let tampered = content.replacen("\"passthrough\"", "\"blocked\"", 1);
+        fs::write(&path, tampered).unwrap();
+
+        let result = verify_chain(&verify_config(&dir)).unwrap();
+        assert!(result.broken_at.is_some());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_legacy_then_chain() {
+        let dir = test_dir("verify-legacy");
+        let logger = test_logger(&dir);
+
+        let path = dir.join("audit.jsonl");
+        let legacy = r#"{"timestamp":"2026-01-01T00:00:00Z","provider":"test","command":"old","rule_id":null,"action":"passthrough","result":"passthrough","target_count":0,"target_hash":"sha256:old"}"#;
+        fs::write(&path, format!("{legacy}\n{legacy}\n")).unwrap();
+
+        logger.append(make_event("new1")).unwrap();
+        logger.append(make_event("new2")).unwrap();
+
+        let result = verify_chain(&verify_config(&dir)).unwrap();
+        assert_eq!(result.chain_entries, 2);
+        assert_eq!(result.legacy_entries, 2);
+        assert!(result.broken_at.is_none());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_legacy_only() {
+        let dir = test_dir("verify-legacy-only");
+        test_logger(&dir); // create secret
+
+        let path = dir.join("audit.jsonl");
+        let legacy = r#"{"timestamp":"2026-01-01T00:00:00Z","provider":"test","command":"old","rule_id":null,"action":"passthrough","result":"passthrough","target_count":0,"target_hash":"sha256:old"}"#;
+        fs::write(&path, format!("{legacy}\n")).unwrap();
+
+        let result = verify_chain(&verify_config(&dir)).unwrap();
+        assert_eq!(result.chain_entries, 0);
+        assert_eq!(result.legacy_entries, 1);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_empty_file() {
+        let dir = test_dir("verify-empty");
+        test_logger(&dir); // create secret
+        fs::write(dir.join("audit.jsonl"), "").unwrap();
+
+        let result = verify_chain(&verify_config(&dir)).unwrap();
+        assert_eq!(result.chain_entries, 0);
+        assert_eq!(result.legacy_entries, 0);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_torn_line() {
+        let dir = test_dir("verify-torn");
+        let logger = test_logger(&dir);
+        logger.append(make_event("first")).unwrap();
+
+        let path = dir.join("audit.jsonl");
+        let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+        write!(f, "{{\"broken\":tru").unwrap();
+
+        logger.append(make_event("second")).unwrap();
+
+        let result = verify_chain(&verify_config(&dir)).unwrap();
+        assert_eq!(result.chain_entries, 2);
+        assert!(result.torn_lines > 0);
+        assert!(result.broken_at.is_none());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_no_secret() {
+        let dir = test_dir("verify-no-secret");
+        fs::write(dir.join("audit.jsonl"), "").unwrap();
+        // No secret file created
+        let result = verify_chain(&verify_config(&dir));
+        assert!(matches!(result, Err(AuditError::SecretUnavailable)));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_no_file() {
+        let dir = test_dir("verify-no-file");
+        test_logger(&dir); // create secret but no audit.jsonl
+
+        let result = verify_chain(&verify_config(&dir));
+        assert!(matches!(result, Err(AuditError::FileNotFound)));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // --- show_entries ---
+
+    #[test]
+    fn show_last_n() {
+        let dir = test_dir("show-last");
+        let logger = test_logger(&dir);
+        for i in 0..10 {
+            logger.append(make_event(&format!("cmd{i}"))).unwrap();
+        }
+
+        let opts = ShowOptions {
+            last: Some(3),
+            rule: None,
+            provider: None,
+            json: false,
+        };
+        let mut buf = Vec::new();
+        show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        // 1 header + 3 data lines
+        assert_eq!(
+            lines.len(),
+            4,
+            "expected header + 3 entries, got:\n{output}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn show_filter_rule() {
+        let dir = test_dir("show-filter-rule");
+        let logger = test_logger(&dir);
+
+        // Append events with different rules by manipulating directly
+        let mut e1 = make_event("rm");
+        e1.rule_id = Some("rm-recursive".to_string());
+        logger.append(e1).unwrap();
+
+        let mut e2 = make_event("git");
+        e2.rule_id = Some("git-push-force".to_string());
+        logger.append(e2).unwrap();
+
+        let mut e3 = make_event("rm");
+        e3.rule_id = Some("rm-recursive".to_string());
+        logger.append(e3).unwrap();
+
+        let opts = ShowOptions {
+            last: None,
+            rule: Some("rm".to_string()),
+            provider: None,
+            json: false,
+        };
+        let mut buf = Vec::new();
+        show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let data_lines = output.lines().skip(1).count(); // skip header
+        assert_eq!(data_lines, 2, "expected 2 rm entries");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn show_json_includes_chain_fields() {
+        let dir = test_dir("show-json");
+        let logger = test_logger(&dir);
+        logger.append(make_event("ls")).unwrap();
+
+        let opts = ShowOptions {
+            last: None,
+            rule: None,
+            provider: None,
+            json: true,
+        };
+        let mut buf = Vec::new();
+        show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert!(
+            parsed.get("entry_hash").is_some(),
+            "json should include entry_hash"
+        );
+        assert!(
+            parsed.get("chain_version").is_some(),
+            "json should include chain_version"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn show_table_hides_hashes() {
+        let dir = test_dir("show-hides");
+        let logger = test_logger(&dir);
+        logger.append(make_event("ls")).unwrap();
+
+        let opts = ShowOptions {
+            last: None,
+            rule: None,
+            provider: None,
+            json: false,
+        };
+        let mut buf = Vec::new();
+        show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            !output.contains("hmac-sha256:"),
+            "table should not show hashes"
+        );
+        assert!(
+            !output.contains("entry_hash"),
+            "table should not show entry_hash"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn show_empty_file() {
+        let dir = test_dir("show-empty");
+        test_logger(&dir);
+        fs::write(dir.join("audit.jsonl"), "").unwrap();
+
+        let opts = ShowOptions {
+            last: None,
+            rule: None,
+            provider: None,
+            json: false,
+        };
+        let mut buf = Vec::new();
+        show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
+        assert!(buf.is_empty());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // --- audit_summary ---
+
+    #[test]
+    fn summary_with_entries() {
+        let dir = test_dir("summary");
+        let logger = test_logger(&dir);
+        logger.append(make_event("ls")).unwrap();
+        logger.append(make_event("rm")).unwrap();
+
+        let summary = audit_summary(&verify_config(&dir));
+        assert!(summary.enabled);
+        assert_eq!(summary.entry_count, 2);
+        assert!(summary.secret_available);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn summary_disabled() {
+        let config = AuditConfig {
+            enabled: false,
+            path: None,
+        };
+        let summary = audit_summary(&config);
+        assert!(!summary.enabled);
+    }
+
+    // --- display_timestamp ---
+
+    #[test]
+    fn timestamp_truncation() {
+        assert_eq!(
+            display_timestamp("2026-04-04T03:31:02.54814Z"),
+            "2026-04-04T03:31:02Z"
+        );
+        assert_eq!(
+            display_timestamp("2026-04-04T03:31:02Z"),
+            "2026-04-04T03:31:02Z"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub fn run(args: &[OsString]) -> Result<i32, AppError> {
         Some("init") => run_init_command(args),
         Some("config") => run_config_command(args),
         Some("override") => run_override_command(args),
+        Some("audit") => run_audit_command(args),
         Some("status") => run_status_command(args),
         Some("cursor-hook") => run_cursor_hook(),
         Some("hook-check") => run_hook_check(args),
@@ -826,7 +827,9 @@ fn run_status_command(args: &[OsString]) -> Result<i32, AppError> {
     }
 
     // Detection engine summary (always displayed)
-    let rule_count = load_config(None)
+    let load_result = load_config(None).ok();
+    let rule_count = load_result
+        .as_ref()
         .map(|r| r.config.rules.iter().filter(|r| r.enabled).count())
         .unwrap_or(7);
     println!("Detection:");
@@ -842,6 +845,32 @@ fn run_status_command(args: &[OsString]) -> Result<i32, AppError> {
         "  {:<6} {:<36} Claude Code + Codex CLI + Cursor",
         "[info]", "Layer 2 coverage"
     );
+    {
+        let audit_config = load_result
+            .as_ref()
+            .map(|r| &r.config.audit)
+            .cloned()
+            .unwrap_or_default();
+        let summary = audit::audit_summary(&audit_config);
+        if !summary.enabled {
+            println!("  {:<6} {:<36} disabled", "[info]", "Layer 3 (audit)");
+        } else if summary.entry_count == 0 {
+            println!(
+                "  {:<6} {:<36} enabled (log created on first event)",
+                "[ok]", "Layer 3 (audit)"
+            );
+        } else if !summary.secret_available {
+            println!(
+                "  {:<6} {:<36} HMAC secret missing",
+                "[warn]", "Layer 3 (audit)"
+            );
+        } else {
+            println!(
+                "  {:<6} {:<36} {} entries (run 'omamori audit verify' to check chain)",
+                "[ok]", "Layer 3 (audit)", summary.entry_count
+            );
+        }
+    }
     println!();
 
     let exit_code = report.exit_code();
@@ -869,6 +898,157 @@ fn run_status_command(args: &[OsString]) -> Result<i32, AppError> {
 
     println!();
     Ok(exit_code)
+}
+
+// ---------------------------------------------------------------------------
+// Audit CLI
+// ---------------------------------------------------------------------------
+
+fn run_audit_command(args: &[OsString]) -> Result<i32, AppError> {
+    match args.get(2).and_then(|item| item.to_str()) {
+        Some("verify") => run_audit_verify(args),
+        Some("show") => run_audit_show(args),
+        Some(other) => Err(AppError::Usage(format!(
+            "unknown audit subcommand: {other}\n\n{}",
+            audit_usage()
+        ))),
+        None => {
+            eprintln!("{}", audit_usage());
+            Ok(0)
+        }
+    }
+}
+
+fn run_audit_verify(args: &[OsString]) -> Result<i32, AppError> {
+    let config_path = parse_config_flag(&args[3..])?;
+    let load_result = load_config(config_path.as_deref())?;
+
+    match audit::verify_chain(&load_result.config.audit) {
+        Ok(result) => {
+            if let Some(seq) = result.broken_at {
+                eprintln!("omamori audit verify: chain broken at entry #{seq}");
+                eprintln!("  The audit log may have been tampered with.");
+                eprintln!("  Inspect: omamori audit show --last 10");
+                Ok(1)
+            } else if result.chain_entries == 0 && result.legacy_entries > 0 {
+                eprintln!(
+                    "omamori audit verify: no chain entries found ({} legacy entries skipped)",
+                    result.legacy_entries
+                );
+                Ok(2)
+            } else if result.chain_entries == 0 {
+                println!("omamori audit verify: no entries to verify.");
+                Ok(0)
+            } else {
+                let mut msg = format!(
+                    "omamori audit verify: {} entries verified, chain intact.",
+                    result.chain_entries
+                );
+                if result.legacy_entries > 0 {
+                    msg.push_str(&format!(" ({} legacy skipped)", result.legacy_entries));
+                }
+                if result.torn_lines > 0 {
+                    msg.push_str(&format!(" ({} torn lines skipped)", result.torn_lines));
+                }
+                println!("{msg}");
+                Ok(0)
+            }
+        }
+        Err(audit::AuditError::SecretUnavailable) => {
+            eprintln!("omamori audit verify: cannot verify \u{2014} HMAC secret unavailable");
+            Ok(2)
+        }
+        Err(audit::AuditError::FileNotFound) => {
+            eprintln!("omamori audit verify: no audit log found");
+            Ok(2)
+        }
+        Err(audit::AuditError::Io(e)) => {
+            eprintln!("omamori audit verify: {e}");
+            Ok(2)
+        }
+    }
+}
+
+fn run_audit_show(args: &[OsString]) -> Result<i32, AppError> {
+    let mut opts = audit::ShowOptions {
+        last: Some(20),
+        rule: None,
+        provider: None,
+        json: false,
+    };
+
+    let mut index = 3usize;
+    while let Some(arg) = args.get(index).and_then(|item| item.to_str()) {
+        match arg {
+            "--last" => {
+                let value = args
+                    .get(index + 1)
+                    .and_then(|v| v.to_str())
+                    .ok_or_else(|| AppError::Usage("--last requires a number".to_string()))?;
+                opts.last =
+                    Some(value.parse::<usize>().map_err(|_| {
+                        AppError::Usage(format!("invalid number for --last: {value}"))
+                    })?);
+                index += 2;
+            }
+            "--all" => {
+                opts.last = None;
+                index += 1;
+            }
+            "--rule" => {
+                opts.rule = Some(
+                    args.get(index + 1)
+                        .and_then(|v| v.to_str())
+                        .ok_or_else(|| AppError::Usage("--rule requires a value".to_string()))?
+                        .to_string(),
+                );
+                index += 2;
+            }
+            "--provider" => {
+                opts.provider = Some(
+                    args.get(index + 1)
+                        .and_then(|v| v.to_str())
+                        .ok_or_else(|| AppError::Usage("--provider requires a value".to_string()))?
+                        .to_string(),
+                );
+                index += 2;
+            }
+            "--json" => {
+                opts.json = true;
+                index += 1;
+            }
+            other => {
+                return Err(AppError::Usage(format!(
+                    "unknown show flag: {other}\n\n{}",
+                    audit_usage()
+                )));
+            }
+        }
+    }
+
+    let load_result = load_config(None)?;
+    let mut stdout = std::io::stdout().lock();
+    match audit::show_entries(&load_result.config.audit, &opts, &mut stdout) {
+        Ok(()) => Ok(0),
+        Err(audit::AuditError::FileNotFound) => {
+            println!("omamori audit: no entries recorded yet");
+            Ok(0)
+        }
+        Err(e) => {
+            eprintln!("omamori audit show: {e}");
+            Ok(1)
+        }
+    }
+}
+
+fn audit_usage() -> &'static str {
+    "omamori audit — audit log commands
+
+  omamori audit verify                           Verify hash chain integrity
+  omamori audit show [--last N] [--json]         View recent audit entries (default: last 20)
+  omamori audit show --all                       View all entries
+  omamori audit show --rule <name>               Filter by rule (substring match)
+  omamori audit show --provider <name>           Filter by provider"
 }
 
 /// Cursor `beforeShellExecution` hook handler.
@@ -1663,6 +1843,8 @@ fn usage_text() -> &'static str {
   omamori config list
   omamori config disable <rule>
   omamori config enable <rule>
+  omamori audit verify                                    # Verify hash chain integrity
+  omamori audit show [--last N] [--json] [--all]          # View audit log entries
   omamori status [--refresh]                              # Health check all defense layers
   omamori override disable <rule>                        # Override a core safety rule
   omamori override enable <rule>                         # Restore a core safety rule


### PR DESCRIPTION
## Summary

- **`omamori audit verify`**: Hash chain verification with exit codes (0=intact, 1=broken, 2=error/missing)
  - Stream processing via `BufReader::lines()`, `flock_shared` for concurrent safety
  - Legacy entries skipped with warning, torn lines counted, 3-line recovery guidance on NG
  - Legacy-only log → exit 2 (no chain entries to verify)
- **`omamori audit show`**: Filtered log viewer
  - Default `--last 20` (matches `git log` convention), `--all` for full dump
  - `--rule`, `--provider` substring filters (AND logic)
  - `--json` outputs all fields including chain fields (for forensics/SIEM)
  - Human-readable 6-column table (no SEQ, no hashes)
- **`omamori status`**: Layer 3 (audit) line in Detection section
  - Entry count only — no full verify (Codex② ruling: avoid false "chain intact" on unverified data)
- **`omamori audit`** with no subcommand shows audit-specific help

### v0.7.1 PR 1 of 2

| PR | Scope | Status |
|----|-------|--------|
| **PR 1 (this)** | verify + show + status + dispatch | 🔄 |
| PR 2 | Docs (README, SECURITY.md, CHANGELOG) + version bump | Planned |

### Test results

- 387 tests (+16 new), 0 failed
- `cargo fmt` + `cargo clippy` clean

## Test plan

- [ ] `cargo test` — all 387 pass
- [ ] `omamori audit verify` on real audit.jsonl → exit 0 + "chain intact"
- [ ] `omamori audit show` → last 20 entries in table format
- [ ] `omamori audit show --json` → JSONL with chain fields
- [ ] `omamori audit show --rule rm` → filtered entries
- [ ] `omamori status` → Layer 3 line in Detection section
- [ ] `omamori audit` (no subcommand) → audit-specific help

🤖 Generated with [Claude Code](https://claude.com/claude-code)