### PR TITLE
docs: v0.7.1 release — audit CLI (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.7.1] - 2026-04-05
+
+### Added
+
+- **`omamori audit verify`** (#29): Verify hash chain integrity of the audit log. Stream processing with `flock_shared` for concurrent safety. Exit codes: 0=intact, 1=broken, 2=error/missing. Legacy entries skipped with warning; legacy-only logs return exit 2 (no chain entries to verify). 3-line recovery guidance on chain break.
+- **`omamori audit show`** (#29): View audit log entries with filters. Defaults to `--last 20` (matches `git log` convention). Supports `--all`, `--rule <name>`, `--provider <name>` (substring match), `--json` (full JSONL including chain fields for forensics). Human-readable table: 6 columns (no SEQ, no hashes).
+- **`omamori status` Layer 3**: Detection section now shows audit status (entry count + verify prompt). Does not run full verification — avoids false "chain intact" on unverified data.
+- **`omamori audit` help**: Running `omamori audit` with no subcommand shows audit-specific usage.
+
 ## [0.7.0] - 2026-04-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ omamori test [--config PATH]             # Verify policy rules
 omamori status [--refresh]               # Health check all defense layers
 omamori exec [--config PATH] -- CMD      # Run command through policy engine
 
+omamori audit verify                     # Verify hash chain integrity (exit 0/1/2)
+omamori audit show [--last N] [--json]   # View recent audit entries (default: last 20)
+omamori audit show --all                 # View all entries
+omamori audit show --rule <name>         # Filter by rule (substring match)
+omamori audit show --provider <name>     # Filter by provider
+
 omamori config list                      # Show rules with status
 omamori config disable <rule>            # Disable a rule
 omamori config enable <rule>             # Re-enable a rule

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -390,4 +390,18 @@ If the secret file is deleted or unreadable:
 
 ### Legacy Compatibility
 
-Entries written before v0.7.0 lack chain fields. When `append()` encounters a legacy last entry (no `chain_version`), it starts a new chain from genesis (`seq=0`). `omamori audit verify` (v0.7.1) will skip legacy entries with a warning.
+Entries written before v0.7.0 lack chain fields. When `append()` encounters a legacy last entry (no `chain_version`), it starts a new chain from genesis (`seq=0`). `omamori audit verify` skips legacy entries with a warning. A log containing only legacy entries returns exit code 2 (no chain entries to verify).
+
+### Verify Information Disclosure Policy (v0.7.1+)
+
+`omamori audit verify` is designed to be useful to the user while limiting information useful to an attacker:
+
+| Information | Disclosed | Rationale |
+|-------------|-----------|-----------|
+| Entry count | Yes | Non-sensitive; needed for user to assess log completeness |
+| Broken entry position (seq #) | Yes | Needed for investigation; without HMAC secret, position alone cannot repair chain |
+| Expected hash value | **No** | Would allow targeted forgery if secret is also compromised |
+| HMAC secret file path | **No** | Reduces attack surface; path is derivable from code but not explicitly provided |
+| Chain structure (prev_hash linkage) | Via `--json` only | Machine consumers need full provenance for forensics/SIEM. HMAC protection means chain fields cannot be forged without secret |
+
+**Recommendation**: Run `omamori audit verify` directly in a terminal, not through an AI agent. AI agents can read stdout and may misrepresent results to the user.


### PR DESCRIPTION
## Summary

- **README.md**: Add `audit verify` + `audit show` to CLI Reference section
- **SECURITY.md**: Add verify information disclosure policy table (what is/isn't shown to users)
- **CHANGELOG.md**: v0.7.1 entry
- **Cargo.toml**: version bump 0.7.0 → 0.7.1

### v0.7.1 PR 2 of 2

| PR | Scope | Status |
|----|-------|--------|
| PR 1 (#91) | verify + show + status + dispatch | ✅ Merged |
| **PR 2 (this)** | Docs + version bump → Release v0.7.1 | 🔄 |

## Test plan
- [ ] `cargo test` — all 387 pass
- [ ] `omamori --version` shows 0.7.1
- [ ] README CLI Reference renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)