### PR TITLE
docs: v0.7.2 release — audit retention (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.7.2] - 2026-04-05
+
+### Added
+
+- **Audit retention + auto prune** (#29): Optional `retention_days` config prunes old audit entries while preserving tamper-evident chain integrity.
+  - `retention_days` in `[audit]` section (default 0 = unlimited). Minimum 7 days enforced; values below are clamped with warning.
+  - Auto-prune triggers every 1000 appends (`seq % 1000`) under flock. Zero overhead when not triggered.
+  - **prune_point**: HMAC-protected chain entry inserted at the head of the pruned log. `prev_hash` = prune genesis (distinct from chain genesis), `target_hash` = HMAC binding to the first retained entry.
+  - **verify_chain**: Recognizes prune_point, validates prune genesis anchor, verifies target_hash binding (detects post-prune deletion). Reports pruned count.
+  - **show**: prune_point displayed as separator (`--- pruned N entries before YYYY-MM-DD ---`).
+  - **status**: Shows retention info (`retention: Nd`) when configured.
+  - Minimum retain 1000 entries regardless of age.
+  - `omamori/config.toml` added to `blocked_command_patterns` to prevent AI agents from editing retention settings.
+
 ## [0.7.1] - 2026-04-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Available for Claude Code, Cursor, and Codex CLI.
 **Layer 3 — Audit** (v0.7.0+): Records every command decision in a tamper-evident log — if an AI agent modifies any entry, the chain breaks and tampering is detected.
 - HMAC-SHA256 signed and hash-chained JSONL (`~/.local/share/omamori/audit.jsonl`)
 - Per-install secret; file paths HMAC-hashed (never stored in plaintext)
-- Enabled by default; no configuration needed
+- Auto-retention (v0.7.2+): set `retention_days` in config to automatically prune old entries — chain integrity is preserved across pruning
+- Logging enabled by default; retention is opt-in via config
 
 **Self-defense** ([#22](https://github.com/yottayoshida/omamori/issues/22)): AI agents cannot `config disable`, `uninstall`, or edit `config.toml` while detected. Hooks block env var unsetting, config modification, and audit log/secret access via shell commands. This is a key differentiator from other CLI guards — omamori assumes adversarial AI behavior and defends against it.
 
@@ -172,6 +173,12 @@ match_any = ["-r", "-rf", "-fr", "--recursive"]
 name = "rm-recursive-to-trash"
 action = "move-to"
 destination = "/tmp/omamori-quarantine/"
+```
+
+**Enable audit retention** (prunes entries older than N days):
+```toml
+[audit]
+retention_days = 90  # 0 = keep all (default). Minimum 7 days.
 ```
 
 **Notes**: Config requires `chmod 600`. Destinations must be absolute paths on the same volume. System directories and symlinks are rejected.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 `omamori` is a PATH-shim safeguard for AI-triggered shell commands. It reduces risk for a narrow set of destructive commands, but it is not a sandbox and it does not claim complete mediation.
 
-## What It Protects (v0.7.0)
+## What It Protects (v0.7.2)
 
 - recursive `rm` variants matched by the default rules
 - `git reset --hard`
@@ -386,7 +386,42 @@ If the secret file is deleted or unreadable:
 - `load_or_create_secret()` attempts to generate a new secret
 - If generation also fails, entries are written with `NO_HMAC_SECRET` marker
 - `omamori audit verify` (v0.7.1) will flag these entries
-- A `strict` mode (v0.7.2) will allow users to block commands when the secret is unavailable
+- A `strict` mode (v0.7.3) will allow users to block commands when the secret is unavailable
+
+### Audit Retention (v0.7.2+)
+
+Optional automatic pruning of old audit entries. Preserves the tamper-evident property through a cryptographic prune_point.
+
+**Configuration** (`~/.config/omamori/config.toml`):
+```toml
+[audit]
+retention_days = 90  # 0 = unlimited (default)
+```
+
+**Security properties**:
+
+| Property | Mechanism |
+|----------|-----------|
+| Prune_point authenticity | `entry_hash` = HMAC-SHA256 over all fields (secret required to forge) |
+| Prune_point anchoring | `prev_hash` = HMAC(secret, "omamori-prune-v1") — distinct from chain genesis |
+| First-retained binding | `target_hash` = HMAC(secret, "prune-bind:{count}:{first_retained_entry_hash}") |
+| Minimum retention | 7 days enforced (values < 7 clamped with warning) |
+| Minimum entry count | 1000 entries always retained regardless of age |
+| Config protection | `omamori/config.toml` added to `blocked_command_patterns` |
+| Trigger frequency | Every 1000 appends (seq % 1000); zero overhead otherwise |
+
+**Threat model**:
+
+| Attack | Defense |
+|--------|---------|
+| Forge prune_point to hide evidence | entry_hash HMAC verification fails without secret |
+| Delete entries after legitimate prune | target_hash binding mismatch detected by verify |
+| Set retention_days=1 to fast-erase | Clamped to min 7; config.toml blocked from AI editing |
+| Truncate file (remove prune_point + entries) | prev_hash ≠ genesis → chain broken |
+
+**Verification**: `omamori audit verify` detects pruned chains and reports: `N entries verified, chain intact. (M entries pruned; prune_point anchored)`.
+
+**Design decision**: In-place rewrite (not tmpfile→rename). Rationale: rename changes the inode, which breaks flock for any other process holding the old inode. Prune is best-effort under flock; crash during rewrite produces torn lines handled by existing recovery.
 
 ### Legacy Compatibility
 

--- a/config.default.toml
+++ b/config.default.toml
@@ -119,3 +119,4 @@ message = "omamori blocked rsync with destructive flags"
 
 [audit]
 enabled = false
+# retention_days = 90  # 0 = unlimited (default). Minimum 7 days.


### PR DESCRIPTION
## Summary
- README: Layer 3 retention description (UX Designer reviewed), config example in Configuration section
- SECURITY.md: retention threat model, prune_point security properties, design decisions
- CHANGELOG: v0.7.2 entry with full feature description
- Cargo.toml: version bump 0.7.1 → 0.7.2
- config.default.toml: `retention_days` comment added

## UX review applied
- `cryptographic prune_point` removed from README (internal detail → SECURITY.md)
- Rewritten to user perspective: "set `retention_days` in config to automatically prune old entries"
- Config example added to Configuration `<details>` section
- "Enabled by default" → "Logging enabled by default; retention is opt-in via config"

## Test plan
- [x] `cargo test` — 404 tests pass
- [x] No code changes — docs + version bump only

🤖 Generated with [Claude Code](https://claude.com/claude-code)