### PR TITLE
security: fail-close on malformed hook input (#111)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1273,10 +1273,15 @@ fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
         HookInput::MalformedJson => {
             eprintln!("omamori hook: blocked — hook input is not valid JSON");
             eprintln!("  The command was denied because omamori cannot verify its safety.");
-            eprintln!("  This may happen after an AI tool update. Try: upgrade omamori, or report at https://github.com/yottayoshida/omamori/issues");
+            eprintln!(
+                "  This may happen after an AI tool update. Try: upgrade omamori, or report at https://github.com/yottayoshida/omamori/issues"
+            );
             if verbose {
                 eprintln!("  provider: {provider}");
-                eprintln!("  raw input (first 200 chars): {}", truncate_for_log(&input, 200));
+                eprintln!(
+                    "  raw input (first 200 chars): {}",
+                    truncate_for_log(&input, 200)
+                );
             }
             Ok(2)
         }
@@ -1286,7 +1291,10 @@ fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
             eprintln!("  Expected: tool_input.command or tool_input.file_path");
             if verbose {
                 eprintln!("  provider: {provider}");
-                eprintln!("  raw input (first 200 chars): {}", truncate_for_log(&input, 200));
+                eprintln!(
+                    "  raw input (first 200 chars): {}",
+                    truncate_for_log(&input, 200)
+                );
             }
             Ok(2)
         }
@@ -1385,10 +1393,8 @@ enum HookInput {
 
     /// `tool_input.file_path` present — file operation (Edit/Write/MultiEdit).
     /// Protected-path checking is implemented in PR2 (#110); until then, allow.
-    FileOp {
-        tool: String,
-        path: String,
-    },
+    #[expect(dead_code, reason = "fields used in PR2 (#110) file_path guard")]
+    FileOp { tool: String, path: String },
 
     /// Valid JSON with a `tool_name` but neither `command` nor `file_path`.
     /// Allow for forward compatibility with future platform tool types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1258,27 +1258,64 @@ fn format_unwrap_chain(original: &str, invocation: &CommandInvocation) -> Option
 // ---------------------------------------------------------------------------
 
 /// `omamori hook-check [--provider NAME]`
-/// Reads command string from stdin, checks against meta-patterns + unwrap stack + rules.
+/// Reads PreToolUse JSON from stdin, classifies via `HookInput`, then evaluates.
 /// Exit 0 = allow, exit 2 = block.
 fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
     use std::io::Read;
 
     let provider = parse_provider_flag(args);
+    let verbose = std::env::var("OMAMORI_VERBOSE").is_ok();
 
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
 
-    // Claude Code sends JSON with tool_input.command; extract it
-    let command = extract_command_from_hook_input(&input);
-
-    if command.is_empty() {
-        print_hook_check_allow_response("omamori: empty command");
-        return Ok(0);
+    match extract_hook_input(&input) {
+        HookInput::MalformedJson => {
+            eprintln!("omamori hook: blocked — hook input is not valid JSON");
+            eprintln!("  The command was denied because omamori cannot verify its safety.");
+            eprintln!("  This may happen after an AI tool update. Try: upgrade omamori, or report at https://github.com/yottayoshida/omamori/issues");
+            if verbose {
+                eprintln!("  provider: {provider}");
+                eprintln!("  raw input (first 200 chars): {}", truncate_for_log(&input, 200));
+            }
+            Ok(2)
+        }
+        HookInput::MalformedMissingField => {
+            eprintln!("omamori hook: blocked — required fields missing from hook input");
+            eprintln!("  The command was denied because omamori cannot verify its safety.");
+            eprintln!("  Expected: tool_input.command or tool_input.file_path");
+            if verbose {
+                eprintln!("  provider: {provider}");
+                eprintln!("  raw input (first 200 chars): {}", truncate_for_log(&input, 200));
+            }
+            Ok(2)
+        }
+        HookInput::UnknownTool(tool_name) => {
+            print_hook_check_allow_response(&format!(
+                "omamori: unrecognized tool '{tool_name}' — allowed for forward compatibility"
+            ));
+            Ok(0)
+        }
+        HookInput::FileOp { .. } => {
+            // PR2 (#110) will add protected-path checking here.
+            // Until then, allow all file operations to avoid false positives.
+            print_hook_check_allow_response("omamori: file operation — not yet inspected");
+            Ok(0)
+        }
+        HookInput::Command(command) => {
+            if command.is_empty() {
+                print_hook_check_allow_response("omamori: empty command");
+                return Ok(0);
+            }
+            run_hook_check_command(&command, &provider, verbose)
+        }
     }
+}
 
-    let verbose = std::env::var("OMAMORI_VERBOSE").is_ok();
-
-    match check_command_for_hook(&command) {
+/// Evaluate a shell command through the two-phase hook check pipeline.
+/// Extracted from `run_hook_check` to keep the match arms concise.
+fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Result<i32, AppError> {
+    match check_command_for_hook(command) {
         HookCheckResult::Allow => {
             print_hook_check_allow_response("omamori: no dangerous pattern detected");
             Ok(0)
@@ -1325,25 +1362,117 @@ fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
     }
 }
 
-/// Extract the command string from Claude Code's PreToolUse hook JSON input.
-/// Falls back to treating the entire input as the command if JSON parsing fails.
-fn extract_command_from_hook_input(input: &str) -> String {
-    // Claude Code PreToolUse sends: { "tool_name": "Bash", "tool_input": { "command": "..." } }
-    if let Ok(v) = serde_json::from_str::<serde_json::Value>(input) {
-        if let Some(cmd) = v
-            .get("tool_input")
-            .and_then(|ti| ti.get("command"))
-            .and_then(|c| c.as_str())
-        {
-            return cmd.to_string();
-        }
-        // Cursor format: { "command": "..." }
-        if let Some(cmd) = v.get("command").and_then(|c| c.as_str()) {
-            return cmd.to_string();
-        }
+/// Truncate a string for log output, avoiding panic on multi-byte boundaries.
+fn truncate_for_log(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
     }
-    // Fallback: treat raw input as command
-    input.trim().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// HookInput: typed representation of PreToolUse hook stdin
+// ---------------------------------------------------------------------------
+
+/// Parsed hook input from AI tool platforms (Claude Code, Codex CLI, etc.).
+///
+/// Fail-close design: anything that cannot be positively identified as a known
+/// tool invocation is treated as malformed and blocked.
+enum HookInput {
+    /// `tool_input.command` present — shell command to evaluate.
+    /// Covers tool_name = "Bash", "Shell", or any tool that carries a command field.
+    Command(String),
+
+    /// `tool_input.file_path` present — file operation (Edit/Write/MultiEdit).
+    /// Protected-path checking is implemented in PR2 (#110); until then, allow.
+    FileOp {
+        tool: String,
+        path: String,
+    },
+
+    /// Valid JSON with a `tool_name` but neither `command` nor `file_path`.
+    /// Allow for forward compatibility with future platform tool types.
+    UnknownTool(String),
+
+    /// JSON parse failed entirely (invalid syntax, non-UTF8, etc.).
+    MalformedJson,
+
+    /// JSON parsed but required structure is missing (no `tool_input`, etc.).
+    MalformedMissingField,
+}
+
+/// Parse PreToolUse hook stdin into a typed `HookInput`.
+///
+/// Classification priority:
+///   1. JSON parse failure → `MalformedJson`
+///   2. `tool_input.command` (string) → `Command`
+///   3. top-level `command` (Cursor compat) → `Command`
+///   4. `tool_input.file_path` (string) → `FileOp`
+///   5. `tool_name` present → `UnknownTool`
+///   6. nothing recognizable → `MalformedMissingField`
+fn extract_hook_input(input: &str) -> HookInput {
+    let v = match serde_json::from_str::<serde_json::Value>(input) {
+        Ok(v) => v,
+        Err(_) => return HookInput::MalformedJson,
+    };
+
+    let tool_input = v.get("tool_input");
+
+    // Priority 1: tool_input.command (Claude Code / Codex CLI format)
+    if let Some(cmd_val) = tool_input.and_then(|ti| ti.get("command")) {
+        // Key exists — value MUST be a string. null/number/array = malformed.
+        return match cmd_val.as_str() {
+            Some(cmd) => HookInput::Command(cmd.to_string()),
+            None => HookInput::MalformedMissingField,
+        };
+    }
+
+    // Priority 2: top-level command (Cursor beforeShellExecution compat)
+    if let Some(cmd_val) = v.get("command") {
+        return match cmd_val.as_str() {
+            Some(cmd) => HookInput::Command(cmd.to_string()),
+            None => HookInput::MalformedMissingField,
+        };
+    }
+
+    // Priority 3: tool_input.file_path (Edit/Write/MultiEdit)
+    if let Some(path_val) = tool_input.and_then(|ti| ti.get("file_path")) {
+        return match path_val.as_str() {
+            Some(path) => {
+                let tool = v
+                    .get("tool_name")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                HookInput::FileOp {
+                    tool,
+                    path: path.to_string(),
+                }
+            }
+            None => HookInput::MalformedMissingField,
+        };
+    }
+
+    // Priority 4: tool_input exists but has no command/file_path
+    if let Some(ti) = tool_input {
+        // Empty tool_input or non-object = malformed (e.g. {"tool_name":"Bash","tool_input":{}})
+        if ti.as_object().is_none_or(|obj| obj.is_empty()) {
+            return HookInput::MalformedMissingField;
+        }
+        // Non-empty tool_input with unrecognized fields = future tool type
+        if let Some(name) = v.get("tool_name").and_then(|t| t.as_str()) {
+            return HookInput::UnknownTool(name.to_string());
+        }
+        return HookInput::MalformedMissingField;
+    }
+
+    // Priority 5: no tool_input at all — tool_name alone = future tool type
+    if let Some(name) = v.get("tool_name").and_then(|t| t.as_str()) {
+        return HookInput::UnknownTool(name.to_string());
+    }
+
+    // Nothing recognizable
+    HookInput::MalformedMissingField
 }
 
 /// Parse --provider flag from args. Defaults to "unknown".

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1074,24 +1074,160 @@ fn hook_check_verbose_does_not_pollute_stdout() {
     );
 }
 
-/// V-010: Malformed (non-JSON) input still returns ALLOW JSON
+/// #111: Malformed (non-JSON) input is BLOCKED (fail-close).
+/// Supersedes old V-010 which expected ALLOW — that was the fail-open vulnerability.
 #[test]
-fn hook_check_malformed_input_returns_allow_json() {
-    let (stdout, _, exit_code) = run_hook_check("this is not json at all");
-    assert_eq!(exit_code, 0);
+fn hook_check_malformed_input_blocks_with_exit_2() {
+    let (stdout, stderr, exit_code) = run_hook_check("this is not json at all");
+    assert_eq!(exit_code, 2, "malformed input must be blocked (fail-close)");
+    assert!(
+        stdout.trim().is_empty(),
+        "BLOCK stdout must be empty (exit 2)"
+    );
+    assert!(
+        stderr.contains("not valid JSON"),
+        "stderr must explain the parse failure"
+    );
+}
+
+/// #111: Completely empty stdin is BLOCKED (fail-close).
+/// Empty string is not valid JSON, so it triggers MalformedJson.
+#[test]
+fn hook_check_empty_stdin_blocks_with_exit_2() {
+    let (stdout, stderr, exit_code) = run_hook_check("");
+    assert_eq!(exit_code, 2, "empty stdin must be blocked (fail-close)");
+    assert!(
+        stdout.trim().is_empty(),
+        "BLOCK stdout must be empty (exit 2)"
+    );
+    assert!(
+        stderr.contains("not valid JSON"),
+        "stderr must explain the parse failure"
+    );
+}
+
+/// #111: JSON array (not an object) is BLOCKED — missing required fields.
+#[test]
+fn hook_check_json_array_blocks() {
+    let (_, _, exit_code) = run_hook_check("[1, 2, 3]");
+    assert_eq!(exit_code, 2, "JSON array must be blocked (no tool_input)");
+}
+
+/// #111: Valid JSON object but no tool_input and no command → MalformedMissingField.
+#[test]
+fn hook_check_json_no_tool_input_blocks() {
+    let input = serde_json::json!({"unrelated": "data"}).to_string();
+    let (_, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "JSON without tool_input must be blocked");
+    assert!(stderr.contains("required fields missing"));
+}
+
+/// #111: tool_input exists but command is null → MalformedMissingField.
+#[test]
+fn hook_check_null_command_blocks() {
+    let input = serde_json::json!({
+        "tool_name": "Bash",
+        "tool_input": { "command": null }
+    })
+    .to_string();
+    let (_, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "null command must be blocked");
+    assert!(stderr.contains("required fields missing"));
+}
+
+/// #111: tool_input.command is a number (not string) → falls through to MalformedMissingField.
+#[test]
+fn hook_check_non_string_command_blocks() {
+    let input = serde_json::json!({
+        "tool_name": "Bash",
+        "tool_input": { "command": 42 }
+    })
+    .to_string();
+    let (_, _, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "non-string command must be blocked");
+}
+
+/// #111: Unknown tool_name with non-empty tool_input (no command/file_path) → allowed.
+/// Forward compatibility: future tools may have different field names.
+#[test]
+fn hook_check_unknown_tool_with_payload_allowed() {
+    let input = serde_json::json!({
+        "tool_name": "FutureTool2027",
+        "tool_input": { "query": "search term", "options": {} }
+    })
+    .to_string();
+    let (stdout, _, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 0, "unknown tool with payload must be allowed");
     let parsed: serde_json::Value =
-        serde_json::from_str(stdout.trim()).expect("malformed input must still return valid JSON");
+        serde_json::from_str(stdout.trim()).expect("must return valid JSON");
     assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "allow");
 }
 
-/// V-006 variant: Completely empty stdin returns ALLOW JSON
+/// #111: Known tool_name with empty tool_input → blocked (malformed).
+/// e.g. {"tool_name":"Bash","tool_input":{}} — Bash must have command field.
 #[test]
-fn hook_check_empty_stdin_returns_allow_json() {
-    let (stdout, _, exit_code) = run_hook_check("");
-    assert_eq!(exit_code, 0);
+fn hook_check_known_tool_empty_tool_input_blocks() {
+    let input = serde_json::json!({
+        "tool_name": "Bash",
+        "tool_input": {}
+    })
+    .to_string();
+    let (_, _, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "empty tool_input must be blocked");
+}
+
+/// #111: tool_name only (no tool_input) → allowed (minimal future tool).
+#[test]
+fn hook_check_tool_name_only_allowed() {
+    let input = serde_json::json!({
+        "tool_name": "FutureTool2027"
+    })
+    .to_string();
+    let (stdout, _, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 0, "tool_name-only must be allowed");
     let parsed: serde_json::Value =
-        serde_json::from_str(stdout.trim()).expect("empty stdin must return valid JSON");
+        serde_json::from_str(stdout.trim()).expect("must return valid JSON");
     assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "allow");
+}
+
+/// #111: Edit tool with file_path → allowed (PR2 will add path guard).
+#[test]
+fn hook_check_edit_file_op_allowed_pending_pr2() {
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": { "file_path": "/tmp/test.txt", "old_string": "a", "new_string": "b" }
+    })
+    .to_string();
+    let (stdout, _, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 0, "Edit file op must be allowed until PR2");
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("must return valid JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "allow");
+}
+
+/// #111: VERBOSE mode includes raw input in stderr for malformed input.
+#[test]
+fn hook_check_malformed_verbose_shows_raw_input() {
+    let mut child = Command::new(binary())
+        .args(["hook-check", "--provider", "claude-code"])
+        .env("OMAMORI_VERBOSE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn hook-check");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"broken json {{{")
+        .unwrap();
+
+    let output = child.wait_with_output().expect("failed to wait");
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr.contains("raw input"), "verbose must show raw input");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace fail-open raw-string fallback with typed `HookInput` enum
- Malformed JSON, missing fields, wrong types → `exit 2` (block) instead of silent pass-through
- 3-layer error messages (what happened / current state / what to do) for all deny paths
- `FileOp` variant prepared for PR2 (#110) file_path guard

## HookInput Classification

| Input | Variant | Result |
|-------|---------|--------|
| Valid JSON, `tool_input.command` is string | `Command` | Evaluate via rule engine |
| Valid JSON, `tool_input.file_path` is string | `FileOp` | Allow (PR2 adds guard) |
| Valid JSON, unknown tool with payload | `UnknownTool` | Allow (forward compat) |
| Invalid JSON / empty stdin | `MalformedJson` | **Block** |
| Missing required fields / wrong types | `MalformedMissingField` | **Block** |
| Empty `tool_input` (`{}`) | `MalformedMissingField` | **Block** |

## Test Changes

- 427 → 436 tests (+11 new, −2 replaced)
- Old `hook_check_malformed_input_returns_allow_json` → `hook_check_malformed_input_blocks_with_exit_2`
- Old `hook_check_empty_stdin_returns_allow_json` → `hook_check_empty_stdin_blocks_with_exit_2`

## Test plan

- [x] All 436 tests pass (`cargo test`)
- [x] Malformed JSON → exit 2 with 3-layer stderr message
- [x] Empty stdin → exit 2
- [x] null/number command → exit 2
- [x] Empty tool_input `{}` → exit 2
- [x] Unknown tool with payload → exit 0 (forward compat)
- [x] tool_name only (no tool_input) → exit 0
- [x] Edit with file_path → exit 0 (pending PR2)
- [x] Normal Bash command → unchanged behavior
- [x] VERBOSE mode shows raw input on malformed
- [x] Existing meta-pattern / rule / structural tests unaffected

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)