### PR TITLE
security: Edit/Write file_path guard for protected files (#110)

### DIFF
--- a/src/installer.rs
+++ b/src/installer.rs
@@ -451,6 +451,36 @@ pub fn blocked_command_patterns() -> Vec<(&'static str, &'static str)> {
             "blocked attempt to unset a detector env var",
         ),
         ("AI_GUARD=", "blocked attempt to unset a detector env var"),
+        // export -n detection — unexport detector env vars (#110 S2)
+        (
+            "export -n CLAUDECODE",
+            "blocked attempt to unexport detector env var",
+        ),
+        (
+            "export -n CODEX_CI",
+            "blocked attempt to unexport detector env var",
+        ),
+        (
+            "export -n CURSOR_AGENT",
+            "blocked attempt to unexport detector env var",
+        ),
+        (
+            "export -n GEMINI_CLI",
+            "blocked attempt to unexport detector env var",
+        ),
+        (
+            "export -n CLINE_ACTIVE",
+            "blocked attempt to unexport detector env var",
+        ),
+        (
+            "export -n AI_GUARD",
+            "blocked attempt to unexport detector env var",
+        ),
+        // Claude Code hook registration protection (#110 T3)
+        (
+            ".claude/settings.json",
+            "blocked attempt to edit Claude Code settings (contains hook config)",
+        ),
         // Config modification protection (#22)
         ("config disable", "blocked attempt to modify omamori rules"),
         ("config enable", "blocked attempt to modify omamori rules"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1432,15 +1432,12 @@ fn is_protected_file_path(path: &str) -> Option<&'static str> {
         Err(_) => {
             // Full path doesn't exist — try canonicalizing the parent directory.
             // This catches symlinked parents: /tmp/alias/newfile where /tmp/alias → protected dir
-            let mut resolved_via_parent = Vec::new();
-            if let Some(parent) = lexical.parent() {
-                if let Ok(canonical_parent) = std::fs::canonicalize(parent) {
-                    if let Some(filename) = lexical.file_name() {
-                        resolved_via_parent.push(canonical_parent.join(filename));
-                    }
-                }
-            }
-            resolved_via_parent
+            lexical
+                .parent()
+                .and_then(|p| std::fs::canonicalize(p).ok())
+                .and_then(|cp| lexical.file_name().map(|f| cp.join(f)))
+                .into_iter()
+                .collect()
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1304,11 +1304,25 @@ fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
             ));
             Ok(0)
         }
-        HookInput::FileOp { .. } => {
-            // PR2 (#110) will add protected-path checking here.
-            // Until then, allow all file operations to avoid false positives.
-            print_hook_check_allow_response("omamori: file operation — not yet inspected");
-            Ok(0)
+        HookInput::FileOp { tool, path } => {
+            if let Some(reason) = is_protected_file_path(&path) {
+                eprintln!("omamori hook: blocked {tool} to protected file — {reason}");
+                eprintln!("  AI agents cannot modify omamori configuration or security files.");
+                eprintln!(
+                    "  To edit config: use `omamori config` CLI or edit the file directly in your terminal."
+                );
+                if verbose {
+                    eprintln!("  provider: {provider}");
+                    eprintln!("  tool: {tool}");
+                    eprintln!("  path: {path}");
+                }
+                Ok(2)
+            } else {
+                print_hook_check_allow_response(&format!(
+                    "omamori: {tool} to non-protected path — allowed"
+                ));
+                Ok(0)
+            }
         }
         HookInput::Command(command) => {
             if command.is_empty() {
@@ -1379,6 +1393,75 @@ fn truncate_for_log(s: &str, max_chars: usize) -> &str {
 }
 
 // ---------------------------------------------------------------------------
+// File path protection for Edit/Write/MultiEdit (#110)
+// ---------------------------------------------------------------------------
+
+/// Patterns that identify omamori's own files and external hook registrations.
+/// Substring match against the canonicalized (or lexically normalized) path.
+/// Intentionally broad: "audit-secret" matches "audit-secret.1.retired" too.
+const PROTECTED_FILE_PATTERNS: &[(&str, &str)] = &[
+    ("omamori/config.toml", "omamori config"),
+    (".integrity.json", "integrity baseline"),
+    ("audit-secret", "audit HMAC secret"),
+    ("audit.jsonl", "audit log"),
+    (".local/share/omamori", "omamori data directory"),
+    ("claude-pretooluse.sh", "omamori hook script"),
+    ("codex-pretooluse.sh", "omamori Codex hook script"),
+    (".codex/hooks.json", "Codex hooks config"),
+    (".codex/config.toml", "Codex config"),
+    // Claude Code hook registration — AI removing hooks = full bypass (#110 T3)
+    (
+        ".claude/settings.json",
+        "Claude Code settings (contains hook config)",
+    ),
+];
+
+/// Check whether a file path targets a protected omamori file.
+///
+/// Resolution strategy (defense-in-depth per Codex review):
+///   1. Try `canonicalize()` to resolve symlinks for existing paths
+///   2. For non-existent paths, canonicalize the parent directory
+///   3. Fall back to lexical normalization (`context::normalize_path`)
+///   4. If canonicalize fails AND lexical path matches → fail-close (block)
+fn is_protected_file_path(path: &str) -> Option<&'static str> {
+    let lexical = context::normalize_path(path);
+
+    // Try full canonicalize first (resolves symlinks for existing paths)
+    let candidates: Vec<std::path::PathBuf> = match std::fs::canonicalize(&lexical) {
+        Ok(canonical) => vec![canonical],
+        Err(_) => {
+            // Full path doesn't exist — try canonicalizing the parent directory.
+            // This catches symlinked parents: /tmp/alias/newfile where /tmp/alias → protected dir
+            let mut resolved_via_parent = Vec::new();
+            if let Some(parent) = lexical.parent() {
+                if let Ok(canonical_parent) = std::fs::canonicalize(parent) {
+                    if let Some(filename) = lexical.file_name() {
+                        resolved_via_parent.push(canonical_parent.join(filename));
+                    }
+                }
+            }
+            resolved_via_parent
+        }
+    };
+
+    // Check all resolved candidates + the lexical path itself
+    let lexical_str = lexical.to_string_lossy();
+    for &(pattern, reason) in PROTECTED_FILE_PATTERNS {
+        // Lexical match always checked (fail-close: even if canonicalize failed)
+        if lexical_str.contains(pattern) {
+            return Some(reason);
+        }
+        // Canonical/parent-resolved matches
+        for candidate in &candidates {
+            if candidate.to_string_lossy().contains(pattern) {
+                return Some(reason);
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
 // HookInput: typed representation of PreToolUse hook stdin
 // ---------------------------------------------------------------------------
 
@@ -1392,8 +1475,7 @@ enum HookInput {
     Command(String),
 
     /// `tool_input.file_path` present — file operation (Edit/Write/MultiEdit).
-    /// Protected-path checking is implemented in PR2 (#110); until then, allow.
-    #[expect(dead_code, reason = "fields used in PR2 (#110) file_path guard")]
+    /// Protected-path checking via `is_protected_file_path()`.
     FileOp { tool: String, path: String },
 
     /// Valid JSON with a `tool_name` but neither `command` nor `file_path`.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1190,19 +1190,269 @@ fn hook_check_tool_name_only_allowed() {
     assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "allow");
 }
 
-/// #111: Edit tool with file_path → allowed (PR2 will add path guard).
+/// #110: Edit to non-protected path → allowed.
 #[test]
-fn hook_check_edit_file_op_allowed_pending_pr2() {
+fn hook_check_edit_non_protected_path_allowed() {
     let input = serde_json::json!({
         "tool_name": "Edit",
         "tool_input": { "file_path": "/tmp/test.txt", "old_string": "a", "new_string": "b" }
     })
     .to_string();
     let (stdout, _, exit_code) = run_hook_check(&input);
-    assert_eq!(exit_code, 0, "Edit file op must be allowed until PR2");
+    assert_eq!(exit_code, 0, "Edit to non-protected path must be allowed");
     let parsed: serde_json::Value =
         serde_json::from_str(stdout.trim()).expect("must return valid JSON");
     assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "allow");
+}
+
+/// #110 V-001: Edit to config.toml → blocked.
+#[test]
+fn hook_check_edit_config_toml_blocked() {
+    let home = std::env::var("HOME").unwrap();
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": format!("{}/.config/omamori/config.toml", home),
+            "old_string": "enabled = true",
+            "new_string": "enabled = false"
+        }
+    })
+    .to_string();
+    let (stdout, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "Edit to config.toml must be blocked");
+    assert!(stdout.trim().is_empty());
+    assert!(stderr.contains("protected file"));
+    assert!(stderr.contains("omamori config"));
+}
+
+/// #110 V-002: Write to .integrity.json → blocked.
+#[test]
+fn hook_check_write_integrity_json_blocked() {
+    let home = std::env::var("HOME").unwrap();
+    let input = serde_json::json!({
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": format!("{}/.omamori/.integrity.json", home),
+            "content": "{}"
+        }
+    })
+    .to_string();
+    let (_, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "Write to .integrity.json must be blocked");
+    assert!(stderr.contains("integrity baseline"));
+}
+
+/// #110: Write to audit.jsonl → blocked.
+#[test]
+fn hook_check_write_audit_jsonl_blocked() {
+    let home = std::env::var("HOME").unwrap();
+    let input = serde_json::json!({
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": format!("{}/.local/share/omamori/audit.jsonl", home),
+            "content": ""
+        }
+    })
+    .to_string();
+    let (_, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "Write to audit.jsonl must be blocked");
+    assert!(stderr.contains("audit log"));
+}
+
+/// #110: Edit to audit-secret → blocked.
+#[test]
+fn hook_check_edit_audit_secret_blocked() {
+    let home = std::env::var("HOME").unwrap();
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": format!("{}/.local/share/omamori/audit-secret", home),
+            "old_string": "old", "new_string": "new"
+        }
+    })
+    .to_string();
+    let (_, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "Edit to audit-secret must be blocked");
+    assert!(stderr.contains("HMAC secret"));
+}
+
+/// #110 T3: Edit to .claude/settings.json → blocked (hook registration protection).
+#[test]
+fn hook_check_edit_claude_settings_blocked() {
+    let home = std::env::var("HOME").unwrap();
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": format!("{}/.claude/settings.json", home),
+            "old_string": "hooks", "new_string": ""
+        }
+    })
+    .to_string();
+    let (_, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "Edit to settings.json must be blocked");
+    assert!(stderr.contains("Claude Code settings"));
+}
+
+/// #110: Edit to .codex/hooks.json → blocked.
+#[test]
+fn hook_check_edit_codex_hooks_json_blocked() {
+    let home = std::env::var("HOME").unwrap();
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": format!("{}/.codex/hooks.json", home),
+            "old_string": "omamori", "new_string": ""
+        }
+    })
+    .to_string();
+    let (_, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "Edit to .codex/hooks.json must be blocked");
+    assert!(stderr.contains("Codex hooks"));
+}
+
+/// #110: Edit to hook script → blocked.
+#[test]
+fn hook_check_edit_hook_script_blocked() {
+    let home = std::env::var("HOME").unwrap();
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": format!("{}/.omamori/hooks/claude-pretooluse.sh", home),
+            "old_string": "exit 2", "new_string": "exit 0"
+        }
+    })
+    .to_string();
+    let (_, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "Edit to hook script must be blocked");
+    assert!(stderr.contains("hook script"));
+}
+
+/// #110 V-006: Path traversal with .. → blocked.
+#[test]
+fn hook_check_edit_path_traversal_blocked() {
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "/tmp/../../home/../tmp/../Users/nonexistent/.config/omamori/config.toml",
+            "old_string": "a", "new_string": "b"
+        }
+    })
+    .to_string();
+    let (_, _, exit_code) = run_hook_check(&input);
+    assert_eq!(
+        exit_code, 2,
+        "path traversal to config.toml must be blocked"
+    );
+}
+
+/// #110: Tilde path ~ → blocked.
+#[test]
+fn hook_check_edit_tilde_path_blocked() {
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "~/.config/omamori/config.toml",
+            "old_string": "a", "new_string": "b"
+        }
+    })
+    .to_string();
+    let (_, _, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2, "tilde path to config.toml must be blocked");
+}
+
+/// #110: Write to completely unrelated path → allowed.
+#[test]
+fn hook_check_write_unrelated_path_allowed() {
+    let input = serde_json::json!({
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": "/Users/someone/projects/myapp/src/main.rs",
+            "content": "fn main() {}"
+        }
+    })
+    .to_string();
+    let (stdout, _, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 0, "Write to unrelated path must be allowed");
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("must return valid JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "allow");
+}
+
+/// #110: Block message includes 3-layer structure and omamori config hint.
+#[test]
+fn hook_check_edit_block_message_has_3_layers() {
+    let home = std::env::var("HOME").unwrap();
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": format!("{}/.config/omamori/config.toml", home),
+            "old_string": "a", "new_string": "b"
+        }
+    })
+    .to_string();
+    let (_, stderr, exit_code) = run_hook_check(&input);
+    assert_eq!(exit_code, 2);
+    // Layer 1: what happened
+    assert!(stderr.contains("blocked Edit to protected file"));
+    // Layer 2: current state
+    assert!(stderr.contains("AI agents cannot modify"));
+    // Layer 3: what to do
+    assert!(stderr.contains("omamori config"));
+}
+
+/// #110: Symlinked parent directory — canonicalize parent catches bypass.
+#[cfg(unix)]
+#[test]
+fn hook_check_edit_symlinked_parent_blocked() {
+    use std::os::unix::fs::symlink;
+
+    let poc_dir = unique_dir("symlink-guard");
+    std::fs::create_dir_all(&poc_dir).unwrap();
+
+    // Create a symlink: poc_dir/alias -> ~/.local/share/omamori
+    let home = std::env::var("HOME").unwrap();
+    let target = format!("{home}/.local/share/omamori");
+    let alias = poc_dir.join("alias");
+    // Only test if the target directory exists
+    if std::path::Path::new(&target).exists() {
+        symlink(&target, &alias).unwrap();
+
+        let fake_file = format!("{}/newfile.jsonl", alias.display());
+        let input = serde_json::json!({
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": fake_file,
+                "content": "injected"
+            }
+        })
+        .to_string();
+        let (_, _, exit_code) = run_hook_check(&input);
+        assert_eq!(
+            exit_code, 2,
+            "symlinked parent to protected dir must be blocked"
+        );
+    }
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&poc_dir);
+}
+
+/// #110 S2: export -n meta-pattern blocks unexport of detector env vars.
+#[test]
+fn hook_check_blocks_export_n_claudecode() {
+    let (_, stderr, exit_code) =
+        run_hook_check(&pretooluse_bash_json("export -n CLAUDECODE && echo hi"));
+    assert_eq!(exit_code, 2);
+    assert!(stderr.contains("unexport"));
+}
+
+/// #110 T3: Bash command editing settings.json is blocked by meta-pattern.
+#[test]
+fn hook_check_blocks_bash_settings_json_edit() {
+    let (_, stderr, exit_code) = run_hook_check(&pretooluse_bash_json(
+        "sed -i '' 's/omamori//' ~/.claude/settings.json",
+    ));
+    assert_eq!(exit_code, 2);
+    assert!(stderr.contains("Claude Code settings"));
 }
 
 /// #111: VERBOSE mode includes raw input in stderr for malformed input.


### PR DESCRIPTION
## Summary

- Block AI Edit/Write/MultiEdit operations targeting omamori's protected files
- `PROTECTED_FILE_PATTERNS`: 10 substring patterns covering config, audit, hooks, and external registrations
- Path normalization with symlink defense (canonicalize parent for non-existent paths)
- 3-layer error messages: what happened → current state → what to do
- New Bash meta-patterns: `export -n` (6 env vars) + `.claude/settings.json`

## Protected Files

| Pattern | Protects |
|---------|----------|
| `omamori/config.toml` | Rule configuration |
| `.integrity.json` | Baseline integrity |
| `audit-secret` | HMAC key (+ retired keys) |
| `audit.jsonl` | Audit log |
| `.local/share/omamori` | Data directory |
| `claude-pretooluse.sh` | Claude Code hook script |
| `codex-pretooluse.sh` | Codex hook script |
| `.codex/hooks.json` | Codex hook registration |
| `.codex/config.toml` | Codex config |
| `.claude/settings.json` | Claude Code hook registration (**new — T3**) |

## Symlink Defense

- Full path → `canonicalize()` (existing paths)
- Non-existent path → canonicalize **parent** + append filename
- Fallback → lexical normalization (always checked)

## Test Changes

- 436 → 450 tests (+14 new)
- Protected path blocks: config.toml, .integrity.json, audit.jsonl, audit-secret, settings.json, .codex/hooks.json, hook scripts
- Path traversal (`../`) and tilde (`~/`) normalization
- Symlinked parent directory bypass prevention
- `export -n` meta-pattern blocking
- 3-layer error message structure validation

## Test plan

- [x] All 450 tests pass (`cargo test`)
- [x] V-001: Edit config.toml → exit 2
- [x] V-002: Write .integrity.json → exit 2
- [x] V-006: Path traversal → exit 2
- [x] Tilde path → exit 2
- [x] Symlinked parent dir → exit 2
- [x] Non-protected path → exit 0
- [x] settings.json (Edit tool) → exit 2
- [x] settings.json (Bash sed) → exit 2
- [x] export -n CLAUDECODE → exit 2
- [x] 3-layer block message format verified
- [x] `-D warnings` clean

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)