### PR TITLE
security: add fuzz testing for parser attack surfaces (#113)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,53 @@
+name: Fuzz
+
+on:
+  # Nightly schedule: longer fuzz runs
+  schedule:
+    - cron: '0 3 * * *'
+  # PR: short fuzz to catch regressions
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'fuzz/**'
+  # Manual trigger
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    name: Fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [fuzz_unwrap, fuzz_hook_input, fuzz_check_command]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Run fuzz target (${{ matrix.target }})
+        run: |
+          cd fuzz
+          # PR: 30 seconds per target. Nightly: 5 minutes.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            DURATION=300
+          else
+            DURATION=30
+          fi
+          cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=$DURATION
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}/

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ tests/poc.sh
 .DS_Store
 omamori-test-sandbox/
 
+# Fuzz artifacts and corpus
+fuzz/artifacts/
+fuzz/corpus/
+fuzz/target/
+
 # Claude Code local plans & investigation notes
 .claude/plans/
 investigation/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "omamori-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.omamori]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_unwrap"
+path = "fuzz_targets/fuzz_unwrap.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_hook_input"
+path = "fuzz_targets/fuzz_hook_input.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_check_command"
+path = "fuzz_targets/fuzz_check_command.rs"
+doc = false

--- a/fuzz/fuzz_targets/fuzz_check_command.rs
+++ b/fuzz/fuzz_targets/fuzz_check_command.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// Fuzz the full hook check pipeline: meta-patterns + unwrap stack + rule matching.
+// Goal: no panics on arbitrary command strings.
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        omamori::fuzz_check_command_for_hook(s);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_hook_input.rs
+++ b/fuzz/fuzz_targets/fuzz_hook_input.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// Fuzz the PreToolUse hook input parser (JSON → HookInput classification).
+// Goal: no panics on arbitrary input, including malformed JSON and edge cases.
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        omamori::fuzz_extract_hook_input(s);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_unwrap.rs
+++ b/fuzz/fuzz_targets/fuzz_unwrap.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// Fuzz the shell command parser — omamori's largest attack surface.
+// Goal: no panics on arbitrary input. Hangs are caught by libFuzzer's timeout.
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = omamori::unwrap::parse_command_string(s);
+    }
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2241,6 +2241,18 @@ pub struct PolicyTestResult {
     pub details: String,
 }
 
+/// Fuzz entry point: parse hook input without exposing internal types.
+/// Panics are the signal — if this doesn't panic, the input is handled safely.
+pub fn fuzz_extract_hook_input(input: &str) {
+    let _ = extract_hook_input(input);
+}
+
+/// Fuzz entry point: check a command string through the hook pipeline.
+/// Exercises meta-patterns + unwrap stack + rule matching.
+pub fn fuzz_check_command_for_hook(command: &str) {
+    let _ = check_command_for_hook(command);
+}
+
 pub fn run_policy_tests(load_result: &ConfigLoadResult) -> Vec<PolicyTestResult> {
     let config = &load_result.config;
     let claude_env = vec![("CLAUDECODE".to_string(), "1".to_string())];

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -252,9 +252,13 @@ fn unwrap_transparent(tokens: &[String]) -> Vec<String> {
                 pos += 1;
                 while pos < len && tokens[pos].starts_with('-') {
                     if tokens[pos] == "-u" || tokens[pos] == "-g" {
-                        pos += 1; // skip the flag value too
+                        pos += 1; // skip the flag
+                        if pos < len {
+                            pos += 1; // skip the value
+                        }
+                    } else {
+                        pos += 1;
                     }
-                    pos += 1;
                 }
             }
             "env" => {
@@ -275,7 +279,10 @@ fn unwrap_transparent(tokens: &[String]) -> Vec<String> {
             "nice" => {
                 pos += 1;
                 if pos < len && tokens[pos] == "-n" {
-                    pos += 2; // -n VALUE
+                    pos += 1; // skip -n
+                    if pos < len {
+                        pos += 1; // skip VALUE
+                    }
                 } else if pos < len && tokens[pos].starts_with("-n") {
                     pos += 1; // -n10 combined form
                 }
@@ -287,6 +294,8 @@ fn unwrap_transparent(tokens: &[String]) -> Vec<String> {
         }
     }
 
+    // Bounds safety: pos can exceed len if input is all wrappers with no actual command
+    let pos = pos.min(len);
     tokens[pos..].to_vec()
 }
 
@@ -611,6 +620,26 @@ mod tests {
     #[test]
     fn nice_combined_form() {
         assert_commands("nice -n10 make", &[cmd("make", &[])]);
+    }
+
+    // Regression: fuzz found panic when input is all wrappers with no actual command
+    #[test]
+    fn wrappers_only_no_command() {
+        // Should return empty commands, not panic
+        let result = parse_command_string("sudo sudo sudo");
+        assert!(matches!(result, ParseResult::Commands(ref cmds) if cmds.is_empty()));
+    }
+
+    #[test]
+    fn nice_n_at_end_no_command() {
+        let result = parse_command_string("nice -n");
+        assert!(matches!(result, ParseResult::Commands(ref cmds) if cmds.is_empty()));
+    }
+
+    #[test]
+    fn sudo_u_at_end_no_command() {
+        let result = parse_command_string("sudo -u root");
+        assert!(matches!(result, ParseResult::Commands(ref cmds) if cmds.is_empty()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- 3 cargo-fuzz targets for omamori's parser attack surfaces
- CI workflow: nightly (5min/target) + PR (30s/target) on ubuntu + nightly toolchain
- Crash artifacts uploaded on failure

## Fuzz Targets

| Target | Entry Point | Attack Surface |
|--------|-------------|----------------|
| `fuzz_unwrap` | `unwrap::parse_command_string` | Shell command parser (1,003 lines, 74 unit tests) |
| `fuzz_hook_input` | `extract_hook_input` | PreToolUse JSON → HookInput classification |
| `fuzz_check_command` | `check_command_for_hook` | Full pipeline: meta-patterns + unwrap + rules |

## Why

- DCG (competitor) has 9 fuzz targets — omamori had zero
- "Fuzz-tested" is a trust signal for security tool adopters
- Shell syntax edge cases are infinite (unicode, control chars, deep nesting)
- Parser crash = fail-close (safe), but false negatives = dangerous

## Test plan

- [x] All 450 tests pass (`cargo test`)
- [x] Clippy clean, format clean
- [x] Fuzz directory structure follows cargo-fuzz conventions
- [x] CI workflow triggers on PR (src/ or fuzz/ changes) + nightly schedule
- [ ] Fuzz targets compile and run on ubuntu + nightly (CI will verify)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)