### PR TITLE
docs: v0.8.0 release — changelog, version bump, docs updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.8.0] - 2026-04-11
+
+**Summary**: Fail-close hook validation (**breaking** for non-standard integrations), Edit/Write file guard for protected files, audit key rotation, fuzz testing, MSRV 1.92.
+
+### Breaking
+
+- **Hook input validation is now strict** (#111): Malformed JSON input to hooks is blocked (exit 2) instead of falling back to string processing. If you see unexpected blocks after upgrading, verify your AI tool is sending valid hook input. Claude Code, Codex CLI, and Cursor are tested and unaffected.
+
+### Security
+
+- **Fail-close on malformed hook input** (#111): Hook layer now blocks (exit 2) when stdin is not valid JSON, missing required fields, or has wrong types. Previously fell back to raw string processing (fail-open). Typed `HookInput` enum replaces the old string-based extraction.
+
+- **Edit/Write file_path guard** (#110): AI Edit/Write/MultiEdit operations targeting omamori's protected files are now blocked. 10 protected patterns: config.toml, .integrity.json, audit-secret, audit.jsonl, hook scripts, `.claude/settings.json`, `.codex/hooks.json`, `.codex/config.toml`. Path normalization includes `canonicalize()` + parent directory symlink resolution. 3-layer error messages (what/state/action) with `omamori config` CLI alternative.
+
+- **New meta-patterns** (#110): `export -n` for 6 detector env vars (CLAUDECODE, CODEX_CI, CURSOR_AGENT, GEMINI_CLI, CLINE_ACTIVE, AI_GUARD). `.claude/settings.json` protection via both file_path guard and blocked_command_patterns.
+
+- **Fuzz testing** (#113): 3 cargo-fuzz targets (fuzz_unwrap, fuzz_hook_input, fuzz_check_command) with CI integration (nightly schedule + PR). Found and fixed a panic in `unwrap_transparent()` on wrapper-only input (e.g., `sudo sudo sudo`).
+
+### Fixed
+
+- **Silent audit log failures** (#114): 3 instances of `let _ = logger.append(event)` replaced with `try_audit_append()`. Write failures now emit WARNING to stderr. In strict mode (`audit.strict = true`), write failure blocks the command (exit 1).
+
+- **Parser panic on wrapper-only input** (#113): `unwrap_transparent()` panicked when input consisted entirely of wrappers with no actual command (e.g., `nice -n`, `sudo -u root`). Bounds check added.
+
+### Added
+
+- **Audit key rotation** (#116): `omamori audit key rotate` command. Renames active secret to `audit-secret.N.retired`, generates new secret. Multi-key verification in `verify_chain()` — old entries verify against retired key, new entries against active key. AI environment guard blocks rotation from AI context.
+
+- **MSRV declaration** (#115): `rust-version = "1.92"` in Cargo.toml. CI MSRV check job added.
+
+- **Coverage reporting** (#115): cargo-tarpaulin CI job with Codecov upload on main push.
+
+### Changed
+
+- Sandbox documentation updated: removed #61 references (NO-GO), updated to recommend platform-native sandboxes (Codex CLI, Claude Code `/sandbox`, Cursor) or [nono](https://github.com/always-further/nono).
+- SECURITY.md updated: Edit/Write file operations on protected files now listed as "Blocked" instead of "Not protected".
+
+### Stats
+
+- Tests: 427 → 453 (+26)
+- New CI jobs: MSRV check, Coverage, Fuzz (3 targets)
+
 ## [0.7.5] - 2026-04-07
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.7.5"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Available for Claude Code, Cursor, and Codex CLI.
 
 **Integrity monitoring** (`omamori status`): Verifies all defense layers are intact — shims, hooks, config, core policy, PATH order. Detects tampering including subtle hook edits where the version comment is preserved but the body is rewritten.
 
-**Sandbox complementarity**: omamori operates at the semantic layer — it understands *what* a command does (Layer 1: shim, Layer 2: hooks). A filesystem sandbox (e.g., sandbox-exec, container isolation) operates at the OS boundary — it restricts *where* processes can read and write. These are complementary: omamori catches `rm -rf src/` before it runs; a sandbox prevents damage if something slips through. For defense in depth, use both. omamori plans to add optional sandbox integration in a future release ([#61](https://github.com/yottayoshida/omamori/issues/61)).
+**Sandbox complementarity**: omamori operates at the semantic layer — it understands *what* a command does (Layer 1: shim, Layer 2: hooks). A filesystem sandbox operates at the OS boundary — it restricts *where* processes can read and write. These are complementary: omamori catches `rm -rf src/` before it runs; a sandbox prevents damage if something slips through. For defense in depth, combine omamori with your AI tool's sandbox (Codex CLI sandbox (on by default), Claude Code `/sandbox`, Cursor agent sandbox) or a dedicated tool like [nono](https://github.com/always-further/nono).
+
+**File protection** (v0.8.0+): AI Edit/Write operations on omamori's own files (config, hooks, audit log, integrity baseline, Claude Code settings.json) are blocked. See [SECURITY.md](SECURITY.md) for the full protected file list.
 
 For what omamori **cannot** catch, see [Structural Limitations](#structural-limitations).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 `omamori` is a PATH-shim safeguard for AI-triggered shell commands. It reduces risk for a narrow set of destructive commands, but it is not a sandbox and it does not claim complete mediation.
 
-## What It Protects (v0.7.5)
+## What It Protects (v0.8.0)
 
 - recursive `rm` variants matched by the default rules
 - `git reset --hard`
@@ -242,7 +242,7 @@ Real-world testing ([#22](https://github.com/yottayoshida/omamori/issues/22)) sh
 - Uses the same detector logic as the PATH shim (`evaluate_detectors()`)
 - Hooks also block these commands as string patterns (Claude Code + Cursor)
 - Hooks block shell commands that modify `config.toml` (sed, echo, etc.)
-- **Not yet implemented**: file_path-aware blocking for Edit/Write tools (planned for v0.7+)
+- **Edit/Write file_path guard** (v0.8.0 #110): AI Edit/Write/MultiEdit operations on protected files (config, hooks, audit, settings.json) are blocked via `PROTECTED_FILE_PATTERNS` with path normalization and symlink resolution
 
 ### Known limitations
 
@@ -250,7 +250,7 @@ Real-world testing ([#22](https://github.com/yottayoshida/omamori/issues/22)) sh
 |--------------|-----------|-------|
 | `omamori config disable` | Yes — env var guard | All tools with known env vars |
 | `omamori uninstall` | Yes — env var guard | All tools with known env vars |
-| Direct config.toml editing (Edit/Write) | **No** | file_path-aware hook not yet implemented (v0.7+) |
+| Direct config.toml editing (Edit/Write) | **Yes** — file_path guard (v0.8.0) | Claude Code PreToolUse. Codex CLI: Bash only (structural limitation) |
 | Direct config.toml editing (Bash: sed, echo >>) | Claude Code + Cursor | Hooks block Bash patterns containing config.toml |
 | Direct config.toml editing (other tools) | **No** | Codex CLI, Gemini CLI cannot prevent file editing |
 | env var unset → config disable | Partially | Hooks block env var unset. Without hooks, this attack succeeds |
@@ -377,10 +377,11 @@ If a previous write was interrupted (partial JSON line), `append()` detects the 
 | AI modifies log entries (content change) | Hash chain (`entry_hash` mismatch) | Detected by `omamori audit verify` |
 | AI deletes/truncates log entries | Hash chain (seq gap / `prev_hash` mismatch) | Detected by `omamori audit verify` |
 | AI accesses secret via omamori hook layer | `blocked_command_patterns` | Detected and blocked |
-| AI directly operates on files (bypassing omamori) | None (same OS user) | **Not protected** |
-| AI reads secret and forges valid chain | None (same OS user) | **Not protected** |
+| AI Edit/Write to protected files (config, audit, hooks, settings.json) | `is_protected_file_path` + `PROTECTED_FILE_PATTERNS` | **Blocked** (v0.8.0 #110) |
+| AI directly operates on files via OS (bypassing hook layer) | None (same OS user) | **Not protected** (structural limitation) |
+| AI reads secret and forges valid chain | None (same OS user) | **Not protected** (structural limitation) |
 
-**Fundamental constraint**: AI agent and omamori run as the same OS user. Unix file permissions do not provide isolation. `blocked_command_patterns` operates at the hook layer only (`check_command_for_hook()`). Complete filesystem isolation requires OS-level sandboxing ([#61](https://github.com/yottayoshida/omamori/issues/61)).
+**Fundamental constraint**: AI agent and omamori run as the same OS user. Unix file permissions do not provide isolation. `blocked_command_patterns` operates at the hook layer only (`check_command_for_hook()`). Complete filesystem isolation requires OS-level sandboxing — use your AI tool's sandbox (Codex CLI sandbox (on by default), Claude Code `/sandbox`, Cursor agent sandbox) or a dedicated tool like [nono](https://github.com/always-further/nono).
 
 ### Secret Loss
 


### PR DESCRIPTION
## Summary

Final PR for v0.8.0 release: version bump, CHANGELOG, docs updates.

### Changes

- **Version bump**: 0.7.5 → 0.8.0 in Cargo.toml
- **CHANGELOG**: v0.8.0 entry with **Breaking** section (fail-close behavioral change), summary line, full feature list
- **SECURITY.md**: Edit/Write guard updated from "Not yet implemented" to "Blocked (v0.8.0 #110)". Version header v0.7.5 → v0.8.0
- **README.md**: New "File protection" paragraph. Sandbox wording precision (Codex "on by default", Claude Code `/sandbox`)
- **Sandbox docs**: Removed #61 references (NO-GO). Recommend platform-native sandboxes with activation status

### UX Designer Review

8 findings, 7 addressed:

| # | Priority | Finding | Status |
|---|----------|---------|--------|
| 1 | HIGH | SECURITY.md stale "Not yet implemented" | Fixed |
| 2 | HIGH | Version header v0.7.5 | Fixed → v0.8.0 |
| 3 | HIGH | No breaking change callout | Fixed → Breaking section added |
| 4 | MEDIUM | Sandbox claims imprecise | Fixed → tool-specific wording |
| 5 | MEDIUM | Deferred section noise | Fixed → removed |
| 6 | MEDIUM | CHANGELOG hard to triage | Fixed → summary line added |
| 7 | LOW | README missing Edit/Write guard | Fixed → File protection paragraph |
| 8 | LOW | Stats format inconsistent | Skipped (cosmetic) |

## Test plan

- [x] All 453 tests pass
- [x] Clippy + format clean
- [x] No stale version references in SECURITY.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)