### PR TITLE
docs: v0.8.1 release — changelog, version bump (#112 PR 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.8.1] - 2026-04-12
+
+**Summary**: Internal module split for maintainability. No behavior changes, no config changes. Existing installations work as-is.
+
+### Changed
+
+- **Module split** (#112): Monolithic `lib.rs` (2,893 lines) and `audit.rs` (2,765 lines) split into focused submodules (`src/audit/`, `src/engine/`, `src/cli/`, `src/util.rs`). `lib.rs` reduced to 103-line dispatcher.
+
+### Internal
+
+- 19 guardrail tests added before the split to lock security-critical invariants (#132)
+- Tests: 453 → 473 (+20)
+
 ## [0.8.0] - 2026-04-11
 
 **Summary**: Fail-close hook validation (**breaking** for non-standard integrations), Edit/Write file guard for protected files, audit key rotation, fuzz testing, MSRV 1.92.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"


### PR DESCRIPTION
## Summary
- CHANGELOG.md: v0.8.1 section added
- Cargo.toml: version bump 0.8.0 → 0.8.1
- **Final PR** in the v0.8.1 module split sequence (#112)

## CHANGELOG (UX-reviewed)

UX designer reviewed the CHANGELOG and recommended condensing from 25 lines to 6:
- End users confirm "no action needed" from Summary alone
- Internal jargon removed (T8, DREAD, HashableEvent)
- 17 file names collapsed to 4 directory names (Miller's Law)
- Test-internal fixes omitted (invisible to users)
- Explicit "existing installations work as-is" for security tool confidence

## v0.8.1 Module Split Complete (#112)

| PR | Scope | Status |
|----|-------|--------|
| #132 | 19 guardrail tests | merged |
| #133 | audit/ split (5 submodules) | merged |
| #134 | util.rs extraction | merged |
| #135 | engine/ split (4 submodules) | merged |
| #136 | cli/ split (5 submodules) | merged |
| **#137** | **docs + version bump** | **this PR** |

**Result**: lib.rs 2,893 → 103 lines. audit.rs 2,765 → 5 files. 473 tests (unchanged).

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test` — 473 tests pass
- [x] `cargo doc --no-deps` — rustdoc clean, pub API unchanged
- [x] `cd fuzz && cargo check` — fuzz targets compile
- [ ] CI: full suite
- [ ] After merge: `cargo publish`, `gh release create v0.8.1`, homebrew-tap PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)