### PR TITLE
feat: add explain hint to block messages (#117 PR 4/5)

### DIFF
--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -198,6 +198,7 @@ fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Resul
                 eprintln!("  provider: {provider}");
                 eprintln!("  layer: meta-pattern (string-level)");
             }
+            eprintln!("  hint: run `omamori explain -- {}` for details", command);
             Ok(2)
         }
         HookCheckResult::BlockRule {
@@ -215,9 +216,7 @@ fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Resul
                 eprintln!("  rule: {rule_name}");
                 eprintln!("  layer: unwrap-stack (token-level)");
             }
-            eprintln!(
-                "  hint: if intentional, run the command directly in your terminal (not via AI agent)"
-            );
+            eprintln!("  hint: run `omamori explain -- {command}` for details");
             Ok(2)
         }
         HookCheckResult::BlockStructural(message) => {
@@ -226,9 +225,7 @@ fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Resul
                 eprintln!("  provider: {provider}");
                 eprintln!("  layer: unwrap-stack (structural)");
             }
-            eprintln!(
-                "  hint: if intentional, run the command directly in your terminal (not via AI agent)"
-            );
+            eprintln!("  hint: run `omamori explain -- {command}` for details");
             Ok(2)
         }
     }

--- a/src/engine/shim.rs
+++ b/src/engine/shim.rs
@@ -346,6 +346,8 @@ pub(crate) fn run_command(
         match &outcome {
             ActionOutcome::Blocked { .. } | ActionOutcome::Failed { .. } => {
                 eprintln!("{}", outcome.message());
+                let explain_cmd = format_explain_hint(&invocation);
+                eprintln!("  hint: run `{explain_cmd}` for details");
             }
             ActionOutcome::Trashed { message, .. } | ActionOutcome::MovedTo { message, .. } => {
                 eprintln!("{message}");
@@ -374,6 +376,16 @@ pub(crate) fn run_command(
     }
 
     Ok(outcome.exit_code())
+}
+
+/// Format `omamori explain -- <program> <args...>` hint for block messages.
+fn format_explain_hint(invocation: &CommandInvocation) -> String {
+    let args_str = if invocation.args.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", shell_words::join(&invocation.args))
+    };
+    format!("omamori explain -- {}{}", invocation.program, args_str)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Block messages in both Layer 1 (shim) and Layer 2 (hook) now include an actionable hint
- `hint: run `omamori explain -- <command>` for details` bridges "blocked → understood"
- Replaces generic "run directly in terminal" with command-specific explain reference

## Context
v0.9.0 "UX Revolution" — PR 4 of 5. Depends on PR 3 (#140, merged).

## Changes
| File | Change |
|------|--------|
| `src/engine/shim.rs` | +9/-0 — hint after Blocked/Failed + `format_explain_hint` helper |
| `src/engine/hook.rs` | +6/-6 — update 3 block types with explain hint |

## Test plan
- [x] 490 tests pass + 1 ignored (`RUSTFLAGS="-D warnings" cargo test`)
- [x] Clippy + Format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)