### PR TITLE
docs: v0.9.0 release — README, SECURITY, changelog, bump (#117 #118 #120 PR 5/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.9.0] - 2026-04-14
+
+**Summary**: "UX Revolution" — two new commands (`doctor`, `explain`) that transform the user experience from "something broke" to "fix it" and from "why was I blocked?" to "here's why."
+
+### Added
+
+- **`omamori doctor`** (#117): Diagnose installation health. Shows only problems (or 3-line "all healthy" summary).
+  - `--fix`: Auto-repair shims, hooks, config permissions, and baseline. Repair order: install → hooks → chmod → baseline (DI-10).
+  - `--verbose`: Show all check items (works in both healthy and unhealthy states).
+  - `--json`: Structured JSON output for automation.
+  - AI guard (DI-7): `--fix` is blocked in AI environments to prevent baseline normalization attacks.
+
+- **`omamori explain -- <command>`** (#118): Simulate command evaluation through both defense layers without executing.
+  - Shows Layer 1 (PATH shim) rule match + context override and Layer 2 (hook) meta-pattern/unwrap evaluation.
+  - `--json`: Structured JSON output. `--config PATH`: Custom config for testing.
+  - AI guard (DI-8): Blocked in AI environments to prevent oracle attacks.
+  - Exit code: 0 = would be allowed, 2 = would be blocked (consistent with `hook-check`).
+
+- **Block message hint line**: All block messages (shim + hook) now include `hint: run \`omamori explain -- <cmd>\` for details`.
+
+- **`Remediation` enum**: Each integrity check item carries a suggested fix action (`RunInstall`, `RegenerateHooks`, `RegenerateBaseline`, `ChmodConfig`, `ManualOnly`). Foundation for `doctor --fix`.
+
+### Security
+
+- **DI-7 through DI-10**: Four new design invariants for `doctor --fix` and `explain`. See SECURITY.md.
+- **DI-9**: `blocked_command_patterns` updated with `omamori doctor --fix` and `omamori explain` (defense-in-depth via Layer 2 hooks).
+- `guard_ai_config_modification` call sites: 7 → 9.
+
+### Changed
+
+- **README overhaul** (#120): Removed 5 version annotations. Added `doctor` to Quick Start. Added `doctor` and `explain` to CLI Reference. User-value ordering per UX rules.
+
+### Internal
+
+- Tests: 473 → 491 (+18 new tests for doctor and explain)
+
 ## [0.8.1] - 2026-04-12
 
 **Summary**: Internal module split for maintainability. No behavior changes, no config changes. Existing installations work as-is.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Terminal → rm -rf src/
 Available for Claude Code, Cursor, and Codex CLI.
 
 **Audit log**: Records every command decision in a tamper-evident log — if an AI agent modifies any entry, the chain breaks and tampering is detected.
-- HMAC-SHA256 signed and hash-chained JSONL (`~/.local/share/omamori/audit.jsonl`)
+- Tamper-evident JSONL log at `~/.local/share/omamori/audit.jsonl`
+- HMAC-SHA256 signed and hash-chained — tampering breaks the chain and is detected
 - Per-install secret; file paths HMAC-hashed (never stored in plaintext)
 - Set `retention_days` in config to automatically prune old entries — chain integrity is preserved across pruning
 - Logging enabled by default; retention is opt-in via config

--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ omamori install --hooks
 
 # Add to your shell profile (~/.zshrc or ~/.bashrc)
 export PATH="$HOME/.omamori/shim:$PATH"
+
+# Verify everything is healthy
+omamori doctor
 ```
 
 That's it. Works with Claude Code Auto mode — no extra config needed.
+
+> Requires omamori >= 0.9.0 for `doctor` and `explain` commands.
 
 > **Cursor users**: After upgrades, re-merge the hook snippet. See [Auto-sync](#how-it-works).
 
@@ -78,20 +83,20 @@ Terminal → rm -rf src/
 
 Available for Claude Code, Cursor, and Codex CLI.
 
-**Layer 3 — Audit** (v0.7.0+): Records every command decision in a tamper-evident log — if an AI agent modifies any entry, the chain breaks and tampering is detected.
+**Audit log**: Records every command decision in a tamper-evident log — if an AI agent modifies any entry, the chain breaks and tampering is detected.
 - HMAC-SHA256 signed and hash-chained JSONL (`~/.local/share/omamori/audit.jsonl`)
 - Per-install secret; file paths HMAC-hashed (never stored in plaintext)
-- Auto-retention (v0.7.2+): set `retention_days` in config to automatically prune old entries — chain integrity is preserved across pruning
+- Set `retention_days` in config to automatically prune old entries — chain integrity is preserved across pruning
 - Logging enabled by default; retention is opt-in via config
 
-**Self-defense** ([#22](https://github.com/yottayoshida/omamori/issues/22)): AI agents cannot `config disable`, `uninstall`, or edit `config.toml` while detected. Hooks block env var unsetting, config modification, and audit log/secret access via shell commands. This is a key differentiator from other CLI guards — omamori assumes adversarial AI behavior and defends against it.
+**Self-defense**: AI agents cannot `config disable`, `uninstall`, or edit `config.toml` while detected. Hooks block env var unsetting, config modification, and audit log/secret access via shell commands. This is a key differentiator from other CLI guards — omamori assumes adversarial AI behavior and defends against it.
 
-**Auto mode compatible** (v0.6.2+): Works seamlessly with Claude Code's [Auto mode](https://claude.com/blog/auto-mode) — safe commands proceed without prompts, dangerous commands are still hard-blocked.
+**Auto mode compatible**: Works seamlessly with Claude Code's [Auto mode](https://claude.com/blog/auto-mode) — safe commands proceed without prompts, dangerous commands are still hard-blocked.
 
 **Auto-sync**: After `brew upgrade`, the shim detects version mismatch and auto-regenerates hook files on the next invocation.
 
 - **Claude Code**: Hooks are applied automatically. No action needed.
-- **Codex CLI**: Hooks and config are auto-configured during install (v0.6.3+). If you install Codex later, the shim sets up hooks on first invocation. Auto-sync regenerates the wrapper on upgrade.
+- **Codex CLI**: Hooks and config are auto-configured during install. If you install Codex later, the shim sets up hooks on first invocation. Auto-sync regenerates the wrapper on upgrade.
 - **Cursor**: Run `omamori install --hooks` to regenerate the snippet, then merge `~/.omamori/hooks/cursor-hooks.snippet.json` into your `.cursor/hooks.json`.
 
 **Core policy**: The 7 built-in rules cannot be disabled via `config.toml` — an AI agent setting `enabled = false` is silently ignored. For legitimate overrides, see `omamori override` in [CLI Reference](#cli-reference).
@@ -100,7 +105,7 @@ Available for Claude Code, Cursor, and Codex CLI.
 
 **Sandbox complementarity**: omamori operates at the semantic layer — it understands *what* a command does (Layer 1: shim, Layer 2: hooks). A filesystem sandbox operates at the OS boundary — it restricts *where* processes can read and write. These are complementary: omamori catches `rm -rf src/` before it runs; a sandbox prevents damage if something slips through. For defense in depth, combine omamori with your AI tool's sandbox (Codex CLI sandbox (on by default), Claude Code `/sandbox`, Cursor agent sandbox) or a dedicated tool like [nono](https://github.com/always-further/nono).
 
-**File protection** (v0.8.0+): AI Edit/Write operations on omamori's own files (config, hooks, audit log, integrity baseline, Claude Code settings.json) are blocked. See [SECURITY.md](SECURITY.md) for the full protected file list.
+**File protection**: AI Edit/Write operations on omamori's own files (config, hooks, audit log, integrity baseline, Claude Code settings.json) are blocked. See [SECURITY.md](SECURITY.md) for the full protected file list.
 
 For what omamori **cannot** catch, see [Structural Limitations](#structural-limitations).
 
@@ -197,6 +202,8 @@ strict = true  # default: false. Hook-only commands (ls, cat, etc.) are not affe
 
 ```
 omamori install [--hooks]                # Setup shims + hooks + config (re-run after brew upgrade for Cursor)
+omamori doctor [--fix] [--verbose] [--json]  # Diagnose and auto-repair installation
+omamori explain [--json] -- <cmd...>     # Show what would happen to a command and why
 omamori test [--config PATH]             # Verify policy rules
 omamori status [--refresh]               # Health check all defense layers
 omamori exec [--config PATH] -- CMD      # Run command through policy engine

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 `omamori` is a PATH-shim safeguard for AI-triggered shell commands. It reduces risk for a narrow set of destructive commands, but it is not a sandbox and it does not claim complete mediation.
 
-## What It Protects (v0.8.0)
+## What It Protects (v0.9.0)
 
 - recursive `rm` variants matched by the default rules
 - `git reset --hard`
@@ -31,6 +31,17 @@
 - **Basename collision avoidance**: When `move-to` processes multiple targets, a dedup suffix (`_2`, `_3`, ...) prevents same-named files from overwriting each other.
 
 - **Cross-device move rejection**: `move-to` uses `rename(2)` which is atomic on the same filesystem. Cross-device moves (`EXDEV`) are rejected to avoid the TOCTOU window that copy+delete would introduce.
+
+## Design Invariants (v0.9.0+)
+
+| ID | Invariant | Enforcement |
+|----|-----------|-------------|
+| DI-7 | `doctor --fix` is blocked in AI environments | `guard_ai_config_modification("doctor --fix")` — prevents baseline normalization to hide tampering |
+| DI-8 | `explain` is blocked in AI environments | `guard_ai_config_modification("explain")` — prevents oracle attacks (probing which commands are blocked) |
+| DI-9 | `doctor --fix` and `explain` in `blocked_command_patterns` | Defense-in-depth: Layer 2 hooks also block these commands via string matching |
+| DI-10 | `doctor --fix` repair order: install → hooks → chmod → baseline (last) | Baseline must reflect the post-repair state, not the pre-repair state |
+
+`guard_ai_config_modification` call sites: 9 (as of v0.9.0).
 
 ## Integrity Monitoring (v0.5.0+)
 

--- a/src/engine/guard.rs
+++ b/src/engine/guard.rs
@@ -1,7 +1,7 @@
 //! AI environment guard for config-mutating operations.
 //!
 //! SECURITY (T3): `guard_ai_config_modification` must be called on every
-//! config-mutating code path (7 call sites as of v0.8.0).
+//! config-mutating code path (9 call sites as of v0.9.0).
 
 use crate::AppError;
 use crate::config;


### PR DESCRIPTION
## Summary
- **README overhaul** (#120): Remove 5 version annotations, add `doctor`/`explain` to CLI Reference and Quick Start, Quick Start minimum version note
- **SECURITY.md**: Add DI-7 through DI-10 design invariants, update `guard_ai_config_modification` call site count 7→9
- **CHANGELOG**: v0.9.0 "UX Revolution" entry with all 4 features
- **Cargo.toml**: version bump 0.8.1 → 0.9.0

## Context
v0.9.0 "UX Revolution" — PR 5 of 5 (final). All code PRs (#138-#141) merged.

## Changes
| File | Change |
|------|--------|
| `README.md` | Remove version annotations, add doctor/explain, Quick Start update |
| `SECURITY.md` | DI-7~DI-10 table, call site count update |
| `CHANGELOG.md` | v0.9.0 entry |
| `Cargo.toml` | 0.8.1 → 0.9.0 |
| `src/engine/guard.rs` | Comment update: 7→9 call sites |

## README checklist (rules/readme.md)
- [x] No version annotations `(vX.Y.Z+)` in body text
- [x] Features ordered by user value (not chronologically)
- [x] No CHANGELOG duplication
- [x] No sentence with 3+ technical concepts
- [x] Quick Start within 1 screen scroll

## Test plan
- [x] 490 tests pass + 1 ignored (`RUSTFLAGS="-D warnings" cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)