### PR TITLE
feat: v093 PR1 governance foundation (issue #147)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml,toml,json}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Normalize line endings across platforms.
+* text=auto eol=lf
+
+# Treat these as binary (no diff, no merge).
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.pdf binary
+
+# Rust sources / scripts are always LF.
+*.rs  text eol=lf
+*.toml text eol=lf
+*.sh  text eol=lf
+
+# Exclude from GitHub archive tarballs (`git archive` / "Download ZIP").
+# Note: this does NOT affect `cargo package` — see Cargo.toml `include=` / `exclude=`.
+.claude/            export-ignore
+investigation/      export-ignore
+PLAN.md             export-ignore
+ACCEPTANCE_TEST.md  export-ignore
+demo.svg            export-ignore
+fuzz/               export-ignore
+omamori-test-sandbox/ export-ignore

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# omamori CODEOWNERS
+#
+# Every file has a default owner. Security-critical paths are explicitly listed
+# so PRs touching them trigger an ownership review even if the default wildcard
+# would have matched.
+
+* @yottayoshida
+
+# Security-critical source paths (v0.9.3+)
+# Policy & trust-boundary modules: command parsing, rule evaluation, detection,
+# execution context. A subtle refactor here can silently weaken the product.
+/src/audit/          @yottayoshida
+/src/engine/         @yottayoshida
+/src/engine/hook.rs  @yottayoshida
+/src/actions.rs      @yottayoshida
+/src/installer.rs    @yottayoshida
+/src/integrity.rs    @yottayoshida
+/src/config.rs       @yottayoshida
+/src/rules.rs        @yottayoshida
+/src/detector.rs     @yottayoshida
+/src/context.rs      @yottayoshida
+
+# Supply-chain / release surface
+/.github/workflows/  @yottayoshida
+/Cargo.toml          @yottayoshida
+/Cargo.lock          @yottayoshida
+/SECURITY.md         @yottayoshida

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!-- Thank you for contributing to omamori.
+     Keep PRs small (ideally < 100 lines of diff) and focused on a single change. -->
+
+## Summary
+
+<!-- 1-3 lines: what this PR changes and why. -->
+
+## Change Type
+
+- [ ] `feat/` — new feature or behavior change
+- [ ] `fix/` — bug fix (no behavior change for correct inputs)
+- [ ] `docs/` — documentation only
+- [ ] `refactor/` — internal refactor (no behavior change)
+- [ ] `ci/` — CI/CD or tooling changes
+- [ ] `security/` — security fix or hardening
+
+> **Branch prefix is MUST for new branches** (v0.9.3+): `feat/<slug>`, `fix/<slug>`, …
+> Legacy `feature/*` branches are accepted **only until 2026-05-15** so in-flight
+> PRs can land. After the cutoff, new `feature/*` branches may be rejected and
+> remaining ones may be renamed or promoted to a GitHub ruleset. See
+> `CONTRIBUTING.md` for the migration ladder.
+
+## CI Checklist
+
+- [ ] `./scripts/pre-pr-check.sh` passes locally (fmt + clippy + tests, all `--locked`)
+- [ ] I did NOT run `cargo` commands with `--allow-dirty` or `--no-verify`
+- [ ] If I bumped a dependency: `Cargo.lock` is updated and committed
+- [ ] If I touched a workflow: every `uses:` is a 40-char SHA with a `# vX.Y.Z` comment
+- [ ] If I touched `Cargo.toml`: `cargo publish --dry-run --locked` still succeeds
+
+## Security Checklist
+
+- [ ] No new `cargo install` without `--locked --version` (or `taiki-e/install-action` with `fallback: none`)
+- [ ] No new files under `.claude/`, `investigation/`, or `CLAUDE.local.md` committed
+- [ ] No secrets, tokens, or PII in diff / commit messages
+
+## Context
+
+<!-- Issue number, design doc, or prior PR. -->

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ fuzz/target/
 .claude/
 investigation/
 PLAN.md
+CLAUDE.local.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to omamori
+
+Thank you for considering a contribution. omamori is a security product for
+AI-assisted development environments, so supply-chain integrity and small,
+reviewable changes matter more than raw throughput.
+
+---
+
+## Branch naming
+
+Use these prefixes. The PR template will remind you.
+
+| Prefix       | Purpose                                                |
+|--------------|--------------------------------------------------------|
+| `feat/*`     | New feature or behavior change                         |
+| `fix/*`      | Bug fix (no behavior change for correct inputs)        |
+| `docs/*`     | Documentation only                                     |
+| `refactor/*` | Internal refactor (no behavior change)                 |
+| `ci/*`       | CI/CD or tooling changes                               |
+| `security/*` | Security fix or hardening                              |
+
+### `feature/*` → `feat/*` migration
+
+`feature/*` was the historical prefix. Starting with v0.9.3, new branches MUST
+use `feat/*`. Existing `feature/*` branches are accepted until **2026-05-15**
+to let in-flight PRs land naturally. After that cutoff the maintainer may
+prune or rename any remaining `feature/*` branches, and `feat/*` enforcement
+may be promoted from PR-template checklist to a repository ruleset.
+
+---
+
+## Repository Layout & Automation
+
+| Path / File                         | What it does                                                   |
+|-------------------------------------|----------------------------------------------------------------|
+| `Cargo.toml` `include=` / `exclude=` | Deny-by-default allowlist of files packaged to crates.io      |
+| `Cargo.lock` (tracked, v0.9.3+)     | Reproducible builds for consumers of `cargo install --locked`  |
+| `rust-toolchain.toml`               | Pins stable toolchain for dev + non-fuzz CI jobs               |
+| `.github/workflows/ci.yml`          | Test, clippy, fmt, MSRV, coverage, guard jobs                  |
+| `.github/workflows/fuzz.yml`        | Nightly fuzz (reproducibility NOT guaranteed — corpus is non-deterministic) |
+| `.github/dependabot.yml`            | Weekly grouped bumps for cargo + github-actions                |
+| `.github/CODEOWNERS`                | Ownership review hint for security-critical paths              |
+| `.editorconfig` / `.gitattributes`  | Line-ending + whitespace normalization                         |
+| `SECURITY.md`                       | Security model + AI-assisted contribution invariants           |
+| `scripts/pre-pr-check.sh`           | Local gate (fmt / clippy / test, all `--locked`)               |
+| `scripts/pre-release-check.sh`      | Release gate (clean tree / tag match / package listing / dry-run) |
+
+---
+
+## GitHub Actions SHA pinning
+
+Every `uses:` in `.github/workflows/*.yml` MUST be pinned to a 40-character
+commit SHA with a trailing `# vX.Y.Z` comment, e.g.
+
+```yaml
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+```
+
+Dependabot updates both the SHA and the version comment automatically. Floating
+tags (`@v4`, `@main`) are rejected by the `action-pin-check` CI job.
+
+---
+
+## Before opening a PR
+
+Run the local gate once. It is a thin wrapper around the CI jobs, with
+`--locked` on every `cargo` invocation so a stale `Cargo.lock` fails fast.
+
+```bash
+./scripts/pre-pr-check.sh
+```
+
+If `Cargo.lock` was updated during the run, commit it. Do not pass
+`--allow-dirty` or `--no-verify` to `cargo` or `git`.
+
+---
+
+## Releasing (maintainer only)
+
+1. Bump `Cargo.toml` `version`.
+2. Update `CHANGELOG.md`.
+3. Run `./scripts/pre-release-check.sh` — this verifies a clean tree, the tag
+   (once created) matches `Cargo.toml`, nothing forbidden appears in the
+   package listing, and `cargo publish --dry-run --locked` passes.
+4. `git tag vX.Y.Z && git push --tags`.
+5. `cargo publish --locked` (never `--allow-dirty`).
+6. Update the homebrew-tap formula.
+
+See `.claude/plans/` for design notes on prior releases.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -504,3 +504,34 @@ Entries written before v0.7.0 lack chain fields. When `append()` encounters a le
 | Chain structure (prev_hash linkage) | Via `--json` only | Machine consumers need full provenance for forensics/SIEM. HMAC protection means chain fields cannot be forged without secret |
 
 **Recommendation**: Run `omamori audit verify` directly in a terminal, not through an AI agent. AI agents can read stdout and may misrepresent results to the user.
+
+## AI-assisted Contribution Invariants (v0.9.3+)
+
+omamori is developed with AI coding assistants (Claude Code / Codex). That
+convenience creates an attack surface: an AI that subtly weakens supply-chain
+defenses inside an otherwise innocent refactoring PR can bypass the product's
+own philosophy.
+
+These five invariants are **load-bearing**. A PR that removes or neutralizes
+any of them SHOULD be rejected. If a future proposal argues for loosening one,
+treat it as a security change (separate RFC, human review, not an AI-batched
+cleanup).
+
+**Enforcement state (v0.9.3 series)**: the invariants are introduced across
+six PRs (PR1 policy -> PR6 release). Until the corresponding CI job listed
+below is live, reviewers MUST enforce the rule manually. The `Intended CI
+check` column describes the mechanism that becomes authoritative once v0.9.3
+ships; before that, the column is a specification, not an existing guarantee.
+
+| # | Invariant | Why it matters | Intended CI check (v0.9.3) |
+|---|-----------|----------------|-----------------------------|
+| 1 | `Cargo.lock` is tracked | `cargo install omamori --locked` must reproduce the exact dependency graph for consumers. An untracked lockfile makes release binaries non-reproducible and hides transitive-dep drift. | `invariants-check` job asserts `git ls-files Cargo.lock` is non-empty (added in PR2/PR3) |
+| 2 | Every `uses:` in `.github/workflows/*.yml` is pinned to a 40-char SHA | Moving tags (`@v4`, `@main`) let a compromised action execute with our repo secrets (incl. `CARGO_REGISTRY_TOKEN`). SHA pinning shrinks this to SHA-1 collision difficulty. | `action-pin-check` regex match on `@[0-9a-f]{40}` (added in PR3) |
+| 3 | `.gitignore` retains entries for `.claude/`, `investigation/`, `CLAUDE.local.md`, `target/`, `.env`, `.env.*` | These paths hold AI-agent context, private notes, and credentials. Removing an ignore rule risks accidental `git add` and subsequent crate/tarball inclusion. | `invariants-check` greps for required entries as fixed strings (added in PR3) |
+| 4 | `Cargo.toml` has an `include = [...]` allowlist | Deny-by-default is the structural defense against "a stray tracked file leaks to crates.io". `exclude=` alone is reactive — it only blocks what you already thought of. | `invariants-check` parses `include=` array (added in PR3, populated in PR5) |
+| 5 | CI jobs and release scripts always pass `--locked` to cargo | Without `--locked`, a fresh CI run can silently pick a newer transitive dep than the lockfile records, masking reproducibility bugs and dependency-confusion issues. | `pre-release-check.sh` runs `cargo ... --locked`; CI audit is manual review plus the `invariants-check` job (added in PR3) |
+
+An AI-generated PR that proposes loosening any of these (e.g. "move
+`Cargo.lock` to `.gitignore` for convenience", "pin at `@v4` instead of SHA",
+"drop `--locked` to speed up CI") is a supply-chain regression, not a
+quality-of-life change, and must be handled as such.

--- a/scripts/pre-pr-check.sh
+++ b/scripts/pre-pr-check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Local gate run before opening a PR.
+# Mirrors the CI jobs, with `--locked` on every cargo invocation so a stale
+# Cargo.lock fails here instead of in CI.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> cargo fmt --all -- --check"
+cargo fmt --all -- --check
+
+echo "==> cargo clippy --all-targets --all-features --locked -- -D warnings"
+cargo clippy --all-targets --all-features --locked -- -D warnings
+
+echo "==> cargo test --all-features --locked"
+cargo test --all-features --locked
+
+echo
+echo "pre-pr-check: OK"

--- a/scripts/pre-release-check.sh
+++ b/scripts/pre-release-check.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Release gate. Run after bumping Cargo.toml + CHANGELOG.md and before
+# `git tag` / `cargo publish`. Fails fast on anything that would poison a
+# crates.io release.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+FAIL=0
+warn()  { echo "WARN:  $*"; }
+fail()  { echo "ERROR: $*"; FAIL=1; }
+
+# 1. clean working tree
+if [ -n "$(git status --porcelain)" ]; then
+    fail "working tree is dirty (run 'git status'); refusing to release"
+fi
+
+# 2. Cargo.toml version vs. latest tag (if any)
+VERSION="$(grep -E '^version = ' Cargo.toml | head -1 | sed -E 's/version = "(.*)"/\1/')"
+if [ -z "$VERSION" ]; then
+    fail "could not read version from Cargo.toml"
+else
+    echo "Cargo.toml version: $VERSION"
+    LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+    if [ -n "$LATEST_TAG" ] && [ "v$VERSION" != "$LATEST_TAG" ]; then
+        warn "Cargo.toml is v$VERSION but latest tag is $LATEST_TAG — remember to tag v$VERSION before publishing"
+    fi
+fi
+
+# 3. package listing: no forbidden files should ship to crates.io.
+#
+# NOTE (v0.9.3 transition): This is a denylist, which has structural false
+# negatives — it only blocks what we thought of. PR5 replaces this with an
+# allowlist strategy driven by `Cargo.toml` `include = [...]`, at which point
+# this regex becomes a belt-and-suspenders layer over deny-by-default.
+# Until then, this list expands to cover governance files that are currently
+# tracked but do not belong in the crate tarball.
+FORBIDDEN_REGEX='^(\.claude/|investigation/|\.github/|PLAN\.md$|ACCEPTANCE_TEST\.md$|demo\.svg$|CLAUDE\.local\.md$|omamori-test-sandbox/|fuzz/|\.editorconfig$|\.gitattributes$|CONTRIBUTING\.md$|scripts/)'
+if ! PKG_LIST="$(cargo package --list --locked 2>&1)"; then
+    fail "cargo package --list failed:"
+    echo "$PKG_LIST"
+else
+    if LEAKED="$(echo "$PKG_LIST" | grep -E "$FORBIDDEN_REGEX" || true)"; [ -n "$LEAKED" ]; then
+        fail "forbidden paths in package listing:"
+        echo "$LEAKED"
+    fi
+fi
+
+# 4. dry-run publish (uses the same --locked discipline)
+echo "==> cargo publish --dry-run --locked"
+if ! cargo publish --dry-run --locked; then
+    fail "cargo publish --dry-run --locked failed"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+    echo
+    echo "pre-release-check: FAIL"
+    exit 1
+fi
+
+echo
+echo "pre-release-check: OK"


### PR DESCRIPTION
## Summary

PR1/6 of the v0.9.3 supply-chain hardening series (issue #147). Lays the
policy + tooling groundwork that PR2-PR6 make mechanically enforceable.

- **CODEOWNERS** — default owner + explicit security-critical paths (audit/,
  engine/, policy/detector/config/context, release surface)
- **.editorconfig / .gitattributes** — line-ending normalization + export-ignore
  for developer-only trees (`.claude/`, `investigation/`, fuzz corpus, ...)
- **PULL_REQUEST_TEMPLATE.md** — Change Type / CI / Security checklists with
  the **2026-05-15** `feat/*` migration cutoff
- **CONTRIBUTING.md** — branch ladder, repository/automation map, SHA pin
  rule, pre-pr-check workflow, `feat/feature` migration policy
- **SECURITY.md** — new *AI-assisted Contribution Invariants (v0.9.3+)*
  section. Five load-bearing invariants framed as **intended** CI checks that
  become authoritative as v0.9.3 lands (NOT claimed as already-existing)
- **scripts/pre-pr-check.sh** — local gate (fmt / clippy / test, all `--locked`)
- **scripts/pre-release-check.sh** — release gate with denylist flagged as
  transitional until PR5 installs the `include=` allowlist
- **.gitignore** — add `CLAUDE.local.md` to satisfy invariant #3

## Dependencies

Standalone. PR2-PR6 depend on this (and on each other in order).

## Notes

- No code or CI-job changes in this PR. Behavior of existing jobs is
  unchanged; new scripts are opt-in until PR2 wires them.
- Addresses Codex adversarial-review findings (5/5 resolved): SECURITY.md
  re-framed from "exists" to "intended"; `pre-release-check.sh` denylist
  expanded with a transitional-note; `.gitignore` `CLAUDE.local.md` added;
  CODEOWNERS adds policy/detector/config/context modules; PR template
  mirrors the 2026-05-15 cutoff.

## Test plan

- [ ] CI green on this branch
- [ ] `shellcheck` / `bash -n` on the two new scripts (local `bash -n` already passes)
- [ ] Render CONTRIBUTING.md, CODEOWNERS, SECURITY.md on GitHub and eyeball for formatting
- [ ] Open a dummy PR against this branch to see the new PR template render

🤖 Generated with [Claude Code](https://claude.com/claude-code)