### PR TITLE
feat: v093 PR3 SHA pin + permissions + Dependabot + invariants gate (issue #147)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+
+# Weekly grouped updates. Minor + patch bumps are grouped into a single PR
+# per ecosystem to keep PR volume manageable; major bumps come as separate
+# PRs for individual review.
+#
+# The `github-actions` ecosystem also updates the SHA pins introduced in
+# v0.9.3 PR3 and rewrites the trailing `# vX.Y.Z` comment.
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: cargo
+    directory: /fuzz
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 3
+    groups:
+      fuzz-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,100 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default. Jobs that need to write (e.g. upload artifacts,
+# publish releases) must override this explicitly — none currently do.
+permissions:
+  contents: read
+
+# action-pin-check is a *gate*: every job below declares `needs: action-pin-check`
+# so no third-party action executes until its pinning has been validated
+# (see Codex adversarial-review finding H1 on PR3).
 jobs:
+  action-pin-check:
+    name: Action pin check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Verify every uses ref is SHA-pinned
+        run: ./scripts/check-action-pins.sh
+
+  invariants-check:
+    name: Invariants check
+    runs-on: ubuntu-latest
+    needs: action-pin-check
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Enforce SECURITY.md AI-assisted contribution invariants
+        run: |
+          set -euo pipefail
+          fail=0
+
+          # Invariant #1: Cargo.lock is tracked.
+          if [ -z "$(git ls-files Cargo.lock)" ]; then
+              echo "FAIL [invariant #1]: Cargo.lock is not tracked"
+              fail=1
+          fi
+
+          # Invariant #3: required paths are EFFECTIVELY ignored — probe with
+          # `git check-ignore` rather than grep so a later `!pattern` negation
+          # cannot silently disable an ignore rule.
+          probes=(
+              ".claude/probe.md"
+              "investigation/probe.md"
+              "CLAUDE.local.md"
+              "target/probe"
+              ".env"
+              ".env.local"
+          )
+          for probe in "${probes[@]}"; do
+              if ! git check-ignore -q "$probe"; then
+                  echo "FAIL [invariant #3]: $probe is NOT effectively ignored (check .gitignore + negation rules)"
+                  fail=1
+              fi
+          done
+
+          # Invariant #4: Cargo.toml has an include= allowlist (added in PR5).
+          # Until PR5 lands, this is WARN-only; it flips to FAIL once include=
+          # appears in Cargo.toml.
+          if grep -Eq '^include[[:space:]]*=' Cargo.toml; then
+              echo "#4 OK: Cargo.toml has include= allowlist"
+          else
+              echo "WARN [invariant #4]: Cargo.toml has no include= yet (expected before v0.9.3 release; enforced in PR5)"
+          fi
+
+          # Invariant #5: representative --locked usage in workflows.
+          if ! grep -q 'cargo test --locked' .github/workflows/ci.yml; then
+              echo "FAIL [invariant #5]: cargo test must use --locked"
+              fail=1
+          fi
+          if ! grep -q 'cargo publish --dry-run --locked' .github/workflows/ci.yml; then
+              echo "FAIL [invariant #5]: cargo publish --dry-run must use --locked"
+              fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+              echo
+              echo "invariants-check: FAIL"
+              exit 1
+          fi
+          echo "invariants-check: OK"
+
   test:
     name: Test
     runs-on: macos-latest
+    needs: action-pin-check
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - run: cargo test --locked
 
   clippy:
     name: Clippy
     runs-on: macos-latest
+    needs: action-pin-check
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: clippy
       - run: cargo clippy --locked -- -D warnings
@@ -31,9 +110,10 @@ jobs:
   fmt:
     name: Format
     runs-on: macos-latest
+    needs: action-pin-check
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -41,17 +121,19 @@ jobs:
   publish-dry-run:
     name: Publish dry-run
     runs-on: macos-latest
+    needs: action-pin-check
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - run: cargo publish --dry-run --locked
 
   msrv:
     name: MSRV check
     runs-on: macos-latest
+    needs: action-pin-check
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           toolchain: "1.92"
       - run: cargo +1.92 check --locked
@@ -59,16 +141,17 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    needs: action-pin-check
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Generate coverage
         run: cargo tarpaulin --locked --out xml --skip-clean
       - name: Upload to Codecov
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: cobertura.xml
           fail_ci_if_error: false
@@ -76,17 +159,19 @@ jobs:
   lockfile-sanity:
     name: Lockfile sanity
     runs-on: ubuntu-latest
+    needs: action-pin-check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # need origin/main as base for regression check
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: Detect direct-dep downgrades
         run: ./scripts/check-lockfile-regressions.sh origin/main
 
   audit:
     name: Security audit
     runs-on: ubuntu-latest
+    needs: action-pin-check
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/audit@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24 # v1.2.7

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,18 +16,33 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
+  # Mirrors ci.yml's action-pin-check so the fuzz workflow's third-party
+  # actions cannot execute until their pinning has been validated. Both
+  # sentinels share scripts/check-action-pins.sh.
+  action-pin-check:
+    name: Action pin check (fuzz)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Verify every uses ref is SHA-pinned
+        run: ./scripts/check-action-pins.sh
+
   fuzz:
     name: Fuzz (${{ matrix.target }})
     runs-on: ubuntu-latest
+    needs: action-pin-check
     strategy:
       fail-fast: false
       matrix:
         target: [fuzz_unwrap, fuzz_hook_input, fuzz_check_command]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           toolchain: nightly
 
@@ -47,7 +62,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: fuzz-crash-${{ matrix.target }}
           path: fuzz/artifacts/${{ matrix.target }}/

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# check-action-pins.sh
+#
+# Verify that every `uses:` reference in .github/workflows/*.yml is pinned
+# to a 40-character commit SHA. Invoked by the `action-pin-check` job in
+# ci.yml and the sentinel job in fuzz.yml.
+#
+# Why YAML-aware (not grep):
+#   A grep over raw text cannot distinguish the SHA of an actual `uses:`
+#   ref from a 40-hex substring inside a comment. `yq` extracts the
+#   parsed `uses:` value itself, so `@v4 # @<40hex>` is correctly rejected.
+#
+# Covers:
+#   - step-level: `.jobs[*].steps[*].uses`
+#   - job-level (reusable workflow invocation): `.jobs[*].uses`
+#
+# Accepts:
+#   - `owner/name@<40-hex>` (e.g. `actions/checkout@34e1...`)
+#   - `owner/name/subpath@<40-hex>` (monorepo actions)
+#   - local composite actions: `./path` or `../path`
+#
+# Preinstalled on GitHub-hosted runners. Locally: `brew install yq`.
+
+set -euo pipefail
+
+if ! command -v yq >/dev/null 2>&1; then
+    echo "ERROR: yq is required (preinstalled on GitHub runners; 'brew install yq' locally)"
+    exit 2
+fi
+
+SHA_RE='^[A-Za-z0-9._-]+/[A-Za-z0-9._/-]+@[0-9a-f]{40}$'
+LOCAL_RE='^\.\.?/'
+
+fail=0
+
+for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [ -f "$wf" ] || continue
+
+    # Collect step-level and job-level `uses:` values.
+    refs="$(
+        {
+            yq eval '.jobs[].steps[]? | .uses // ""' "$wf" 2>/dev/null
+            yq eval '.jobs[] | .uses // ""' "$wf" 2>/dev/null
+        } | grep -v '^$' || true
+    )"
+
+    while IFS= read -r ref; do
+        [ -z "$ref" ] && continue
+        # Local composite actions are allowed (no remote ref).
+        if [[ "$ref" =~ $LOCAL_RE ]]; then
+            continue
+        fi
+        if ! [[ "$ref" =~ $SHA_RE ]]; then
+            echo "FAIL: $wf: unpinned or malformed uses ref: $ref"
+            fail=1
+        fi
+    done <<<"$refs"
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo
+    echo "check-action-pins: FAIL — every uses: MUST be owner/name[/path]@<40-hex>"
+    exit 1
+fi
+
+echo "check-action-pins: OK"


### PR DESCRIPTION
## Summary

PR3/6 of the v0.9.3 supply-chain hardening series (#147). Moves invariants
#2 (SHA pin) and #3 (.gitignore effective) from *intended* to *mechanically
enforced*, and turns action-pin validation from a parallel sibling job into
an actual gate.

- **ci.yml / fuzz.yml**: every `uses:` now pinned to a 40-char SHA with a
  `# vX.Y.Z` trailing comment. SHAs resolved from `gh api releases/latest`
  + `matching-refs/tags`, scoped to the currently-used major version
  (no opportunistic major bumps).
- **Top-level `permissions: contents: read`** on both workflows.
- **`action-pin-check` is now a gate**: every job declares
  `needs: action-pin-check`, so no third-party action can execute until
  pinning has been validated.
- **scripts/check-action-pins.sh**: YAML-aware validator. Covers step-level
  (`.jobs[*].steps[*].uses`) and job-level (`.jobs[*].uses` / reusable
  workflows) — and matches SHA on the *parsed* ref, so `@v4 # @<40hex>`
  can't false-pass like the grep version would have.
- **invariants-check**: rewritten to probe invariant #3 with
  `git check-ignore -q <probe>` on representative paths, so a later
  `!pattern` negation can't silently disable an ignore.
- **dependabot.yml**: weekly grouped minor/patch bumps for cargo (root
  and `/fuzz`) + github-actions. Dependabot will keep the SHA pins and
  their `# vX.Y.Z` comments current automatically.

## Dependencies

Depends on PR2 (merged). This PR makes invariant #2 and #3 *actually*
enforced; invariant #4 remains WARN-only and becomes hard-fail in PR5.

## Notes

Addresses Codex adversarial-review findings (3/3 resolved):
- H1 (race condition before pin validation) → `needs:` DAG gate
- H2 (grep over raw text false-passes SHA-looking comments) → yq parse
- M3 (text-only .gitignore check misses `!pattern` negation) → `git check-ignore`

### SHA pin table

| Action | SHA | Tag |
|--------|-----|-----|
| actions/checkout | `34e11487...` | v4.3.1 |
| actions-rust-lang/setup-rust-toolchain | `2b1f5e9b...` | v1.16.0 |
| codecov/codecov-action | `b9fd7d16...` | v4.6.0 |
| actions-rust-lang/audit | `72c09e02...` | v1.2.7 |
| actions/upload-artifact | `ea165f8d...` | v4.6.2 |

## Test plan

- [ ] CI green on this branch (note: `action-pin-check` must pass BEFORE
  all other jobs start — visible in the Actions tab DAG)
- [ ] `invariants-check` passes with its new `git check-ignore` probes
- [ ] Dependabot picks up the config on the next schedule (Mon 09:00 JST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)