### PR TITLE
feat: v093 PR4 cargo install version pinning (issue #147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        # Pin cargo-tarpaulin via taiki-e/install-action. `fallback: none`
+        # disables the silent fallback-to-`cargo install`, so a registry
+        # hiccup cannot cause the job to silently build an unpinned binary.
+        uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # v2.75.16
+        with:
+          tool: cargo-tarpaulin@0.35.2
+          fallback: none
       - name: Generate coverage
         run: cargo tarpaulin --locked --out xml --skip-clean
       - name: Upload to Codecov

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -47,7 +47,11 @@ jobs:
           toolchain: nightly
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        # taiki-e/install-action does not currently ship cargo-fuzz binaries,
+        # so we fall back to `cargo install` with an explicit --locked --version
+        # pin. This keeps the supply-chain policy auditable (exact version,
+        # locked deps) without a silent registry fallback path.
+        run: cargo install --locked --version 0.13.1 cargo-fuzz
 
       - name: Run fuzz target (${{ matrix.target }})
         run: |


### PR DESCRIPTION
## Summary

PR4/6 of the v0.9.3 supply-chain hardening series (#147). Closes the last
silent \`cargo install\` path in CI.

- **ci.yml — cargo-tarpaulin**: replace \`cargo install cargo-tarpaulin\`
  with \`taiki-e/install-action@v2.75.16\` + \`tool: cargo-tarpaulin@0.35.2\`
  + **\`fallback: none\`**. \`fallback: none\` is the safety bit — it
  prevents the action from silently building an unpinned binary when
  the prebuilt mirror is missing.
- **fuzz.yml — cargo-fuzz**: taiki-e does not ship cargo-fuzz binaries,
  so we pin directly with \`cargo install --locked --version 0.13.1 cargo-fuzz\`.

## Pin provenance

| Tool / Action | Pin | Source |
|---|---|---|
| taiki-e/install-action | \`a2352fc6...\` # v2.75.16 | \`gh api repos/taiki-e/install-action/git/ref/tags/v2.75.16\` (annotated-tag dereferenced) |
| cargo-tarpaulin | 0.35.2 | crates.io max_stable_version |
| cargo-fuzz | 0.13.1 | crates.io max_stable_version |

## Dependencies

Depends on PR3 (merged). \`action-pin-check\` now validates the new
\`taiki-e/install-action\` SHA as part of its regular sweep.

## Notes

- Codex adversarial-review verdict: **approve** (no material findings).
- Confirmed: \`tool:\` is the correct input key; \`fallback: none\` is a
  valid setting; \`cargo install --version X.Y.Z\` is an exact pin (no \`=\` needed).

## Test plan

- [ ] CI green on this branch (note: Coverage job now runs through
  taiki-e/install-action instead of \`cargo install\`)
- [ ] action-pin-check picks up the new taiki-e SHA and passes
- [ ] Fuzz PR trigger (on changes under \`src/**\` or \`fuzz/**\`) uses
  the new \`--version 0.13.1\` pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)