### PR TITLE
feat: v093 PR5 artifact leakage guard (issue #147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,59 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Enforce SECURITY.md AI-assisted contribution invariants
-        run: |
-          set -euo pipefail
-          fail=0
-
-          # Invariant #1: Cargo.lock is tracked.
-          if [ -z "$(git ls-files Cargo.lock)" ]; then
-              echo "FAIL [invariant #1]: Cargo.lock is not tracked"
-              fail=1
-          fi
-
-          # Invariant #3: required paths are EFFECTIVELY ignored — probe with
-          # `git check-ignore` rather than grep so a later `!pattern` negation
-          # cannot silently disable an ignore rule.
-          probes=(
-              ".claude/probe.md"
-              "investigation/probe.md"
-              "CLAUDE.local.md"
-              "target/probe"
-              ".env"
-              ".env.local"
-          )
-          for probe in "${probes[@]}"; do
-              if ! git check-ignore -q "$probe"; then
-                  echo "FAIL [invariant #3]: $probe is NOT effectively ignored (check .gitignore + negation rules)"
-                  fail=1
-              fi
-          done
-
-          # Invariant #4: Cargo.toml has an include= allowlist (added in PR5).
-          # Until PR5 lands, this is WARN-only; it flips to FAIL once include=
-          # appears in Cargo.toml.
-          if grep -Eq '^include[[:space:]]*=' Cargo.toml; then
-              echo "#4 OK: Cargo.toml has include= allowlist"
-          else
-              echo "WARN [invariant #4]: Cargo.toml has no include= yet (expected before v0.9.3 release; enforced in PR5)"
-          fi
-
-          # Invariant #5: representative --locked usage in workflows.
-          if ! grep -q 'cargo test --locked' .github/workflows/ci.yml; then
-              echo "FAIL [invariant #5]: cargo test must use --locked"
-              fail=1
-          fi
-          if ! grep -q 'cargo publish --dry-run --locked' .github/workflows/ci.yml; then
-              echo "FAIL [invariant #5]: cargo publish --dry-run must use --locked"
-              fail=1
-          fi
-
-          if [ "$fail" -ne 0 ]; then
-              echo
-              echo "invariants-check: FAIL"
-              exit 1
-          fi
-          echo "invariants-check: OK"
+        run: ./scripts/check-invariants.sh
 
   test:
     name: Test
@@ -173,6 +121,16 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: Detect direct-dep downgrades
         run: ./scripts/check-lockfile-regressions.sh origin/main
+
+  crate-contents-guard:
+    name: Crate contents guard
+    runs-on: ubuntu-latest
+    needs: action-pin-check
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+      - name: Verify crate tarball contents
+        run: ./scripts/check-crate-contents.sh
 
   audit:
     name: Security audit

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -70,3 +70,7 @@ jobs:
         with:
           name: fuzz-crash-${{ matrix.target }}
           path: fuzz/artifacts/${{ matrix.target }}/
+          # Crash samples can reveal unpublished bugs; cap retention so a
+          # stale run does not advertise an open vulnerability indefinitely
+          # (security threat-model T9/M8 — accepted risk with 7-day cap).
+          retention-days: 7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,33 @@ categories = ["command-line-utilities", "development-tools"]
 authors = ["Iori Yoshida <yotta@users.noreply.github.com>"]
 readme = "README.md"
 
+# v0.9.3+ supply-chain policy (SECURITY.md invariants #4).
+#
+# `include` is a deny-by-default allowlist: only these paths ship in the
+# crate tarball uploaded to crates.io. Anything not listed — including
+# everything under `.claude/`, `investigation/`, `.github/`, `scripts/`,
+# `rust-toolchain.toml`, `CONTRIBUTING.md`, `demo.svg`, etc. — is
+# structurally excluded, regardless of whether it happens to be tracked
+# by git.
+#
+# Note on `exclude`: cargo ignores `exclude` whenever `include` is also
+# specified ("both package.include and package.exclude are specified;
+# the exclude list will be ignored"), so `include` is the single source
+# of truth here. `crate-contents-guard` in ci.yml is the defense-in-depth
+# layer that catches accidental widening of `include`.
+include = [
+    "src/**/*.rs",
+    "tests/**/*.rs",
+    "Cargo.toml",
+    "Cargo.lock",
+    "README.md",
+    "CHANGELOG.md",
+    "SECURITY.md",
+    "LICENSE-MIT",
+    "LICENSE-APACHE",
+    "config.default.toml",
+]
+
 [dependencies]
 libc = "0.2.183"
 serde = { version = "1.0", features = ["derive"] }

--- a/scripts/check-crate-contents.sh
+++ b/scripts/check-crate-contents.sh
@@ -45,11 +45,11 @@ ALLOWED_PATTERNS=(
     '^tests/[A-Za-z0-9_/-]+\.rs$'
 )
 
-list_out="$(cargo package --list --locked --allow-dirty 2>&1)"
-list_rc=$?
-if [ "$list_rc" -ne 0 ]; then
-    echo "ERROR: cargo package --list failed (rc=$list_rc):"
-    echo "$list_out"
+# Capture ONLY stdout — cargo writes progress (`Updating crates.io index`,
+# `Compiling ...`) to stderr, and mixing it in makes those lines look like
+# package paths to the allowlist check.
+if ! list_out="$(cargo package --list --locked --allow-dirty)"; then
+    echo "ERROR: cargo package --list failed"
     exit 1
 fi
 

--- a/scripts/check-crate-contents.sh
+++ b/scripts/check-crate-contents.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# check-crate-contents.sh
+#
+# Defense-in-depth layer over Cargo.toml `include = [...]` allowlist. Runs
+# `cargo package --list --locked` and verifies the output is a subset of a
+# known-good allowlist. Also rejects binary-looking files.
+#
+# Role: even with cargo's own `include =` as the primary structural
+# defense, a future PR could widen the allowlist (e.g. `"**"`). This
+# guard is the circuit breaker. It is intentionally strict — any path
+# that is not *explicitly* expected fails the build, not just paths on
+# the old denylist.
+#
+# The --allow-dirty is intentional when invoked from CI (the checkout
+# tree is always clean) but kept so the script is runnable mid-edit
+# locally.
+
+set -euo pipefail
+# pipefail is essential: a broken `cargo package --list` must not silently
+# become an empty list that then "passes" a subset check.
+set -o pipefail
+
+cd "$(dirname "$0")/.."
+
+# Exact filenames that are always OK to ship.
+# Cargo.toml.orig and .cargo_vcs_info.json are cargo-generated.
+ALLOWED_EXACT=(
+    ".cargo_vcs_info.json"
+    "Cargo.toml"
+    "Cargo.toml.orig"
+    "Cargo.lock"
+    "README.md"
+    "CHANGELOG.md"
+    "SECURITY.md"
+    "LICENSE-MIT"
+    "LICENSE-APACHE"
+    "config.default.toml"
+)
+
+# Path patterns (bash regex) for whole subtrees that are OK.
+# Deliberately narrow — no `.*` at the root; every entry anchors a specific
+# directory that belongs in a published crate.
+ALLOWED_PATTERNS=(
+    '^src/[A-Za-z0-9_/-]+\.rs$'
+    '^tests/[A-Za-z0-9_/-]+\.rs$'
+)
+
+list_out="$(cargo package --list --locked --allow-dirty 2>&1)"
+list_rc=$?
+if [ "$list_rc" -ne 0 ]; then
+    echo "ERROR: cargo package --list failed (rc=$list_rc):"
+    echo "$list_out"
+    exit 1
+fi
+
+# Read package list into an array. Avoid `mapfile` / `readarray` because
+# macOS ships bash 3.2 which lacks them; a plain while/read loop via
+# process substitution is fail-closed for us (set -e is in effect).
+pkg_files=()
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    pkg_files+=("$line")
+done < <(printf '%s\n' "$list_out")
+
+if [ "${#pkg_files[@]}" -eq 0 ]; then
+    echo "ERROR: cargo package --list returned empty output — refusing to pass"
+    exit 1
+fi
+
+fail=0
+
+is_allowed() {
+    local f="$1"
+    for a in "${ALLOWED_EXACT[@]}"; do
+        [ "$f" = "$a" ] && return 0
+    done
+    for p in "${ALLOWED_PATTERNS[@]}"; do
+        if [[ "$f" =~ $p ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+unexpected=()
+for f in "${pkg_files[@]}"; do
+    [ -z "$f" ] && continue
+    if ! is_allowed "$f"; then
+        unexpected+=("$f")
+        fail=1
+    fi
+done
+
+if [ "${#unexpected[@]}" -gt 0 ]; then
+    echo "FAIL: unexpected paths in crate tarball (not in allowlist):"
+    for f in "${unexpected[@]}"; do
+        echo "  $f"
+    done
+fi
+
+# Binary-file detection. For each file in the package that is a regular
+# file on disk, assert its MIME type is text/* (or cargo-generated json).
+for f in "${pkg_files[@]}"; do
+    [ -z "$f" ] && continue
+    case "$f" in
+        Cargo.toml.orig|.cargo_vcs_info.json) continue ;;
+    esac
+    [ -f "$f" ] || continue
+    mime="$(file --brief --mime "$f" 2>/dev/null || true)"
+    if [ -z "$mime" ]; then
+        echo "ERROR: could not determine MIME type for $f — refusing to pass"
+        fail=1
+        continue
+    fi
+    case "$mime" in
+        text/*|inode/x-empty*|application/json*) : ;;
+        *)
+            echo "FAIL: binary-looking file in crate: $f ($mime)"
+            fail=1
+            ;;
+    esac
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo
+    echo "crate-contents-guard: FAIL"
+    exit 1
+fi
+
+echo "crate-contents-guard: OK"
+echo
+echo "=== tarball contents (${#pkg_files[@]} files) ==="
+printf '%s\n' "${pkg_files[@]}"

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# check-invariants.sh
+#
+# Enforces SECURITY.md "AI-assisted Contribution Invariants (v0.9.3+)".
+# Runs in the `invariants-check` CI job. Exits non-zero on any violation.
+#
+# Why a standalone script (not inline in ci.yml):
+#   - Makes the check locally testable (same logic as CI).
+#   - Avoids Python-heredoc indent fragility inside YAML `run: |` blocks.
+#
+# Requirements:
+#   - Python 3.11+ (for `tomllib` in stdlib) — available on GitHub ubuntu-latest.
+#   - `git`.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# ---------- Invariant #1: Cargo.lock is tracked ----------
+if [ -z "$(git ls-files Cargo.lock)" ]; then
+    echo "FAIL [invariant #1]: Cargo.lock is not tracked"
+    fail=1
+else
+    echo "#1 OK: Cargo.lock is tracked"
+fi
+
+# ---------- Invariant #3: required paths are effectively ignored ----------
+# `git check-ignore -q` respects the full .gitignore hierarchy *including*
+# any `!pattern` negations, so a negation rule that silently disabled an
+# ignore would be caught here.
+probes=(
+    ".claude/probe.md"
+    "investigation/probe.md"
+    "CLAUDE.local.md"
+    "target/probe"
+    ".env"
+    ".env.local"
+)
+for probe in "${probes[@]}"; do
+    if ! git check-ignore -q "$probe"; then
+        echo "FAIL [invariant #3]: $probe is NOT effectively ignored"
+        fail=1
+    fi
+done
+echo "#3 OK: all required probes are effectively ignored"
+
+# ---------- Invariant #4: package.include exists ----------
+# TOML-aware check instead of grep: tolerates any formatting cargo accepts
+# and cannot be fooled by an `include =` line outside the `[package]` table.
+if ! python3 - <<'PYEOF'
+import sys, tomllib
+with open("Cargo.toml", "rb") as f:
+    data = tomllib.load(f)
+inc = data.get("package", {}).get("include")
+if not isinstance(inc, list) or len(inc) == 0:
+    print("FAIL [invariant #4]: package.include is missing or empty in Cargo.toml")
+    sys.exit(1)
+print(f"#4 OK: package.include has {len(inc)} entries")
+PYEOF
+then
+    fail=1
+fi
+
+# ---------- Invariant #5: representative --locked usage ----------
+if ! grep -q 'cargo test --locked' .github/workflows/ci.yml; then
+    echo "FAIL [invariant #5]: cargo test must use --locked"
+    fail=1
+fi
+if ! grep -q 'cargo publish --dry-run --locked' .github/workflows/ci.yml; then
+    echo "FAIL [invariant #5]: cargo publish --dry-run must use --locked"
+    fail=1
+fi
+echo "#5 OK: representative --locked invocations present"
+
+if [ "$fail" -ne 0 ]; then
+    echo
+    echo "invariants-check: FAIL"
+    exit 1
+fi
+
+echo
+echo "invariants-check: OK"

--- a/scripts/pre-release-check.sh
+++ b/scripts/pre-release-check.sh
@@ -29,13 +29,11 @@ fi
 
 # 3. package listing: no forbidden files should ship to crates.io.
 #
-# NOTE (v0.9.3 transition): This is a denylist, which has structural false
-# negatives — it only blocks what we thought of. PR5 replaces this with an
-# allowlist strategy driven by `Cargo.toml` `include = [...]`, at which point
-# this regex becomes a belt-and-suspenders layer over deny-by-default.
-# Until then, this list expands to cover governance files that are currently
-# tracked but do not belong in the crate tarball.
-FORBIDDEN_REGEX='^(\.claude/|investigation/|\.github/|PLAN\.md$|ACCEPTANCE_TEST\.md$|demo\.svg$|CLAUDE\.local\.md$|omamori-test-sandbox/|fuzz/|\.editorconfig$|\.gitattributes$|CONTRIBUTING\.md$|scripts/)'
+# As of v0.9.3 PR5, the primary structural defense is `Cargo.toml`
+# `include = [...]` — an allowlist applied by cargo itself. This denylist
+# is a belt-and-suspenders layer that catches accidental widening of the
+# allowlist (e.g. someone adding `"**"` to include).
+FORBIDDEN_REGEX='^(\.claude/|investigation/|\.github/|PLAN\.md$|ACCEPTANCE_TEST\.md$|demo\.svg$|CLAUDE\.local\.md$|omamori-test-sandbox/|fuzz/|\.editorconfig$|\.gitattributes$|\.gitignore$|CONTRIBUTING\.md$|scripts/|rust-toolchain\.toml$)'
 if ! PKG_LIST="$(cargo package --list --locked 2>&1)"; then
     fail "cargo package --list failed:"
     echo "$PKG_LIST"


### PR DESCRIPTION
## Summary

PR5/6 of the v0.9.3 supply-chain hardening series (#147). The **One-way
Door** PR: installs \`Cargo.toml include=\` as the structural defense
against developer-only files leaking to crates.io, plus a CI guard with
a strict allowlist as defense-in-depth. Flips SECURITY.md invariant #4
from WARN to FAIL.

### What ships in the tarball now (42 files, down from 58)

Allowed: \`src/**/*.rs\`, \`tests/**/*.rs\`, \`Cargo.{toml,lock}\`,
\`README.md\`, \`CHANGELOG.md\`, \`SECURITY.md\`, \`LICENSE-MIT\`,
\`LICENSE-APACHE\`, \`config.default.toml\` (plus cargo's own
\`Cargo.toml.orig\` and \`.cargo_vcs_info.json\`).

**Dropped**: \`.editorconfig\`, \`.gitattributes\`, \`.github/*\`,
\`scripts/*\`, \`rust-toolchain.toml\`, \`CONTRIBUTING.md\`,
\`demo.svg\`, \`ACCEPTANCE_TEST.md\`, \`.gitignore\`.

### Why \`exclude=\` was removed

cargo logs \`"both package.include and package.exclude are specified;
the exclude list will be ignored"\`. \`include=\` is authoritative when
present — exclude= was a plan-time assumption that does not match
cargo's actual behavior. Documented inline in Cargo.toml.

## V-006 positive test

Logged locally at \`investigation/2026-04-17-v093-artifact-guard-verification.md\`
(gitignored per invariant #3 — intentionally not in PR).

Summary:
- **Baseline** (include= authoritative): 42 files, all on allowlist. Guard: \`OK\`.
- **Deliberate misconfig** (\`.claude/**/*.md\` added to include=, fake \`.claude/verify.md\` sentinel created): guard enumerates 22 unexpected paths and exits non-zero.
- **Restore**: guard: \`OK\`.

## Dependencies

Depends on PR3 (\`action-pin-check\` gate, invariants-check framework) and PR4 (cargo install pinning). After this merges, invariant #4 is hard-FAIL on every PR.

## Notes

- Addresses Codex adversarial-review findings (3/3 resolved):
  - H1 (here-string fail-open) → process-substitution + explicit empty-list check; \`mapfile\` avoided for macOS bash 3.2 parity with the locally-runnable script.
  - M2 (partial denylist misses future dev-paths) → **strict allowlist**: exact filenames + narrow subtree regex. Unknown paths fail by default.
  - M3 (grep over Cargo.toml is TOML-agnostic) → \`python3 tomllib\` structural check for \`package.include\`.
- New CI job: \`crate-contents-guard\` (runs strict allowlist + binary MIME scan).
- \`fuzz.yml\`: \`retention-days: 7\` on upload-artifact (threat T9/M8 — cap stale crash samples).

## Test plan

- [ ] CI green on this branch, including the two new scripts invoked via CI:
  - \`invariants-check\` (now includes the hard-FAIL on \`package.include\`)
  - \`crate-contents-guard\` (strict allowlist)
- [ ] \`cargo publish --dry-run --locked\` still passes — all files needed for build + \`include_str!("../config.default.toml")\` are still in the allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)