### PR TITLE
chore: narrow dependabot github-actions to patch-only (#159)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,17 @@
 version: 2
 
-# Weekly grouped updates. Minor + patch bumps are grouped into a single PR
-# per ecosystem to keep PR volume manageable; major bumps come as separate
-# PRs for individual review.
+# Cargo ecosystems: weekly grouped minor+patch updates (unchanged).
+# GitHub Actions ecosystem (v0.9.4, #159): narrowed to monthly patch-only.
+# Major and minor bumps are ignored to cut PR noise from Actions upstream
+# release cadence.
+#
+# Security updates are NOT affected by this narrowing — per GitHub docs:
+# "There is no interaction between the settings specified in the
+#  dependabot.yml file and Dependabot security alerts" and
+# "ignore only affects version updates, not security updates. Security
+#  updates will always be created regardless of the ignore setting."
+# Security PRs operate under a separate internal limit of ten which cannot
+# be changed, independent of open-pull-requests-limit here.
 #
 # The `github-actions` ecosystem also updates the SHA pins introduced in
 # v0.9.3 PR3 and rewrites the trailing `# vX.Y.Z` comment.
@@ -39,13 +48,17 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
       time: "09:00"
       timezone: Asia/Tokyo
-    open-pull-requests-limit: 5
-    groups:
-      actions-minor-patch:
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
         update-types:
-          - minor
-          - patch
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+    groups:
+      actions-patch-only:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Narrow `.github/dependabot.yml` github-actions ecosystem to monthly patch-only updates. Cuts weekly major/minor bump PR noise (motivation PRs #152 #153 #154 closed in v0.9.3 cycle) without impacting security update reach. Fixes #159.

## Changes

- github-actions: `schedule.interval: weekly` → `monthly`
- github-actions: `open-pull-requests-limit: 5` → `2`
- github-actions: `ignore: version-update:semver-major` + `semver-minor` for `dependency-name: "*"`
- github-actions: group rename `actions-minor-patch` → `actions-patch-only` (`patterns: ["*"]`)
- cargo (`/`, `/fuzz`) ecosystems: unchanged

## Security updates are unaffected

Per GitHub documentation (verbatim quotes):

> "There is no interaction between the settings specified in the `dependabot.yml` file and Dependabot security alerts, other than the fact that alerts will be closed when related pull requests generated by Dependabot for security updates are merged."
> — [About Dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates)

> "`ignore` only affects *version* updates, not *security* updates. Security updates will always be created regardless of the `ignore` setting."
> "`update-types` only affects *version* updates, not *security* updates. Security updates will always be created regardless of the `update-types` setting."
> — [Controlling which dependencies get updated](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated)

> "Security updates have a separate, internal limit of ten open pull requests which cannot be changed."
> — [Configuration options for the dependabot.yml file](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

## Interpretation note

GitHub documentation discusses `ignore` / `update-types` across multiple pages. The `about-dependabot-security-updates` page's "no interaction" wording is the most direct statement; the `controlling-dependencies-updated` page explicitly reiterates it for both `ignore` and `update-types`. The `configuring-dependabot-security-updates` page further confirms independence by showing how to fully disable version updates (`open-pull-requests-limit: 0`) while keeping security updates flowing. No docs page contradicts this; the above direct quotes resolve the ambiguity in favor of independence.

## Expected behavior after merge

- Weekly action major/minor bumps from Dependabot stop (current rate: 5+ per week with auto-closes, target: 0 for major/minor)
- Monthly group PR for any github-actions patch-level updates (expected frequency: 0–1 per month given the small set of pinned actions in this repo)
- Security advisories on pinned actions will still trigger Dependabot security PRs, counted against the separate internal limit of ten (not `open-pull-requests-limit: 2`)

## Rollback criteria

Revert this PR if any of the following is observed within 90 days of merge:
- A published security advisory on a pinned action fails to produce a Dependabot PR (observable in the Dependabot alerts tab)
- A CVE in a Cargo dependency fails to route through the existing cargo ecosystem channel (this PR does not touch cargo — regression there would be unrelated)
- Any other signal that security alerts are being suppressed by this narrow version-update config

## Plan context

This is **PR1 of 5** in the v0.9.4 rollout (see `.claude/plans/atomic-herding-bengio.md`). Follow-ups:
- PR2a / PR2b: #121 (Linux CI matrix + hook integration test + invariants)
- PR3: `curl | bash` gap issue filing + `SECURITY.md` note
- PR4: chore: release v0.9.4 (CHANGELOG 3-tier + README Platform Support + version bump)

## Related

- Closes #159
- Motivation PRs (closed in v0.9.3 cycle): #152 #153 #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
