### PR TITLE
feat(ci): structural invariants for hook integration surface (#121)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,3 +25,20 @@
 /Cargo.toml          @yottayoshida
 /Cargo.lock          @yottayoshida
 /SECURITY.md         @yottayoshida
+
+# Security-critical test surface (v0.9.4+, #121 T10 mitigation)
+# A silently disabled or removed hook integration test becomes a blind spot
+# that AI agents can exploit. Explicit ownership here guarantees every PR
+# touching these paths surfaces for ownership review, complementing the
+# structural invariants enforced by scripts/check-invariants.sh.
+/tests/                        @yottayoshida
+/tests/hook_integration.rs     @yottayoshida
+/fuzz/fuzz_targets/            @yottayoshida
+
+# Invariant enforcer itself — if this file is weakened the whole gate collapses.
+/scripts/check-invariants.sh   @yottayoshida
+
+# Additional policy-adjacent sources (v0.9.4+)
+# src/unwrap.rs: command tokenization / PATH bypass detection — a regression
+# here silently widens the Allow surface without touching hook.rs or rules.rs.
+/src/unwrap.rs                 @yottayoshida

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -105,7 +105,9 @@ else
         echo "FAIL [invariant #6d]: $hi must have zero #[ignore] attributes"
         hi_fail=1
     fi
-    if grep -qF '#[cfg(target_os' "$hi"; then
+    # Strip single-line comments before matching so explanatory text like
+    # "// never add #[cfg(target_os)] here" doesn't trip the check.
+    if sed 's|//.*$||' "$hi" | grep -qF '#[cfg(target_os'; then
         echo "FAIL [invariant #6e]: $hi must not gate tests on target_os"
         hi_fail=1
     fi
@@ -128,21 +130,31 @@ if [ ! -f "$ih" ]; then
     echo "FAIL [invariant #7a]: $ih is missing"
     ih_fail=1
 else
-    if ! grep -qF 'pub fn render_hook_script' "$ih"; then
+    # Extract the body of `render_hook_script` so that matching fixture strings
+    # elsewhere in the file (e.g. test fixtures with `set -eu`) cannot satisfy
+    # the contract checks. The function spans from its `pub fn` line to the
+    # next top-level closing `}` at column 1.
+    fn_body=$(awk '
+        /^pub fn render_hook_script/ { inside=1 }
+        inside { print }
+        inside && /^}/ { exit }
+    ' "$ih")
+    if [ -z "$fn_body" ]; then
         echo "FAIL [invariant #7b]: render_hook_script function must exist in $ih"
         ih_fail=1
-    fi
-    if ! grep -qF 'cat | omamori hook-check' "$ih"; then
-        echo "FAIL [invariant #7c]: render_hook_script must pipe stdin through omamori hook-check"
-        ih_fail=1
-    fi
-    if ! grep -qF 'set -eu' "$ih"; then
-        echo "FAIL [invariant #7d]: render_hook_script must use set -eu"
-        ih_fail=1
-    fi
-    if ! grep -qF 'exit $?' "$ih"; then
-        echo "FAIL [invariant #7e]: render_hook_script must propagate exit code via exit \$?"
-        ih_fail=1
+    else
+        if ! printf '%s\n' "$fn_body" | grep -qF 'cat | omamori hook-check'; then
+            echo "FAIL [invariant #7c]: render_hook_script must pipe stdin through omamori hook-check"
+            ih_fail=1
+        fi
+        if ! printf '%s\n' "$fn_body" | grep -qF 'set -eu'; then
+            echo "FAIL [invariant #7d]: render_hook_script body must use set -eu"
+            ih_fail=1
+        fi
+        if ! printf '%s\n' "$fn_body" | grep -qF 'exit $?'; then
+            echo "FAIL [invariant #7e]: render_hook_script body must propagate exit code via exit \$?"
+            ih_fail=1
+        fi
     fi
 fi
 if [ "$ih_fail" -eq 0 ]; then
@@ -168,9 +180,20 @@ else
         "/scripts/check-invariants.sh"
         "/src/unwrap.rs"
     )
+    # Use awk to enforce: non-comment line, path is the first token, and at
+    # least one @owner follows. A bare `grep -F "$path"` would let comments,
+    # substring matches, or ownerless paths pass.
     for path in "${required_owners[@]}"; do
-        if ! grep -qF "$path" "$co"; then
-            echo "FAIL [invariant #8]: $co must include explicit owner for $path"
+        if ! awk -v p="$path" '
+            /^[[:space:]]*#/ { next }
+            $1 == p {
+                for (i = 2; i <= NF; i++) {
+                    if ($i ~ /^@/) { ok=1; exit }
+                }
+            }
+            END { exit !ok }
+        ' "$co"; then
+            echo "FAIL [invariant #8]: $co must include '$path' as a non-comment line with at least one @owner"
             co_fail=1
         fi
     done

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -74,6 +74,113 @@ if ! grep -q 'cargo publish --dry-run --locked' .github/workflows/ci.yml; then
 fi
 echo "#5 OK: representative --locked invocations present"
 
+# ---------- Invariant #6: hook integration test structural invariants (v0.9.4+, #121) ----------
+# Structural (not name-based): the hook integration suite must (a) exist,
+# (b) contain at least one test that spawns the hook script via /bin/sh,
+# (c) include both Decision::Allow and Decision::Block in its corpus,
+# (d) not use `#[ignore]`, (e) not gate on `#[cfg(target_os = ...)]`.
+# These shape checks complement the runtime Rust invariant
+# `corpus_includes_both_decisions` — if someone silently guts the corpus or
+# disables a test with `#[ignore]`, the gate here fails before the Rust
+# invariant even runs.
+hi=tests/hook_integration.rs
+hi_fail=0
+if [ ! -f "$hi" ]; then
+    echo "FAIL [invariant #6a]: $hi is missing"
+    hi_fail=1
+else
+    if ! grep -qF 'Command::new("/bin/sh")' "$hi"; then
+        echo "FAIL [invariant #6b]: $hi must spawn the hook script via /bin/sh"
+        hi_fail=1
+    fi
+    if ! grep -qF 'Decision::Allow' "$hi"; then
+        echo "FAIL [invariant #6c-allow]: $hi corpus must include Decision::Allow"
+        hi_fail=1
+    fi
+    if ! grep -qF 'Decision::Block' "$hi"; then
+        echo "FAIL [invariant #6c-block]: $hi corpus must include Decision::Block"
+        hi_fail=1
+    fi
+    if grep -Eq '^[[:space:]]*#\[ignore\]' "$hi"; then
+        echo "FAIL [invariant #6d]: $hi must have zero #[ignore] attributes"
+        hi_fail=1
+    fi
+    if grep -qF '#[cfg(target_os' "$hi"; then
+        echo "FAIL [invariant #6e]: $hi must not gate tests on target_os"
+        hi_fail=1
+    fi
+fi
+if [ "$hi_fail" -eq 0 ]; then
+    echo "#6 OK: hook integration suite has required structure"
+else
+    fail=1
+fi
+
+# ---------- Invariant #7: render_hook_script delegation contract (v0.9.4+, #121) ----------
+# The generated hook wrapper is the thin shell bridge between an AI tool and
+# `omamori hook-check`. If this shape drifts (e.g. `set -eu` dropped,
+# `cat | omamori hook-check` replaced, `exit $?` mutated), downstream tests
+# and the hook integration suite may still pass while the wrapper silently
+# stops enforcing policy. Pin the literal strings that make the contract.
+ih=src/installer.rs
+ih_fail=0
+if [ ! -f "$ih" ]; then
+    echo "FAIL [invariant #7a]: $ih is missing"
+    ih_fail=1
+else
+    if ! grep -qF 'pub fn render_hook_script' "$ih"; then
+        echo "FAIL [invariant #7b]: render_hook_script function must exist in $ih"
+        ih_fail=1
+    fi
+    if ! grep -qF 'cat | omamori hook-check' "$ih"; then
+        echo "FAIL [invariant #7c]: render_hook_script must pipe stdin through omamori hook-check"
+        ih_fail=1
+    fi
+    if ! grep -qF 'set -eu' "$ih"; then
+        echo "FAIL [invariant #7d]: render_hook_script must use set -eu"
+        ih_fail=1
+    fi
+    if ! grep -qF 'exit $?' "$ih"; then
+        echo "FAIL [invariant #7e]: render_hook_script must propagate exit code via exit \$?"
+        ih_fail=1
+    fi
+fi
+if [ "$ih_fail" -eq 0 ]; then
+    echo "#7 OK: render_hook_script contract intact"
+else
+    fail=1
+fi
+
+# ---------- Invariant #8: CODEOWNERS must explicitly list security-critical paths (v0.9.4+) ----------
+# `* @owner` would implicitly cover everything, but explicit entries guarantee
+# that future changes to the default line (e.g. adding a second owner or
+# removing the wildcard) cannot silently drop ownership on these paths.
+co=.github/CODEOWNERS
+co_fail=0
+if [ ! -f "$co" ]; then
+    echo "FAIL [invariant #8a]: $co is missing"
+    co_fail=1
+else
+    required_owners=(
+        "/tests/"
+        "/tests/hook_integration.rs"
+        "/fuzz/fuzz_targets/"
+        "/scripts/check-invariants.sh"
+        "/src/unwrap.rs"
+    )
+    for path in "${required_owners[@]}"; do
+        if ! grep -qF "$path" "$co"; then
+            echo "FAIL [invariant #8]: $co must include explicit owner for $path"
+            co_fail=1
+        fi
+    done
+fi
+if [ "$co_fail" -eq 0 ]; then
+    echo "#8 OK: CODEOWNERS includes required explicit paths"
+else
+    fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then
     echo
     echo "invariants-check: FAIL"


### PR DESCRIPTION
## Summary

Adds three structural invariants to `scripts/check-invariants.sh` and explicit CODEOWNERS entries for security-critical test and policy paths. This is **PR2b of 5** in the v0.9.4 rollout (see `.claude/plans/atomic-herding-bengio.md`). Completes plan SR-1 and SR-2; part of #121.

## Why shell-level gates on top of Rust tests

PR2a added `corpus_includes_both_decisions` as a runtime Rust invariant. That test protects against corpus hollowing but still requires `cargo test` to actually run. An attacker (human or AI agent) who proposes a PR that disables the whole hook integration suite with `#[ignore]` would make the Rust invariant never execute. These shell-level gates fire in the `invariants-check` job — a separate, cheap CI step that runs before the Rust test matrix. Defense in depth for omamori's core value: *an AI cannot disable its own watchdog*.

## New invariants

### #6: hook integration shape

`tests/hook_integration.rs` must:
- exist
- spawn the hook script via `/bin/sh` (catches wrapper-bypass refactors)
- include both `Decision::Allow` and `Decision::Block` in the corpus
- have zero `#[ignore]` attributes
- not gate tests on `#[cfg(target_os = ...)]`

Structural (not name-based): no hard-coded function names, so future refactors that rename helpers stay green.

### #7: render_hook_script contract

`src/installer.rs::render_hook_script()` must generate the exact literals the hook integration suite depends on:
- `cat | omamori hook-check`
- `set -eu`
- `exit $?`

A silent drop of any of these would break the enforcement chain while passing behavior tests.

### #8: CODEOWNERS explicit paths

CODEOWNERS must include explicit entries for:
- `/tests/`
- `/tests/hook_integration.rs`
- `/fuzz/fuzz_targets/`
- `/scripts/check-invariants.sh`
- `/src/unwrap.rs`

`* @yottayoshida` already covers these implicitly, but explicit entries survive future tweaks to the default line.

## CODEOWNERS additions

The same five paths plus inline comments noting T10 (AI adversary) mitigation role:
- hook test → blind-spot target
- fuzz corpus → mutation surface
- invariants script → gate-collapsing vector
- unwrap.rs → tokenization / policy-adjacent regression surface

## 7-file diff-based monitoring (plan T10)

The plan called for 7-file diff-based monitoring. Implementation map:

| File | Coverage |
|------|----------|
| `.github/workflows/ci.yml` | CODEOWNERS `/.github/workflows/` (existing) |
| `.github/CODEOWNERS` | CODEOWNERS `* @yottayoshida` (default) + invariant #8 self-check |
| `scripts/check-invariants.sh` | CODEOWNERS new entry (this PR) |
| `tests/hook_integration.rs` | CODEOWNERS new entry + invariant #6 |
| `src/engine/hook.rs` | CODEOWNERS `/src/engine/hook.rs` (existing) |
| `src/unwrap.rs` | CODEOWNERS new entry (this PR) |
| `src/installer.rs` | CODEOWNERS `/src/installer.rs` (existing) + invariant #7 |

All seven now require explicit ownership review (via CODEOWNERS) and, where applicable, static invariant checks in CI.

## Local verification

```
$ bash scripts/check-invariants.sh
#1 OK: Cargo.lock is tracked
#3 OK: all required probes are effectively ignored
[...]
#5 OK: representative --locked invocations present
#6 OK: hook integration suite has required structure
#7 OK: render_hook_script contract intact
#8 OK: CODEOWNERS includes required explicit paths
```

Existing invariant #4 (`package.include` via `tomllib`) is Python 3.11+ only. CI runs on ubuntu-latest (3.11+) so CI passes; dev machines with Python 3.9/3.10 will see `ModuleNotFoundError` on that single line — a pre-existing condition unrelated to this PR.

## Plan context

- Closes security requirement **SR-1** (CODEOWNERS explicit) and **SR-2** (invariants.sh extended)
- Complements PR2a's runtime Rust invariant
- Part of #121

Follow-ups: PR3 (`curl | bash` gap) → PR4 (release v0.9.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
