### PR TITLE
docs(security): document curl|env bash and curl|sudo bash implementation gap (#146)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -244,6 +244,7 @@ These attack vectors **cannot** be detected by omamori's design. They are docume
 | `export -n CLAUDECODE` | Removes export attribute without unsetting; not caught by `unset` patterns |
 | `python -c "shutil.rmtree(...)"` | Python/Node interpreters not in shell list; [investigated, zero incidents in target tools](https://github.com/yottayoshida/omamori/issues/74) |
 | `bash -c "$VAR"` where VAR is set earlier | Variable expansion requires runtime evaluation |
+| `curl URL \| env bash` / `curl URL \| sudo bash` | **Implementation gap, not a design limit.** Transparent-wrapper unwrapping (`env`, `sudo`) runs before pipe-to-shell detection, so the wrapped `bash` looks like a bare command and the pipe-to-shell signal is lost. Gap is documented in `src/unwrap.rs::tests::{curl_pipe_env_bash_not_yet_blocked,echo_pipe_sudo_bash_not_yet_blocked}`. Fix tracked as P1-1 in [#146](https://github.com/yottayoshida/omamori/issues/146); planned for v0.9.5+ by reordering pipe-to-shell detection to precede wrapper unwrapping |
 
 ## AI Config Bypass Guard (v0.3.2+)
 


### PR DESCRIPTION
## Summary

Documents the `curl URL | env bash` / `curl URL | sudo bash` bypass gap in `SECURITY.md` Known limitations. This is **PR3 of 5** in the v0.9.4 rollout.

## What this PR does and does not do

**Does**: adds one row to the `KNOWN_LIMIT` table stating the gap, explaining it is an *implementation* gap (reorderable) rather than a *design* limit (inherent), and linking to issue #146 P1-1 where the fix is tracked.

**Does not**: fix the gap. The runtime behavior change (reorder pipe-to-shell detection to run before transparent-wrapper unwrapping) is scheduled for v0.9.5+.

## Why not a new issue

Originally the plan called for filing a new issue for this gap. On review, issue [#146](https://github.com/yottayoshida/omamori/issues/146) already lists exactly this under **P1-1** (`curl x | env bash`, `curl x | sudo bash`). The bypass corpus in `src/unwrap.rs` also documents the gap in comments (`TODO(#146): fix pipe-to-shell detection to check BEFORE unwrapping`) and tests (`curl_pipe_env_bash_not_yet_blocked`, `echo_pipe_sudo_bash_not_yet_blocked`). Creating a duplicate issue would fragment tracking. Linking to #146 P1-1 preserves the single source of truth.

## Why document now if the fix is v0.9.5

omamori's transparency principle: maintain a bypass corpus — *a set of tests that verify both "what we block" and "what we cannot block"* — and mirror that honesty in `SECURITY.md`. An AI agent that reads SECURITY.md before attempting bypass should see the exact gap rather than discover it by trial. Documentation is cheap; pretending the gap doesn't exist is expensive.

## Diff

One new row, inserted at the end of the `Known limitations (KNOWN_LIMIT)` table:

```markdown
| `curl URL \| env bash` / `curl URL \| sudo bash` | **Implementation gap, not a design limit.** Transparent-wrapper unwrapping (`env`, `sudo`) runs before pipe-to-shell detection, so the wrapped `bash` looks like a bare command and the pipe-to-shell signal is lost. Gap is documented in `src/unwrap.rs::tests::{curl_pipe_env_bash_not_yet_blocked,echo_pipe_sudo_bash_not_yet_blocked}`. Fix tracked as P1-1 in [#146](https://github.com/yottayoshida/omamori/issues/146); planned for v0.9.5+ by reordering pipe-to-shell detection to precede wrapper unwrapping |
```

## Plan context

Follow-up:
- **PR4** (final in v0.9.4): release — CHANGELOG 3-tier + README Platform Support section + `Cargo.toml` version bump + tag

Not in this PR:
- Runtime fix for #146 P1-1 (v0.9.5+)
- Fix for `context::tests::multi_target_all_regenerable_downgrades` flake on Ubuntu — tracked separately in [#164](https://github.com/yottayoshida/omamori/issues/164)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
