### PR TITLE
docs(readme): clarify Layer 2 pipe-to-shell wrapper coverage (v0.9.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Terminal → rm -rf src/
 
 **Layer 2 — Hooks**: Evaluates commands against the same rules as Layer 1, with three additional capabilities:
 - Recursively unwraps shell wrappers (`sudo env bash -c "..."` → extracts inner command)
-- Blocks pipe-to-shell patterns (`curl | bash`)
+- Blocks pipe-to-shell patterns (`curl URL | bash`, `curl URL | sudo bash`, and other transparent-wrapper variants — see [SECURITY.md](SECURITY.md))
 - Blocks dynamic command generation (`bash -c "$(cmd)"`)
 
 Available for Claude Code, Cursor, and Codex CLI.


### PR DESCRIPTION
## Summary

1-line polish to `README.md` L94 reflecting the v0.9.5 `curl URL | env bash` / `curl URL | sudo bash` wrapper-evasion fix ([#170](https://github.com/yottayoshida/omamori/pull/170), #146 P1-1).

## Before

```markdown
- Blocks pipe-to-shell patterns (`curl | bash`)
```

## After

```markdown
- Blocks pipe-to-shell patterns (`curl URL | bash`, `curl URL | sudo bash`, and other transparent-wrapper variants — see [SECURITY.md](SECURITY.md))
```

## Why this specific wording (ux-designer review summary)

- **Example count = 2** (Hick's Law: small in-line choice set)
- **No numeric claim in README body** ("7 wrappers" stays in SECURITY.md so the number can drift without README doc-drift)
- **Preserves 3-bullet parallelism** at L92-95 (each bullet = one category + 1-2 examples, matching the existing shape)
- **Matches existing SECURITY.md link style** (L122 already links without anchor)

UX-designer explicitly rejected:
- 「7 transparent wrappers」数値 claim in README body — marketing-speak tone ズレ against omamori's understated doc style
- 3+ wrapper examples inline (`bash` / `env bash` / `sudo bash`) — Hick's Law, plus `env bash` requires readers to know what `env` does (~80% lose the analogy)
- Listing wrapper names (`sudo`, `env`, `nohup`, …) inline — middle-ground that serves neither broad readers nor security-focused ones

## Relationship to v0.9.5 release state

- `main` already carries the v0.9.5 release body state (PR #171 merged): `Cargo.toml` 0.9.5, CHANGELOG `[0.9.5]` entry, SECURITY.md "Closed in v0.9.5" flip
- This PR lands on top of that and will be part of the v0.9.5 release when the ceremony (tag / GitHub Release / cargo publish / homebrew-tap PR) is run by yotta
- The CHANGELOG PRs section may optionally be amended later to reference this PR; kept separate here to keep this PR scope to 1 line

## Local verification

No Rust code changes. `cargo check --locked` unaffected. Markdown renders correctly on GitHub preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)