### PR TITLE
chore(changelog): add PR #173 to v0.9.5 PRs section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on Keep a Changelog.
 - [#168](https://github.com/yottayoshida/omamori/pull/168) — `test(context): quarantine multi_target_* with #[serial_test::serial]`. Closes #164.
 - [#169](https://github.com/yottayoshida/omamori/pull/169) — `docs(acceptance,security): refresh acceptance test prerequisites and Known Limitations`. Closes #167.
 - [#170](https://github.com/yottayoshida/omamori/pull/170) — `fix(unwrap): detect pipe-to-shell through transparent wrappers`. 8 rounds of Codex Phase 6-A adversarial review + 1 round of 6-B test adversarial review shaped the final surface (16 distinct fixes recorded in commit history). Refs #146 (P1-1 only).
+- [#173](https://github.com/yottayoshida/omamori/pull/173) — `docs(readme): clarify Layer 2 pipe-to-shell wrapper coverage`. README's "How It Works" → "Layer 2 — Hooks" bullet expanded to add `sudo bash` as a second example and link to `SECURITY.md` for the full wrapper list. UX-designer reviewed.
 
 ## [0.9.4] - 2026-04-19
 


### PR DESCRIPTION
## Summary

1-line addition to `CHANGELOG.md` v0.9.5 PRs section, referencing PR #173 (README polish) which merged after PR #171 (release commit).

## Why

Option β chosen for v0.9.5 release ceremony: include the README polish as part of the v0.9.5 PRs list rather than letting it fall outside the changelog. Keeps the v0.9.5 narrative complete.

## Diff

```diff
- [#170](...) — fix(unwrap): detect pipe-to-shell through transparent wrappers...
+ [#170](...) — fix(unwrap): detect pipe-to-shell through transparent wrappers...
+ [#173](...) — docs(readme): clarify Layer 2 pipe-to-shell wrapper coverage. README's "How It Works" → "Layer 2 — Hooks" bullet expanded to add `sudo bash` as a second example and link to `SECURITY.md` for the full wrapper list. UX-designer reviewed.
```

No version bump, no Cargo.toml/Cargo.lock change.

## Next steps after merge

This PR is the last commit before tagging `v0.9.5`. After merge, the release ceremony continues:

1. `git tag v0.9.5` at the merge commit
2. `git push --tags`
3. `gh release create v0.9.5 --notes-file <CHANGELOG v0.9.5 extract>`
4. `cargo publish --locked`
5. Compute tarball SHA256, open homebrew-tap PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)