### PR TITLE
feat(tests): PR3 - argument reordering corpus (scope 1 only; scope 2 → v0.9.7)

### DIFF
--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -3763,4 +3763,38 @@ mod tests {
         ];
         assert!(segment_has_stdin_redirect(&tokens));
     }
+
+    // =========================================================================
+    // 14. PR3 scope 1: argument reordering is detection-agnostic
+    //     (existing match_rule is order-independent; pin the invariant).
+    //     scope 2 (verb-position ${IFS}/ANSI-C $'...' detection) was
+    //     retracted after Codex review found bypasses in the narrow
+    //     fail-close (e.g. `$'rm' -rf /tmp` passed, `X=rm; $X -rf`
+    //     passed). Deferred to v0.9.7 #176 with a raw-segment approach.
+    // =========================================================================
+
+    #[test]
+    fn arg_reorder_rm_rf_order_flipped() {
+        // rm's -r and -f can appear in any order or combined. Both surface
+        // the same program+args to the rule layer; reordering does not
+        // change matching (match_rule iterates args independently).
+        assert_commands("rm -rf /tmp/x", &[cmd("rm", &["-rf", "/tmp/x"])]);
+        assert_commands("rm -r -f /tmp/x", &[cmd("rm", &["-r", "-f", "/tmp/x"])]);
+        assert_commands("rm -f -r /tmp/x", &[cmd("rm", &["-f", "-r", "/tmp/x"])]);
+        assert_commands(
+            "rm --force --recursive /tmp/x",
+            &[cmd("rm", &["--force", "--recursive", "/tmp/x"])],
+        );
+        assert_commands(
+            "rm --recursive --force /tmp/x",
+            &[cmd("rm", &["--recursive", "--force", "/tmp/x"])],
+        );
+    }
+
+    #[test]
+    fn arg_reorder_path_before_flags() {
+        // Target path before flags: `rm /tmp/x -rf` is valid POSIX and
+        // must surface identically.
+        assert_commands("rm /tmp/x -rf", &[cmd("rm", &["/tmp/x", "-rf"])]);
+    }
 }

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -372,6 +372,21 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Allow,
         "env-dash-u-bare-ls-allow",
     ),
+    // 14. PR3 scope 1: argument reordering is match_rule-agnostic.
+    //     `rm -rf /tmp/x` and `rm /tmp/x -rf` both surface as `rm` with
+    //     the same arg set — rule layer matches independently of order.
+    //     (scope 2 verb-position expansion deferred to v0.9.7 #176 —
+    //     Codex review found bypasses in the narrow fail-close.)
+    (
+        "rm /tmp/x -rf",
+        Decision::Block,
+        "arg-reorder-path-before-flags-block",
+    ),
+    (
+        "rm --recursive --force /tmp/x",
+        Decision::Block,
+        "arg-reorder-long-flag-order-block",
+    ),
 ];
 
 /// Cross-OS invariant: the same bash input must yield the same Decision on


### PR DESCRIPTION
## Scope retracted: scope 2 → v0.9.7 #176

Initial commit 05b899f included scope 2 (verb-position \${IFS} / ANSI-C \$'...' detection). Codex review found 1 Critical + 1 Major bypass in the narrow fail-close approach:

- \`\$'rm' -rf /tmp\` passes: shell_words strips \$'rm' to \$rm, missing the \$+backslash signature which only matched the escape form \$'\\x72\\x6d'.
- \`X=rm; \$X -rf /tmp\` passes: simple \$VAR substitution was allowed for FP avoidance, but same-command self-reference bypasses that.
- Token-level detection cannot distinguish shell_words' quote-stripped output from legitimate \$VAR; raw-segment scanning needs a quote-aware state machine.

Combined with #176's plan for \`BlockReason::ObfuscatedExpansion\` + brace expansion general detection, the principled path is a raw-segment scan in v0.9.7, not patch-level v0.9.6 fixes. **#176 milestone promoted v0.10.0 → v0.9.7**.

## What this PR delivers (scope 1 only)

**scope 1 (#146 P1-2)**: E2E evidence that \`match_rule\` is already order-independent, via lib + hook_integration corpus pins for argument reordering.

- lib tests +2: \`arg_reorder_rm_rf_order_flipped\`, \`arg_reorder_path_before_flags\`
- hook_integration corpus +2: \`arg-reorder-path-before-flags-block\`, \`arg-reorder-long-flag-order-block\`
- **No code changes** — the invariant is pinned by additional test evidence.

## Test results

- lib: 599 (597 PR2 baseline + 2 reorder pins), 0 failed
- hook_integration: 101 pass (36 corpus entries), 0 failed
- cargo fmt --check / clippy -D warnings / check-invariants.sh: all green

## Scope 2 migration plan

| item | owner |
|------|-------|
| Raw-segment scan impl + ObfuscatedExpansion enum + brace detection | #176 (v0.9.7) |
| Plan file update (\`moonlit-sparking-meadow.md\` PR3 row) | follow-up |
| SECURITY.md Known Limitations entries (\`\${IFS}rm\`, \`\$'rm'\`, \`X=rm; \$X\`, \`\$"..."\`) | PR7 docs merge |

## Related

- Codex Round 1 review: found C1 (\`\$'rm'\` bypass) + M1 (\`X=rm;\$X\` bypass)
- PR2 merged: #184 (2d7dae9 on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)