### PR TITLE
test: PR4 - structural test quality (#146 scope 4)

### DIFF
--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -520,13 +520,32 @@ mod tests {
     //   would silently pass. Goldens break that symmetry by pinning the
     //   exact bytes a v0.9.x reader must accept.
     //
+    // All inputs the goldens depend on (change any and the hex must be
+    // regenerated). PR #186 proxy review P3 — earlier comment only listed
+    // timestamp; these additional inputs also feed the HMAC:
+    //   - `TEST_SECRET = [0x42u8; 32]`
+    //   - `test_logger` defaults: `key_id: "default"`,
+    //     `retention_days: 0`, path under temp dir
+    //   - `make_event` defaults: `timestamp: "2026-01-01T00:00:00Z"`,
+    //     `provider: "test"`, `action/result: "passthrough"`,
+    //     `target_count: 0`, `target_hash: "hmac-sha256:test"`,
+    //     `detection_layer: Some("layer1")`, all optional chain fields None
+    //   - `AuditLogger::append` populates `chain_version`, `seq`,
+    //     `prev_hash`, `key_id`, `entry_hash` on each event before write
+    //     and does NOT overwrite `timestamp`
+    //   - `compute_entry_hash` via `HashableEvent::from_event`
+    //     (see `src/audit/chain.rs`)
+    //
     // How to regenerate (if a deliberate algorithm change lands):
-    //   Temporarily add a `#[test] fn tmp_print` that prints
-    //   `genesis_hash(Some(&TEST_SECRET))` and each `events[i]["entry_hash"]`
-    //   for `make_event("cmd0"..="cmd4")`, run with `--nocapture`, paste the
-    //   output below, then delete the tmp test. The inputs are deterministic
-    //   because `make_event` uses a fixed timestamp ("2026-01-01T00:00:00Z")
-    //   and `AuditLogger::append` does not overwrite the event timestamp.
+    //   Run `chain_integrity_verification` with a temporary
+    //   `println!("{events:#?}");` inserted after `read_events(&logger.path)`.
+    //   Read the printed `entry_hash` and `prev_hash` fields
+    //   (events[0].prev_hash == genesis). Paste below and delete the
+    //   `println!`. Do NOT regenerate by calling `compute_entry_hash`
+    //   directly on a `make_event(...)` result — the chain fields
+    //   (seq / prev_hash / key_id) would be `None` and the digest would
+    //   diverge from what `append` writes. Changing `test_logger` defaults
+    //   (key_id, retention_days, etc.) also invalidates these goldens.
     const GOLDEN_GENESIS: &str = "d9c14c4fc7dbc19fce81268a054a22fa092e4946cc762823bd641e156233030b";
     const GOLDEN_ENTRY_HASHES: [&str; 5] = [
         // seq=0, command="cmd0"

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -534,7 +534,10 @@ mod tests {
     //     `prev_hash`, `key_id`, `entry_hash` on each event before write
     //     and does NOT overwrite `timestamp`
     //   - `compute_entry_hash` via `HashableEvent::from_event`
-    //     (see `src/audit/chain.rs`)
+    //     (see `src/audit/chain.rs` — the field order of `HashableEvent`
+    //     is additionally SECURITY-pinned by golden test GR-002; reordering
+    //     fields invalidates these entry-hash goldens even if the HMAC
+    //     algorithm itself is unchanged)
     //
     // How to regenerate (if a deliberate algorithm change lands):
     //   Run `chain_integrity_verification` with a temporary

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -509,32 +509,37 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
-    // --- Verify chain integrity (helper for tests) ---
-
-    fn check_chain_manual(events: &[serde_json::Value], secret: Option<&[u8; 32]>) -> bool {
-        let genesis = genesis_hash(secret);
-        let mut expected_prev = genesis;
-
-        for (i, event) in events.iter().enumerate() {
-            let parsed: AuditEvent = serde_json::from_value(event.clone()).unwrap();
-            let recomputed = compute_entry_hash(secret, &parsed);
-            let recorded = event["entry_hash"].as_str().unwrap_or("");
-
-            if recomputed != recorded {
-                eprintln!("hash mismatch at index {i}");
-                return false;
-            }
-
-            let prev = event["prev_hash"].as_str().unwrap_or("");
-            if prev != expected_prev {
-                eprintln!("prev_hash mismatch at index {i}");
-                return false;
-            }
-
-            expected_prev = recorded.to_string();
-        }
-        true
-    }
+    // --- Golden hex vectors (PR #v096-pr4) ---
+    //
+    // WHY golden vectors (not a self-verifying helper):
+    //   The previous form recomputed `compute_entry_hash` inside the test
+    //   and compared it against the recorded `entry_hash`. Since both sides
+    //   flow through the same function, an algorithm-level regression
+    //   (HMAC key derivation change, field order change, genesis marker
+    //   change) would produce a matching pair on both sides and the test
+    //   would silently pass. Goldens break that symmetry by pinning the
+    //   exact bytes a v0.9.x reader must accept.
+    //
+    // How to regenerate (if a deliberate algorithm change lands):
+    //   Temporarily add a `#[test] fn tmp_print` that prints
+    //   `genesis_hash(Some(&TEST_SECRET))` and each `events[i]["entry_hash"]`
+    //   for `make_event("cmd0"..="cmd4")`, run with `--nocapture`, paste the
+    //   output below, then delete the tmp test. The inputs are deterministic
+    //   because `make_event` uses a fixed timestamp ("2026-01-01T00:00:00Z")
+    //   and `AuditLogger::append` does not overwrite the event timestamp.
+    const GOLDEN_GENESIS: &str = "d9c14c4fc7dbc19fce81268a054a22fa092e4946cc762823bd641e156233030b";
+    const GOLDEN_ENTRY_HASHES: [&str; 5] = [
+        // seq=0, command="cmd0"
+        "ff8d28e58ca55a781c908beb827387f22418350d8b7399b2fdecae1a1f805bf2",
+        // seq=1, command="cmd1"
+        "23473c102da2cc4b56081e1bd9746628feba3c0daf566bb4ecdc7170b085f81f",
+        // seq=2, command="cmd2"
+        "c1c2d820311b47c2b16acbca62dd7b2be7951045bd7514130f3ea22031d8bf6d",
+        // seq=3, command="cmd3"
+        "bd394c8964cf47715e2ad67d78184f7a5cf5be21eb651c885d791c2885d075b3",
+        // seq=4, command="cmd4"
+        "3554f31aac0e3a9ea21afb2f572e09e343c841c21faf2ebf2208f89fc687d165",
+    ];
 
     #[test]
     fn chain_integrity_verification() {
@@ -546,7 +551,36 @@ mod tests {
         }
 
         let events = read_events(&logger.path);
-        assert!(check_chain_manual(&events, Some(&TEST_SECRET)));
+        assert_eq!(events.len(), 5);
+
+        // Pin genesis against the golden: if the HMAC marker changes
+        // (e.g. key_id derivation, domain separator), this fails first.
+        assert_eq!(
+            events[0]["prev_hash"].as_str().unwrap(),
+            GOLDEN_GENESIS,
+            "genesis hash divergence — HMAC key or domain-separator changed?"
+        );
+
+        // Pin each entry's recorded entry_hash + prev_hash chain against
+        // the golden. Using hardcoded hex breaks the symmetry of the old
+        // self-verifying helper (compute_entry_hash on both sides).
+        for (i, expected) in GOLDEN_ENTRY_HASHES.iter().enumerate() {
+            assert_eq!(
+                events[i]["entry_hash"].as_str().unwrap(),
+                *expected,
+                "entry_hash at seq={i} drifted from golden — algorithm change?"
+            );
+            let expected_prev = if i == 0 {
+                GOLDEN_GENESIS
+            } else {
+                GOLDEN_ENTRY_HASHES[i - 1]
+            };
+            assert_eq!(
+                events[i]["prev_hash"].as_str().unwrap(),
+                expected_prev,
+                "prev_hash at seq={i} broke chain linkage from golden"
+            );
+        }
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -560,15 +594,38 @@ mod tests {
             logger.append(make_event(&format!("cmd{i}"))).unwrap();
         }
 
-        // Tamper: change command in second entry
+        // Tamper: change command in second entry on disk.
         let content = fs::read_to_string(&logger.path).unwrap();
         let tampered = content.replacen("cmd1", "HACKED", 1);
         fs::write(&logger.path, tampered).unwrap();
 
         let events = read_events(&logger.path);
-        assert!(
-            !check_chain_manual(&events, Some(&TEST_SECRET)),
-            "tampered chain should fail verification"
+        assert_eq!(events.len(), 3);
+
+        // Tamper detection contract:
+        //   (a) The *recorded* entry_hash on the tampered line is still the
+        //       pre-tamper golden (attacker only flipped a payload byte).
+        //   (b) Recomputing the hash from the post-tamper payload yields a
+        //       different digest. That divergence is the detection signal.
+        // Pinning both sides against goldens (not against each other) ensures
+        // a future algorithm change can't paper over a real tamper.
+        let parsed_seq1: AuditEvent = serde_json::from_value(events[1].clone()).unwrap();
+        let recomputed_seq1 = compute_entry_hash(Some(&TEST_SECRET), &parsed_seq1);
+
+        assert_eq!(
+            events[1]["entry_hash"].as_str().unwrap(),
+            GOLDEN_ENTRY_HASHES[1],
+            "tampered line should still carry the pre-tamper recorded hash"
+        );
+        assert_ne!(
+            recomputed_seq1, GOLDEN_ENTRY_HASHES[1],
+            "recomputed hash over tampered payload must diverge from golden — \
+             this is the tamper signal"
+        );
+        assert_ne!(
+            recomputed_seq1,
+            events[1]["entry_hash"].as_str().unwrap(),
+            "recomputed vs. recorded divergence is the end-to-end detection test"
         );
 
         let _ = fs::remove_dir_all(&dir);

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -955,20 +955,15 @@ mod tests {
     }
 
     // --- Meta-pattern tests (blocked_string_patterns, Phase 1) ---
-
-    #[test]
-    fn meta_patterns_cover_rm_path_boundaries() {
-        let patterns = blocked_string_patterns();
-        for path in &["/bin/rm", "/usr/bin/rm"] {
-            for boundary in &[" ", "\"", "\t", "'"] {
-                let needle = format!("{path}{boundary}");
-                assert!(
-                    patterns.iter().any(|(p, _)| *p == needle),
-                    "blocked_string_patterns should cover: {path}{boundary:?}"
-                );
-            }
-        }
-    }
+    //
+    // Behavioral coverage of `blocked_string_patterns()` now lives in
+    // `tests/hook_integration.rs` (category 15a-15d of HOOK_DECISION_CASES)
+    // as CLI exit-code assertions against `omamori hook-check`. That form
+    // survives internal refactors of the pattern list (renames, grouping,
+    // moving to a const table) and only fails when the attack surface
+    // actually re-opens — which is what the test is there to protect
+    // against. The previous array-shape assertions here tested the data
+    // structure rather than the guarantee and were removed in PR #v096-pr4.
 
     #[test]
     fn protected_env_vars_constant_covers_all_detectors() {
@@ -986,33 +981,6 @@ mod tests {
             assert!(
                 PROTECTED_ENV_VARS.contains(var),
                 "PROTECTED_ENV_VARS should include {var}"
-            );
-        }
-    }
-
-    #[test]
-    fn meta_patterns_cover_config_modification() {
-        let patterns = blocked_string_patterns();
-        for keyword in &[
-            "config disable",
-            "config enable",
-            "omamori uninstall",
-            "omamori init --force",
-        ] {
-            assert!(
-                patterns.iter().any(|(p, _)| p.contains(keyword)),
-                "should block: {keyword}"
-            );
-        }
-    }
-
-    #[test]
-    fn meta_patterns_do_not_false_positive_on_rmdir() {
-        let patterns = blocked_string_patterns();
-        for (pattern, _) in &patterns {
-            assert!(
-                !pattern.contains("/bin/rmdir"),
-                "pattern should not match rmdir: {pattern}"
             );
         }
     }
@@ -1548,21 +1516,10 @@ mod tests {
         let _ = fs::remove_dir_all(dir);
     }
 
-    #[test]
-    fn meta_patterns_cover_codex_protection() {
-        let patterns = blocked_string_patterns();
-        for keyword in &[
-            ".codex/hooks.json",
-            ".codex/config.toml",
-            "config.toml.bak",
-            "codex_hooks",
-        ] {
-            assert!(
-                patterns.iter().any(|(p, _)| p.contains(keyword)),
-                "should block: {keyword}"
-            );
-        }
-    }
+    // meta_patterns_cover_codex_protection was moved to
+    // tests/hook_integration.rs as behavioral CLI exit-code assertions
+    // (HOOK_DECISION_CASES category 15c). See the note above
+    // `protected_env_vars_constant_covers_all_detectors` for rationale.
 
     #[test]
     fn blocked_string_patterns_include_omamori_override() {

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -1373,6 +1373,30 @@ fn basename(path: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    // WHY direct-call tests (not CLI spawn like `tests/hook_integration.rs`):
+    //
+    // unwrap's responsibility is the *internal* parser stage that consumes
+    // already-tokenized `shell_words` output. Going through `omamori hook-check`
+    // would force every input through the full shell parser chain (bash →
+    // shell_words → normalize_compound_operators → unwrap). That chain also
+    // performs quote stripping, operator splitting, and whitespace collapsing
+    // before unwrap ever sees the tokens — so for malformed or edge-case
+    // inputs (e.g. the wrapper-evasion corpus in this module), the CLI
+    // boundary would test `shell_words` parsing behavior, not unwrap's
+    // contract.
+    //
+    // Behavioral end-to-end guarantees (a real command must Block/Allow)
+    // are pinned at the hook boundary in `tests/hook_integration.rs` via
+    // `HOOK_DECISION_CASES`. That is the right layer for "does omamori
+    // actually stop `curl | env bash`?". The tests here answer a different
+    // question: "given these tokens, does unwrap surface the right inner
+    // invocation or Block reason?" — which is the seam a security review
+    // needs pinned directly against parse state, not through a shell.
+    //
+    // This comment exists because the same question came up multiple times
+    // during Codex review rounds for v0.9.6 (#178/#179/#180); keep it here
+    // so future reviewers can find the rationale without re-deriving it.
+
     use super::*;
 
     // --- Helper ---

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -1377,16 +1377,20 @@ mod tests {
     //
     // unwrap's responsibility is the *internal* parser stage that consumes
     // already-tokenized `shell_words` output. Going through `omamori hook-check`
-    // would force every input through the full pre-parse chain:
-    //   JSON `tool_input.command` → normalize_compound_operators →
-    //   shell_words::split → unwrap.
-    // (See `src/engine/hook.rs::check_command_for_hook` lines 146-154 for
-    // the actual order; `normalize_compound_operators` runs before
-    // `shell_words::split`.) That chain performs operator splitting,
-    // quote stripping, and whitespace collapsing before unwrap ever sees
-    // the tokens — so for malformed or edge-case inputs (e.g. the
-    // wrapper-evasion corpus in this module), the CLI boundary would test
-    // `shell_words` parsing behavior, not unwrap's contract.
+    // would force every input through the full pre-parse chain performed by
+    // `parse_at_depth` (this file, lines 81-94):
+    //   input string → normalize_compound_operators → shell_words::split →
+    //   per-segment unwrap logic.
+    // That chain performs operator splitting, quote stripping, and whitespace
+    // collapsing before unwrap's core segmentation / wrapper-peeling logic
+    // ever sees the tokens — so for malformed or edge-case inputs (e.g. the
+    // wrapper-evasion corpus in this module), a CLI-boundary test would
+    // primarily exercise `shell_words` parsing behavior and the coarse
+    // normalization layer, not unwrap's contract proper. (The hook-layer
+    // Phase 1B in `src/engine/hook.rs::check_command_for_hook` L146-151
+    // happens to run the same normalize + shell_words::split pair for a
+    // different purpose — env-tampering detection — which is why that code
+    // cite can read as equivalent to the pre-parse chain here.)
     //
     // Behavioral end-to-end guarantees (a real command must Block/Allow)
     // are pinned at the hook boundary in `tests/hook_integration.rs` via

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -1377,13 +1377,16 @@ mod tests {
     //
     // unwrap's responsibility is the *internal* parser stage that consumes
     // already-tokenized `shell_words` output. Going through `omamori hook-check`
-    // would force every input through the full shell parser chain (bash →
-    // shell_words → normalize_compound_operators → unwrap). That chain also
-    // performs quote stripping, operator splitting, and whitespace collapsing
-    // before unwrap ever sees the tokens — so for malformed or edge-case
-    // inputs (e.g. the wrapper-evasion corpus in this module), the CLI
-    // boundary would test `shell_words` parsing behavior, not unwrap's
-    // contract.
+    // would force every input through the full pre-parse chain:
+    //   JSON `tool_input.command` → normalize_compound_operators →
+    //   shell_words::split → unwrap.
+    // (See `src/engine/hook.rs::check_command_for_hook` lines 146-154 for
+    // the actual order; `normalize_compound_operators` runs before
+    // `shell_words::split`.) That chain performs operator splitting,
+    // quote stripping, and whitespace collapsing before unwrap ever sees
+    // the tokens — so for malformed or edge-case inputs (e.g. the
+    // wrapper-evasion corpus in this module), the CLI boundary would test
+    // `shell_words` parsing behavior, not unwrap's contract.
     //
     // Behavioral end-to-end guarantees (a real command must Block/Allow)
     // are pinned at the hook boundary in `tests/hook_integration.rs` via

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -393,16 +393,24 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
     //     hook-check CLI boundary so the test survives a pattern-list
     //     refactor and only fails if the attack surface actually re-opens.
     //
-    // 15a. Direct-path rm bypassing PATH shim, /usr/bin variant.
-    //      DELIBERATELY non-recursive (`rm /tmp/x`, no `-rf`) so the
-    //      Block decision must come from the Phase 1A meta-pattern layer
-    //      (`/usr/bin/rm ` substring), not from the Phase 2 rule layer
-    //      `rm-recursive-to-trash` (which would only trigger on `-rf`).
-    //      Without this isolation the test would still pass after the
-    //      meta-pattern `/usr/bin/rm ` is dropped, because the rule layer
-    //      would catch the `-rf` form independently. Codex Review PR #186.
-    //      (Note: case #2 `/bin/rm -rf /tmp/x` has the same double-coverage
-    //      weakness but is out of scope for PR4 — tracked for later polish.)
+    // 15a. Direct-path rm bypassing PATH shim, both /bin and /usr/bin
+    //      variants. DELIBERATELY non-recursive (`rm /tmp/x`, no `-rf`)
+    //      so the Block decision must come from the Phase 1A meta-pattern
+    //      layer (`/bin/rm ` / `/usr/bin/rm ` substring), not from the
+    //      Phase 2 rule layer `rm-recursive-to-trash` (which would only
+    //      trigger on `-rf`). Without this isolation the test would still
+    //      pass after the meta-pattern is dropped, because the rule layer
+    //      would catch the `-rf` form independently. Codex Review PR #186
+    //      R1 (/usr/bin variant) + R2 (/bin variant) — the deleted
+    //      `meta_patterns_cover_rm_path_boundaries` test pinned both paths
+    //      against 4 boundaries each, so both must be pinned here too.
+    //      (Case #2 `/bin/rm -rf /tmp/x` remains for historical coverage
+    //      but is double-covered; this pair is the meta-layer guarantee.)
+    (
+        "/bin/rm /tmp/x",
+        Decision::Block,
+        "meta-pattern-bin-rm-direct-path-block",
+    ),
     (
         "/usr/bin/rm /tmp/x",
         Decision::Block,

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -394,11 +394,19 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
     //     refactor and only fails if the attack surface actually re-opens.
     //
     // 15a. Direct-path rm bypassing PATH shim, /usr/bin variant.
-    //      (/bin/rm variant is already covered by case #2.)
+    //      DELIBERATELY non-recursive (`rm /tmp/x`, no `-rf`) so the
+    //      Block decision must come from the Phase 1A meta-pattern layer
+    //      (`/usr/bin/rm ` substring), not from the Phase 2 rule layer
+    //      `rm-recursive-to-trash` (which would only trigger on `-rf`).
+    //      Without this isolation the test would still pass after the
+    //      meta-pattern `/usr/bin/rm ` is dropped, because the rule layer
+    //      would catch the `-rf` form independently. Codex Review PR #186.
+    //      (Note: case #2 `/bin/rm -rf /tmp/x` has the same double-coverage
+    //      weakness but is out of scope for PR4 — tracked for later polish.)
     (
-        "/usr/bin/rm -rf /tmp/x",
+        "/usr/bin/rm /tmp/x",
         Decision::Block,
-        "meta-pattern-usr-bin-rm-block",
+        "meta-pattern-usr-bin-rm-direct-path-block",
     ),
     // 15b. omamori self-mutation attempts: subcommands that tamper with
     //      omamori's own config / install state must be blocked.

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -512,6 +512,14 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
     //          or `config.toml.bak`, so only the `codex_hooks` pattern can
     //          trigger the Block. Same isolation regime as 15a-15b; PR #186
     //          proxy review P1.
+    //
+    //          NOTE: if the `codex_hooks` pattern is ever refactored to a
+    //          stricter form (e.g. `codex_hooks ` trailing-space, or a word
+    //          boundary requirement), the sed-command fixture below must be
+    //          rechecked — it currently happens to include `codex_hooks `
+    //          with a trailing space inside the sed expression, but that
+    //          incidental match should not be relied on when the pattern
+    //          tightens. PR #186 proxy R5.
     (
         "sed -i 's/codex_hooks = true/codex_hooks = false/' /tmp/staged.toml",
         Decision::Block,
@@ -593,16 +601,18 @@ fn corpus_includes_meta_pattern_coverage() {
         .iter()
         .filter(|(_, _, cat)| cat.starts_with("meta-pattern-"))
         .count();
-    // Floor rationale: the 4 deleted installer unit tests pinned
-    //   - rm_path_boundaries: 2 paths × 4 boundaries = 8 patterns
-    //   - config_modification: 5 keywords (incl. override)
-    //   - codex_protection:   4 keywords (.codex/hooks.json,
-    //                         .codex/config.toml, config.toml.bak,
-    //                         codex_hooks — last one isolated in 15c-iso)
-    //   - do_not_false_positive_on_rmdir: 3 FP guards (bare + 2 paths)
-    // → 8 + 5 + 4 + 3 = 20 behavioral fixtures. Floor set to 18 to allow
-    // minor tactical reshuffles without drift, while still catching an
-    // accidental category-level deletion.
+    // Floor rationale: the 4 deleted installer unit tests mapped to
+    //   - rm_path_boundaries: 2 paths × 4 boundaries = 8 fixtures
+    //   - config_modification: 5 keywords (incl. override)         = 5 fixtures
+    //   - codex_protection:   4 original keywords                   = 4 fixtures
+    //                         + 1 isolation fixture for codex_hooks = 5 fixtures
+    //   - do_not_false_positive_on_rmdir: bare + 2 direct paths     = 3 fixtures
+    // → 8 + 5 + 5 + 3 = 21 behavioral fixtures in HEAD (4 of 5 categories
+    // map 1:1 from the deleted unit tests; codex_protection gained +1 from
+    // the R4 isolation requirement). Floor set to 18 to allow minor tactical
+    // reshuffles (up to 3-fixture drift) without drift, while still catching
+    // an accidental category-level deletion. PR #186 R5 proxy corrected the
+    // prior 20/18 arithmetic to 21/18.
     assert!(
         meta_pattern_count >= 18,
         "meta-pattern corpus (#146 scope 4) must have ≥18 entries; got {meta_pattern_count}. \

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -393,28 +393,67 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
     //     hook-check CLI boundary so the test survives a pattern-list
     //     refactor and only fails if the attack surface actually re-opens.
     //
-    // 15a. Direct-path rm bypassing PATH shim, both /bin and /usr/bin
-    //      variants. DELIBERATELY non-recursive (`rm /tmp/x`, no `-rf`)
+    // 15a. Direct-path rm bypassing PATH shim — full boundary coverage.
+    //      The deleted `meta_patterns_cover_rm_path_boundaries` test
+    //      pinned 2 paths × 4 token boundaries (space, double-quote, tab,
+    //      single-quote) = 8 asserts. Phase 1A runs `command.contains`
+    //      against the raw pre-quote-stripped command string, so each
+    //      boundary is an independent attack surface — `/bin/rm"` and
+    //      `/bin/rm\t` are distinct pattern entries that a refactor
+    //      could drop individually.
+    //      All cases DELIBERATELY non-recursive (`rm /tmp/x`, no `-rf`)
     //      so the Block decision must come from the Phase 1A meta-pattern
-    //      layer (`/bin/rm ` / `/usr/bin/rm ` substring), not from the
-    //      Phase 2 rule layer `rm-recursive-to-trash` (which would only
-    //      trigger on `-rf`). Without this isolation the test would still
-    //      pass after the meta-pattern is dropped, because the rule layer
-    //      would catch the `-rf` form independently. Codex Review PR #186
-    //      R1 (/usr/bin variant) + R2 (/bin variant) — the deleted
-    //      `meta_patterns_cover_rm_path_boundaries` test pinned both paths
-    //      against 4 boundaries each, so both must be pinned here too.
-    //      (Case #2 `/bin/rm -rf /tmp/x` remains for historical coverage
-    //      but is double-covered; this pair is the meta-layer guarantee.)
+    //      layer, not from the Phase 2 rule `rm-recursive-to-trash`.
+    //      Codex Review PR #186 R1 (space-boundary), R2 (both paths),
+    //      R3 (non-space boundaries). Case #2 `/bin/rm -rf /tmp/x`
+    //      remains for historical coverage but is double-covered; this
+    //      group is the meta-layer guarantee.
+    // 15a.i space boundary.
     (
         "/bin/rm /tmp/x",
         Decision::Block,
-        "meta-pattern-bin-rm-direct-path-block",
+        "meta-pattern-bin-rm-space-boundary-block",
     ),
     (
         "/usr/bin/rm /tmp/x",
         Decision::Block,
-        "meta-pattern-usr-bin-rm-direct-path-block",
+        "meta-pattern-usr-bin-rm-space-boundary-block",
+    ),
+    // 15a.ii double-quote boundary — raw command `"/bin/rm" /tmp/x`.
+    //        After shell_words strips quotes tokens are fine, but the
+    //        Phase 1A contains-check sees the raw form with the trailing
+    //        quote char right after the path.
+    (
+        "\"/bin/rm\" /tmp/x",
+        Decision::Block,
+        "meta-pattern-bin-rm-dquote-boundary-block",
+    ),
+    (
+        "\"/usr/bin/rm\" /tmp/x",
+        Decision::Block,
+        "meta-pattern-usr-bin-rm-dquote-boundary-block",
+    ),
+    // 15a.iii tab boundary — direct path followed by TAB instead of space.
+    (
+        "/bin/rm\t/tmp/x",
+        Decision::Block,
+        "meta-pattern-bin-rm-tab-boundary-block",
+    ),
+    (
+        "/usr/bin/rm\t/tmp/x",
+        Decision::Block,
+        "meta-pattern-usr-bin-rm-tab-boundary-block",
+    ),
+    // 15a.iv single-quote boundary — raw command `'/bin/rm' /tmp/x`.
+    (
+        "'/bin/rm' /tmp/x",
+        Decision::Block,
+        "meta-pattern-bin-rm-squote-boundary-block",
+    ),
+    (
+        "'/usr/bin/rm' /tmp/x",
+        Decision::Block,
+        "meta-pattern-usr-bin-rm-squote-boundary-block",
     ),
     // 15b. omamori self-mutation attempts: subcommands that tamper with
     //      omamori's own config / install state must be blocked.

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -503,14 +503,43 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Block,
         "meta-pattern-codex-hooks-flag-block",
     ),
-    // 15d. FP guard: `rmdir` must NOT be caught by the `/bin/rm ` boundary
-    //      pattern. Previously asserted by
-    //      `meta_patterns_do_not_false_positive_on_rmdir` at the array
-    //      level; now pinned as a behavioral Allow at the hook boundary.
+    // 15c-iso. Isolation entry for the `codex_hooks` meta-pattern: the
+    //          fixture above matches BOTH `.codex/config.toml` AND
+    //          `codex_hooks` substrings, so if `codex_hooks` is dropped from
+    //          `blocked_string_patterns()` the prior entry still Blocks via
+    //          `.codex/config.toml`. This fixture uses a staging path that
+    //          does not contain `.codex/config.toml`, `.codex/hooks.json`,
+    //          or `config.toml.bak`, so only the `codex_hooks` pattern can
+    //          trigger the Block. Same isolation regime as 15a-15b; PR #186
+    //          proxy review P1.
+    (
+        "sed -i 's/codex_hooks = true/codex_hooks = false/' /tmp/staged.toml",
+        Decision::Block,
+        "meta-pattern-codex-hooks-standalone-block",
+    ),
+    // 15d. FP guard: `rmdir` must NOT be caught by the `/bin/rm ` / `/bin/rm\t`
+    //      / etc. boundary patterns. Previously asserted structurally by
+    //      `meta_patterns_do_not_false_positive_on_rmdir` (pattern array never
+    //      contains `/bin/rmdir`), which also caught the "someone copy-pastes
+    //      a typo'd `/bin/rmdir ` into the block list" class. The bare
+    //      `rmdir /tmp/x` form does not share any substring prefix with the
+    //      /bin/rm* patterns, so direct-path rmdir pins are required to cover
+    //      the typo-injection surface the old test guarded against. PR #186
+    //      proxy review P2.
     (
         "rmdir /tmp/x",
         Decision::Allow,
-        "meta-pattern-rmdir-fp-guard-allow",
+        "meta-pattern-rmdir-bare-fp-guard-allow",
+    ),
+    (
+        "/bin/rmdir /tmp/x",
+        Decision::Allow,
+        "meta-pattern-bin-rmdir-fp-guard-allow",
+    ),
+    (
+        "/usr/bin/rmdir /tmp/x",
+        Decision::Allow,
+        "meta-pattern-usr-bin-rmdir-fp-guard-allow",
     ),
 ];
 
@@ -548,6 +577,38 @@ fn corpus_includes_both_decisions() {
         .any(|(_, d, _)| *d == Decision::Block);
     assert!(has_allow, "corpus must include at least one Allow case");
     assert!(has_block, "corpus must include at least one Block case");
+}
+
+/// Pin the minimum size of the `meta-pattern-*` sub-corpus introduced by PR4
+/// (#146 scope 4). `corpus_includes_both_decisions` only guarantees one
+/// Allow + one Block exist anywhere in HOOK_DECISION_CASES, so a refactor
+/// that silently drops the 15a-15d entries (10+ fixtures) would still pass
+/// because unrelated entries keep both Decisions alive. This test pins the
+/// category floor directly — the thesis of PR4 is that "silent pattern
+/// drop" must fail the suite, so the corpus that encodes that guarantee
+/// must itself be guarded from silent drop. PR #186 proxy review P2.
+#[test]
+fn corpus_includes_meta_pattern_coverage() {
+    let meta_pattern_count = HOOK_DECISION_CASES
+        .iter()
+        .filter(|(_, _, cat)| cat.starts_with("meta-pattern-"))
+        .count();
+    // Floor rationale: the 4 deleted installer unit tests pinned
+    //   - rm_path_boundaries: 2 paths × 4 boundaries = 8 patterns
+    //   - config_modification: 5 keywords (incl. override)
+    //   - codex_protection:   4 keywords (.codex/hooks.json,
+    //                         .codex/config.toml, config.toml.bak,
+    //                         codex_hooks — last one isolated in 15c-iso)
+    //   - do_not_false_positive_on_rmdir: 3 FP guards (bare + 2 paths)
+    // → 8 + 5 + 4 + 3 = 20 behavioral fixtures. Floor set to 18 to allow
+    // minor tactical reshuffles without drift, while still catching an
+    // accidental category-level deletion.
+    assert!(
+        meta_pattern_count >= 18,
+        "meta-pattern corpus (#146 scope 4) must have ≥18 entries; got {meta_pattern_count}. \
+         If you are intentionally removing entries, verify the attack/FP surfaces still \
+         have isolated behavioral coverage and update this floor."
+    );
 }
 
 /// Pin the Block exit code contract at exactly 2. The `cross_os_invariant`

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -387,6 +387,76 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Block,
         "arg-reorder-long-flag-order-block",
     ),
+    // 15. PR4 scope 4: meta-pattern (`blocked_string_patterns`) behavioral
+    //     coverage. Previously asserted at the array-shape level in
+    //     `src/installer.rs` (`meta_patterns_cover_*`), now pinned at the
+    //     hook-check CLI boundary so the test survives a pattern-list
+    //     refactor and only fails if the attack surface actually re-opens.
+    //
+    // 15a. Direct-path rm bypassing PATH shim, /usr/bin variant.
+    //      (/bin/rm variant is already covered by case #2.)
+    (
+        "/usr/bin/rm -rf /tmp/x",
+        Decision::Block,
+        "meta-pattern-usr-bin-rm-block",
+    ),
+    // 15b. omamori self-mutation attempts: subcommands that tamper with
+    //      omamori's own config / install state must be blocked.
+    (
+        "omamori config disable some-rule",
+        Decision::Block,
+        "meta-pattern-config-disable-block",
+    ),
+    (
+        "omamori config enable some-rule",
+        Decision::Block,
+        "meta-pattern-config-enable-block",
+    ),
+    (
+        "omamori uninstall",
+        Decision::Block,
+        "meta-pattern-uninstall-block",
+    ),
+    (
+        "omamori init --force",
+        Decision::Block,
+        "meta-pattern-init-force-block",
+    ),
+    (
+        "omamori override",
+        Decision::Block,
+        "meta-pattern-override-block",
+    ),
+    // 15c. Codex CLI hook / config protection (#66 T2/T3).
+    (
+        "echo payload > ~/.codex/hooks.json",
+        Decision::Block,
+        "meta-pattern-codex-hooks-json-block",
+    ),
+    (
+        "echo payload > ~/.codex/config.toml",
+        Decision::Block,
+        "meta-pattern-codex-config-toml-block",
+    ),
+    (
+        "cp config.toml config.toml.bak",
+        Decision::Block,
+        "meta-pattern-codex-config-toml-bak-block",
+    ),
+    (
+        "sed -i 's/codex_hooks = true/codex_hooks = false/' ~/.codex/config.toml",
+        Decision::Block,
+        "meta-pattern-codex-hooks-flag-block",
+    ),
+    // 15d. FP guard: `rmdir` must NOT be caught by the `/bin/rm ` boundary
+    //      pattern. Previously asserted by
+    //      `meta_patterns_do_not_false_positive_on_rmdir` at the array
+    //      level; now pinned as a behavioral Allow at the hook boundary.
+    (
+        "rmdir /tmp/x",
+        Decision::Allow,
+        "meta-pattern-rmdir-fp-guard-allow",
+    ),
 ];
 
 /// Cross-OS invariant: the same bash input must yield the same Decision on


### PR DESCRIPTION
## Summary

v0.9.6 PR4 / 7. Plan: `.claude/plans/moonlit-sparking-meadow.md` scope 4 (structural test quality). Test-only PR — no runtime behavior change.

Replaces 4 installer meta-pattern array-shape assertions with behavioral CLI exit-code assertions, turns 2 audit-chain self-verifying tests into golden hex vectors, and pins the rationale for unwrap's direct-call test pattern in-file so it doesn't keep getting re-derived in future review rounds.

## Scope

| Before | After | Why |
|---|---|---|
| `installer.rs::meta_patterns_cover_*` x3 + `..._do_not_false_positive_on_rmdir` assert on the shape of `blocked_string_patterns()` | Deleted. Equivalent coverage added to `tests/hook_integration.rs::HOOK_DECISION_CASES` as CLI `exit 2` / `exit 0` assertions (category 15a-15d, 21 fixtures) + independent floor test `corpus_includes_meta_pattern_coverage` | Old form would silently pass a refactor that renamed or restructured the pattern table; new form only fails when the attack surface actually re-opens |
| `audit::tests::check_chain_manual` helper + `chain_integrity_verification` / `chain_tamper_detected` recompute `compute_entry_hash` on both sides of the compare | Hardcoded `GOLDEN_GENESIS` + `GOLDEN_ENTRY_HASHES` pinned against v0.9.5 on-disk output. Tamper test now asserts recorded == golden AND recomputed != golden | Breaks the symmetry of the old self-verifying form — an algorithm-level regression (HMAC key derivation, field order, genesis marker) produced matching digests on both sides and passed silently |
| `unwrap::tests::*` — direct-call tests, no rationale in-file | Added WHY comment at the top of `mod tests`, cited to `parse_at_depth:81-94` | Same question keeps surfacing in Codex review rounds (#178/#179/#180). Leaving the answer in-file |
| scope item: `engine/hook.rs + shim → adversarial E2E` | Achieved via the 21 `HOOK_DECISION_CASES` meta-pattern entries | Each case runs the full chain: `omamori install` → shim dir gen → hook script spawn → `hook-check`. No separate test file — scope discipline |

## Meta-pattern fixture breakdown (HEAD: category 15a-15d, 21 entries)

| Category | Description | Fixtures |
|---|---|---|
| 15a | Direct-path `rm` boundary coverage (2 paths × 4 token boundaries) | 8 |
| 15b | `omamori` self-mutation attempts | 5 |
| 15c | Codex CLI hook/config protection + 1 isolation entry for `codex_hooks` | 5 |
| 15d | `rmdir` FP guards (bare + 2 direct paths) | 3 |

## Review narrative

This PR went through 5 adversarial review rounds over two review sources (Codex R1-R3 + two Claude proxy sessions R4, R5 while Codex usage limit locked). All findings below were addressed in this branch before merge.

| Round | Reviewer | Focus | Findings | Head commit |
|---|---|---|---|---|
| R1 | Codex | category 15a: `/usr/bin/rm -rf` double-coverage (rule layer saves) | P2 × 1 | `528dd55` |
| R2 | Codex | category 15a: `/bin/rm` side asymmetric | P2 × 1 | `3b7fe32` |
| R3 | Codex | category 15a: non-space boundaries (dquote/tab/squote) × 2 paths | P2 × 1 | `07d002a` |
| R4 | Claude proxy | 15c codex_hooks isolation, 15d direct-path rmdir, floor test, golden regen comment, unwrap cite | P1 × 1 + P2 × 2 + P3 × 2 + P3-5 defer | `431c84f` |
| R5 | Claude proxy (second pass) | 15c-iso future note, floor arithmetic, unwrap cite redirect, HashableEvent GR-002 cross-ref, PR body stale numbers | P2 × 1 + P3 × 4 (+ 3 defer) | `d4fc57a` + this body edit |

Deferred to v0.9.7+ (proxy's own recommendation, logged for follow-up issue filing):
- Per-category floor map (current `meta-pattern-*` prefix count doesn't trap category-selective drop)
- DI-9 pattern pins (`omamori doctor --fix` / `omamori explain` — inherited gap, not present in the deleted unit tests)
- `check-invariants.sh` floor-existence check (same multi-layer sync pattern as invariant #9)
- `chain_tamper_detected` coverage expansion (reorder / middle-deletion / genesis rewrite — PR4 scope is replace-pattern, not coverage expansion)

## Verification (HEAD: `d4fc57a`)

- `cargo fmt --check` OK
- `cargo clippy --all-targets -- -D warnings` OK
- `cargo test --locked` all green
  - lib: 595 / 0 failed (1 ignored — existing `multi_target_*` quarantine, out of scope)
  - hook_integration: 9 / 0 — `cross_os_invariant` now runs 50+ HOOK_DECISION_CASES entries via install → shim → hook script → hook-check chain. 9th test is the new `corpus_includes_meta_pattern_coverage` floor pin (≥18 meta-pattern fixtures).
  - cli: 101 / 0 · integration: 12 / 0 · poc_integrity: 5 / 0
- `scripts/check-invariants.sh` OK
- `scripts/pre-pr-check.sh` OK

## Regeneration procedure for goldens

Documented inline in `src/audit/mod.rs` near the `GOLDEN_*` consts: run `chain_integrity_verification` with a temporary `println!("{events:#?}")` after `read_events(&logger.path)`, read the printed `entry_hash` / `prev_hash` fields (events[0].prev_hash == genesis), paste, delete the `println!`. Do NOT call `compute_entry_hash` directly on a bare `make_event(...)` result — the chain fields (seq / prev_hash / key_id) would be `None`. All determinism inputs (TEST_SECRET, test_logger defaults, make_event defaults, HashableEvent field order pinned by GR-002) are listed in the comment block.

## Risk

Test-only. No runtime path, no public API touched. semver patch-safe.

## Test plan
- [x] Full `cargo test --locked` green
- [x] `cargo clippy --all-targets -- -D warnings` green
- [x] `cargo fmt --check` green
- [x] `scripts/check-invariants.sh` green
- [x] `scripts/pre-pr-check.sh` green
- [x] CI matrix (macos-latest + ubuntu-latest) green
- [x] Codex adversarial-review R1/R2/R3 addressed
- [x] Claude proxy R4 addressed
- [x] Claude proxy R5 addressed (including this PR body update for P2 B1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)