### PR TITLE
test(property): PR5 - cross-layer proptest (#146 P1-4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -117,10 +138,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -168,10 +217,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
@@ -207,13 +296,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -233,10 +330,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -305,6 +414,7 @@ version = "0.9.5"
 dependencies = [
  "hmac",
  "libc",
+ "proptest",
  "serde",
  "serde_json",
  "serial_test",
@@ -364,6 +474,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,12 +502,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -391,10 +595,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "scc"
@@ -416,6 +651,12 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -548,6 +789,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,10 +898,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urlencoding"
@@ -660,6 +926,33 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -704,6 +997,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -819,6 +1146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +1225,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ shell-words = "1.1"
 
 [dev-dependencies]
 serial_test = "3"
+proptest = "1.11"

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -226,7 +226,10 @@ if [ ! -f "$uw" ]; then
 else
     # Extract quoted basenames from the TRANSPARENT_WRAPPERS const body.
     wrappers=$(awk '
-        /^const TRANSPARENT_WRAPPERS/ { inside=1; next }
+        # Match visibility-prefixed const declarations:
+        # `const TRANSPARENT_WRAPPERS`, `pub const ...`, `pub(crate) const ...` etc.
+        # `pub(crate)` was added by v0.9.6 PR5 for the property test SoT check.
+        /^(pub(\([a-z]+\))?[[:space:]]+)?const TRANSPARENT_WRAPPERS/ { inside=1; next }
         inside {
             if (/\];/) { exit }
             while (match($0, /"[a-zA-Z_][a-zA-Z0-9_-]*"/)) {

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -17,6 +17,13 @@ use crate::unwrap;
 // ---------------------------------------------------------------------------
 
 /// Result of checking a command string through the hook pipeline.
+///
+/// Crate-internal: consumed by `run_hook_check_command` /
+/// `run_cursor_hook` for stderr framing, and by the in-tree property test
+/// (`crate::property_tests`, `#[cfg(test)]`) for cross-layer verdict
+/// comparison. Not re-exported — downstream callers must invoke the AI-
+/// tool hook entry point (`omamori hook-check`) instead, so phase
+/// short-circuits and rule loading both run.
 pub(crate) enum HookCheckResult {
     /// Command is allowed.
     Allow,
@@ -117,18 +124,20 @@ fn detect_env_var_tampering(tokens: &[String]) -> Option<&'static str> {
     None
 }
 
-/// Three-phase hook check:
-/// Phase 1A: String-level meta-patterns (path/config/uninstall)
-/// Phase 1B: Token-level env var tampering detection (whitespace-resilient)
-/// Phase 2: Token-level unwrap stack → rule matching
+/// Phase 1A (meta-patterns), Phase 1B (env tampering), and the structural
+/// branch of Phase 2 (parse-error / pipe-to-shell). Returns
+/// `Err(verdict)` for any early-return case, or `Ok(invocations)` for the
+/// caller to apply rule matching against a chosen rule slice.
 ///
-/// SECURITY (T8): The `Config::default()` fallback on load_config failure is
-/// intentional fail-safe behavior. DO NOT replace with `?` operator.
-pub(crate) fn check_command_for_hook(command: &str) -> HookCheckResult {
+/// Both `check_command_for_hook` and `check_command_for_hook_with_rules`
+/// share this prefix so the production wrapper does not pay
+/// `load_config(None)` when Phase 1A/1B/structural short-circuits the
+/// verdict.
+fn check_pre_phase_2(command: &str) -> Result<Vec<CommandInvocation>, HookCheckResult> {
     // Phase 1A: String-level meta-patterns (path/config/uninstall)
     for (pattern, reason) in installer::blocked_string_patterns() {
         if command.contains(pattern) {
-            return HookCheckResult::BlockMeta(reason);
+            return Err(HookCheckResult::BlockMeta(reason));
         }
     }
 
@@ -147,49 +156,95 @@ pub(crate) fn check_command_for_hook(command: &str) -> HookCheckResult {
     if let Ok(tokens) = shell_words::split(&normalized)
         && let Some(reason) = detect_env_var_tampering(&tokens)
     {
-        return HookCheckResult::BlockMeta(reason);
+        return Err(HookCheckResult::BlockMeta(reason));
     }
 
-    // Phase 2: Unwrap stack → rule matching
-    let parse_result = unwrap::parse_command_string(command);
-
-    match parse_result {
-        unwrap::ParseResult::Block(reason) => HookCheckResult::BlockStructural(format!(
+    // Phase 2 parse: structural block (parse error / pipe-to-shell etc.)
+    match unwrap::parse_command_string(command) {
+        unwrap::ParseResult::Block(reason) => Err(HookCheckResult::BlockStructural(format!(
             "omamori hook: blocked — {}",
             reason.message()
-        )),
-        unwrap::ParseResult::Commands(invocations) => {
-            // Load config to get rules
-            // SECURITY (T8): fail-safe fallback — do NOT use ? here
-            let load_result = match load_config(None) {
-                Ok(r) => r,
-                Err(_) => {
-                    // Config load failure → use default rules (fail-safe, not fail-open)
-                    ConfigLoadResult {
-                        config: config::Config::default(),
-                        warnings: vec![],
-                    }
-                }
+        ))),
+        unwrap::ParseResult::Commands(invocations) => Ok(invocations),
+    }
+}
+
+/// Apply Phase 2 rule matching against an explicit rule slice. Returns the
+/// first matching rule's `BlockRule` verdict, or `Allow`.
+fn match_invocations_against_rules(
+    command: &str,
+    invocations: &[CommandInvocation],
+    rules: &[crate::rules::RuleConfig],
+) -> HookCheckResult {
+    for inv in invocations {
+        if let Some(rule) = match_rule(rules, inv) {
+            let chain_desc = format_unwrap_chain(command, inv);
+            let msg = rule
+                .message
+                .clone()
+                .unwrap_or_else(|| format!("matched rule: {}", rule.name));
+            return HookCheckResult::BlockRule {
+                rule_name: rule.name.clone(),
+                message: msg,
+                unwrap_chain: chain_desc,
             };
-
-            for inv in &invocations {
-                if let Some(rule) = match_rule(&load_result.config.rules, inv) {
-                    let chain_desc = format_unwrap_chain(command, inv);
-                    let msg = rule
-                        .message
-                        .clone()
-                        .unwrap_or_else(|| format!("matched rule: {}", rule.name));
-                    return HookCheckResult::BlockRule {
-                        rule_name: rule.name.clone(),
-                        message: msg,
-                        unwrap_chain: chain_desc,
-                    };
-                }
-            }
-
-            HookCheckResult::Allow
         }
     }
+    HookCheckResult::Allow
+}
+
+/// Three-phase hook check, evaluating against rules loaded from on-disk
+/// config with a `Config::default()` fail-safe fallback.
+///
+/// Phase 1A: String-level meta-patterns (path/config/uninstall)
+/// Phase 1B: Token-level env var tampering detection (whitespace-resilient)
+/// Phase 2: Token-level unwrap stack → rule matching
+///
+/// `load_config(None)` runs lazily — only when Phase 2 actually reaches
+/// the rule-matching arm. Phase 1A/1B/structural short-circuits pay zero
+/// disk I/O.
+///
+/// SECURITY (T8): The `Config::default()` fallback on `load_config` failure
+/// is intentional fail-safe behavior, not fail-open.
+pub(crate) fn check_command_for_hook(command: &str) -> HookCheckResult {
+    let invocations = match check_pre_phase_2(command) {
+        Ok(invs) => invs,
+        Err(verdict) => return verdict,
+    };
+    // Phase 2 reached — load on-disk config now (fail-safe fallback per T8).
+    let load_result = load_config(None).unwrap_or_else(|_| ConfigLoadResult {
+        config: config::Config::default(),
+        warnings: vec![],
+    });
+    match_invocations_against_rules(command, &invocations, &load_result.config.rules)
+}
+
+/// Three-phase hook check, evaluating Phase 2 rule matching against an
+/// explicitly provided rule slice instead of loading config from disk.
+///
+/// Test-only (`#[cfg(test)]`). Production code paths call
+/// [`check_command_for_hook`] so that the user's on-disk
+/// `~/.config/omamori/config.toml` overrides take effect. Compiling this
+/// helper out of the production binary makes the trust-boundary
+/// guarantee structural: a downstream integration cannot call a
+/// security-looking API with `Config::default().rules`, stale rules, or
+/// an empty slice to silently skip user policy overrides, because the
+/// symbol does not exist in the released binary.
+///
+/// The cross-layer property test (`crate::property_tests`) calls this
+/// helper with `Config::default().rules` to keep both layers' verdicts
+/// evaluated against the same canonical rule set, independent of any
+/// ambient developer or CI config file.
+#[cfg(test)]
+pub(crate) fn check_command_for_hook_with_rules(
+    command: &str,
+    rules: &[crate::rules::RuleConfig],
+) -> HookCheckResult {
+    let invocations = match check_pre_phase_2(command) {
+        Ok(invs) => invs,
+        Err(verdict) => return verdict,
+    };
+    match_invocations_against_rules(command, &invocations, rules)
 }
 
 /// Format the unwrap chain for display: "rm -rf / (via bash -c)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,14 @@ use util::{binary_name, print_usage, usage_text};
 pub use cli::policy_test::{PolicyTestResult, run_policy_tests};
 pub use engine::hook::{fuzz_check_command_for_hook, fuzz_extract_hook_input};
 
+// Crate-internal property tests (cross-layer Layer 1 ⟹ Layer 2 invariant).
+// Lives in-tree so it can call `pub(crate)` helpers like
+// `check_command_for_hook_with_rules` without exposing a security-relevant
+// helper to downstream crates. See `src/property_tests.rs` and
+// `engine::hook::check_command_for_hook_with_rules` doc.
+#[cfg(test)]
+mod property_tests;
+
 #[derive(Debug)]
 pub enum AppError {
     Usage(String),

--- a/src/property_tests.rs
+++ b/src/property_tests.rs
@@ -1,0 +1,551 @@
+//! Cross-layer property test (v0.9.6 PR5, #146 P1-4).
+//!
+//! Pin the one-way implication: if Layer 1 (PATH shim) verdicts a
+//! command invocation as Block / Trash / MoveTo, then Layer 2 (PreToolUse
+//! hook) MUST block the wrapped command string. The reverse direction is
+//! intentionally not pinned: Layer 2 may legitimately block strings whose
+//! tokenized form Layer 1 allows (e.g. parse errors, env-var tampering on
+//! non-shim verbs, structural pipe-to-shell, meta-pattern path bypass).
+//!
+//! ## Why a crate-internal test, not `tests/`
+//!
+//! The property test must call a hermetic version of the hook check that
+//! evaluates Phase 2 against an explicit rule slice instead of loading
+//! config from disk, so that Layer 2 sees the same `Config::default()`
+//! rule set as Layer 1. That helper
+//! ([`crate::engine::hook::check_command_for_hook_with_rules`]) is
+//! deliberately `pub(crate)` — re-exporting it would let downstream
+//! integrations bypass user policy overrides and silently turn deny rules
+//! into allows. Living in-tree under `#[cfg(test)] mod property_tests` is
+//! the cleanest way to use it without widening the production API surface.
+//!
+//! ## Generator design (CWD-independent)
+//!
+//!   destructive_core × wrapper
+//!
+//!   destructive_core ∈ {rm-recursive, find-delete, chmod-777,
+//!                       rsync-delete, git-push-force, git-clean-force}
+//!     — covers every Block/Trash/MoveTo built-in rule emitted by
+//!       `default_rules()`. The set of covered rule names is mirrored in
+//!       the constant [`COVERED_DESTRUCTIVE_RULES`] and pinned by the unit
+//!       test [`coverage_matches_default_rules_destructive_set`], so adding
+//!       a new built-in destructive rule will fail the test until both the
+//!       constant and the generator are updated.
+//!
+//!   wrapper ∈ {Direct,
+//!              Sudo, Doas, Pkexec, EnvU,
+//!              Timeout, Nice, Nohup, Command, Exec,
+//!              BashC, PipeBash, PipeEnvS, SourceDevStdin}
+//!     — every entry in `unwrap::TRANSPARENT_WRAPPERS` (sudo / env /
+//!       timeout / nice / nohup / command / exec / doas / pkexec) is
+//!       represented as a `Wrapper::*` variant, plus four shell-launcher
+//!       variants closed in PR2 (`bash -c`, pipe-to-bash, env -S
+//!       split-string, source /dev/stdin). The transparent-wrapper subset
+//!       is pinned by [`wrapper_kinds_cover_transparent_wrappers_sot`] so
+//!       a future addition to the SoT fails this test until the enum is
+//!       extended.
+//!
+//! Path arguments are drawn from a fixed list of literal absolute paths so
+//! the generator is independent of the test process's working directory
+//! (see PR1 / `normalize_path_with_base` and the v0.9.6 PR5 design note in
+//! `moonlit-sparking-meadow.md`).
+//!
+//! ## Properties (256 cases each)
+//!
+//!   1. [`cross_layer_layer1_destructive_implies_layer2_blocks`] — the core
+//!      one-way implication.
+//!   2. [`generator_emits_only_destructive_cores`] — sanity guard against
+//!      `default_rules()` drifting away from generator coverage. If a
+//!      built-in rule's `match_any` is tightened (e.g. `-fr` is removed
+//!      from `rm-recursive-to-trash`), this property fires and forces the
+//!      generator to be updated in lockstep.
+//!
+//! ## Companion unit test
+//!
+//!   [`coverage_matches_default_rules_destructive_set`] — explicit drift
+//!     guard comparing [`COVERED_DESTRUCTIVE_RULES`] against the actual
+//!     destructive rule names in `Config::default()`.
+
+use crate::config::Config;
+use crate::engine::hook::{HookCheckResult, check_command_for_hook_with_rules};
+use crate::rules::{ActionKind, CommandInvocation, RuleConfig, match_rule};
+
+use proptest::prelude::*;
+
+// ----------------------------------------------------------------------
+// Coverage manifest
+// ----------------------------------------------------------------------
+
+/// The destructive (Block / Trash / MoveTo) rule names from
+/// `default_rules()` that the generator covers. Pinned by
+/// [`coverage_matches_default_rules_destructive_set`] — adding or
+/// renaming a destructive built-in rule must update both this list and the
+/// matching generator branch in [`arb_destructive_core`].
+const COVERED_DESTRUCTIVE_RULES: &[&str] = &[
+    "rm-recursive-to-trash",
+    "git-push-force-block",
+    "git-clean-force-block",
+    "chmod-777-block",
+    "find-delete-block",
+    "rsync-delete-block",
+];
+
+// ----------------------------------------------------------------------
+// Layer judgment helpers
+// ----------------------------------------------------------------------
+
+/// Layer 1 destructive verdict: a protected-environment invocation of
+/// `(program, args)` would be Blocked, sent to Trash, or MovedTo.
+///
+/// Mirrors the post-`match_rule` branch of `engine::shim::run_command`.
+/// Context overrides (`engine::shim` Tier-1 path-based escalation) are
+/// deliberately ignored: they are monotonic (Trash → Block on dangerous
+/// paths), so the un-overridden rule action is the strongest one-way
+/// implication antecedent.
+///
+/// `StashThenExec` (git reset --hard) and `LogOnly` are NOT considered
+/// destructive — they execute the command after a safety net rather than
+/// preventing it.
+fn layer1_destructive(program: &str, args: &[String], rules: &[RuleConfig]) -> bool {
+    let invocation = CommandInvocation::new(program.to_string(), args.to_vec());
+    match match_rule(rules, &invocation) {
+        Some(rule) => matches!(
+            rule.action,
+            ActionKind::Block | ActionKind::Trash | ActionKind::MoveTo
+        ),
+        None => false,
+    }
+}
+
+/// Layer 2 blocking verdict against an explicit rule slice (hermetic; does
+/// not read on-disk config). Returns true for any of the three blocking
+/// variants of `check_command_for_hook_with_rules` (meta-pattern,
+/// structural unwrap, rule match).
+fn layer2_blocks(command: &str, rules: &[RuleConfig]) -> bool {
+    matches!(
+        check_command_for_hook_with_rules(command, rules),
+        HookCheckResult::BlockMeta(_)
+            | HookCheckResult::BlockStructural(_)
+            | HookCheckResult::BlockRule { .. }
+    )
+}
+
+// ----------------------------------------------------------------------
+// Path generator (CWD-independent literals)
+// ----------------------------------------------------------------------
+
+/// Literal absolute paths. Constraints:
+///   - No whitespace, no shell metacharacters → safe for unquoted
+///     interpolation into `bash -c "..."`, `echo "..." | bash`, etc.
+///   - Mix of /tmp / /etc / /var / /usr / /opt / /private / /Users to
+///     exercise both safe-prefix and dangerous-prefix path classes (path
+///     classification is layer-invariant in v0.9.6 — neither layer trims
+///     prefixes — so the implication is pinned independent of path).
+fn arb_path() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("/tmp/foo".to_string()),
+        Just("/tmp/dir-x".to_string()),
+        Just("/tmp/scratch".to_string()),
+        Just("/var/log/test.log".to_string()),
+        Just("/etc/passwd".to_string()),
+        Just("/etc/hosts".to_string()),
+        Just("/usr/local/share/x".to_string()),
+        Just("/opt/data".to_string()),
+        Just("/private/tmp/y".to_string()),
+        Just("/Users/test/work".to_string()),
+    ]
+}
+
+// ----------------------------------------------------------------------
+// Per-program destructive core generators
+// ----------------------------------------------------------------------
+
+/// `rm` with a flag combination that hits `rm-recursive-to-trash` rule
+/// (`match_any: ["-r", "-rf", "-fr", "--recursive"]`). Includes the
+/// reordered-flag forms `-r -f` / `-f -r`: `shell_words` preserves token
+/// order, so these tokenize to two args while `-rf` / `-fr` tokenize to
+/// one. The rule must match both shapes.
+///
+/// Note 1: `-Rf` / `-fR` / `-R` (uppercase) is intentionally excluded —
+/// the built-in rule does not list `-R` in `match_any`, so those forms
+/// are a known Layer 1 hole tracked separately. Including them would only
+/// widen the antecedent-false (vacuous) part of the implication and
+/// dilute coverage.
+///
+/// Note 2 (drift signal): `generator_emits_only_destructive_cores` fires
+/// when `rm-recursive-to-trash`'s coverage genuinely collapses — for
+/// example if BOTH `-r` AND `--recursive` are dropped from `match_any`,
+/// or if the rule's `command` is renamed away from `rm`. Removing only
+/// the multi-character bundles `-rf` / `-fr` is NOT enough to trip the
+/// guard, because `rules::expand_short_flags` decomposes them into `-r`
+/// and `-f` and the rule still matches via the surviving `-r`.
+fn arb_rm_core() -> impl Strategy<Value = (String, Vec<String>)> {
+    let flag_combo = prop_oneof![
+        Just(vec!["-rf".to_string()]),
+        Just(vec!["-fr".to_string()]),
+        Just(vec!["-r".to_string()]),
+        Just(vec!["-r".to_string(), "-f".to_string()]),
+        Just(vec!["-f".to_string(), "-r".to_string()]),
+        Just(vec!["--recursive".to_string()]),
+    ];
+    (flag_combo, arb_path()).prop_map(|(mut flags, path)| {
+        flags.push(path);
+        ("rm".to_string(), flags)
+    })
+}
+
+/// `find <path> -delete` / `find <path> --delete` (find-delete-block rule).
+fn arb_find_core() -> impl Strategy<Value = (String, Vec<String>)> {
+    let delete_flag = prop_oneof![Just("-delete".to_string()), Just("--delete".to_string())];
+    (arb_path(), delete_flag).prop_map(|(path, flag)| ("find".to_string(), vec![path, flag]))
+}
+
+/// `chmod 777 <path>` (chmod-777-block rule).
+fn arb_chmod_core() -> impl Strategy<Value = (String, Vec<String>)> {
+    arb_path().prop_map(|path| ("chmod".to_string(), vec!["777".to_string(), path]))
+}
+
+/// `rsync -av <src> <dst> --delete` (rsync-delete-block rule). Covers all
+/// 8 destructive rsync flags listed in `default_rules()`.
+fn arb_rsync_core() -> impl Strategy<Value = (String, Vec<String>)> {
+    let delete_flag = prop_oneof![
+        Just("--delete".to_string()),
+        Just("--del".to_string()),
+        Just("--delete-before".to_string()),
+        Just("--delete-during".to_string()),
+        Just("--delete-after".to_string()),
+        Just("--delete-excluded".to_string()),
+        Just("--delete-delay".to_string()),
+        Just("--remove-source-files".to_string()),
+    ];
+    (arb_path(), arb_path(), delete_flag)
+        .prop_map(|(src, dst, flag)| ("rsync".to_string(), vec!["-av".to_string(), src, dst, flag]))
+}
+
+/// `git push <remote> <branch> --force` / `-f` (git-push-force-block rule).
+/// `match_all: ["push"]`, `match_any: ["--force", "-f"]`.
+fn arb_git_push_force_core() -> impl Strategy<Value = (String, Vec<String>)> {
+    let force_flag = prop_oneof![Just("--force".to_string()), Just("-f".to_string())];
+    let remote = prop_oneof![Just("origin".to_string()), Just("upstream".to_string())];
+    let branch = prop_oneof![Just("main".to_string()), Just("master".to_string())];
+    (remote, branch, force_flag)
+        .prop_map(|(r, b, flag)| ("git".to_string(), vec!["push".to_string(), r, b, flag]))
+}
+
+/// `git clean -f` / `git clean --force` (git-clean-force-block rule).
+/// `match_all: ["clean"]`, `match_any: ["-f", "--force"]`. Force is required
+/// because vanilla `git clean` is a no-op for safety.
+fn arb_git_clean_force_core() -> impl Strategy<Value = (String, Vec<String>)> {
+    let force_flag = prop_oneof![Just("-f".to_string()), Just("--force".to_string())];
+    let extra_flag = prop_oneof![
+        Just(Vec::<String>::new()),
+        Just(vec!["-d".to_string()]),
+        Just(vec!["-x".to_string()]),
+    ];
+    (force_flag, extra_flag).prop_map(|(force, extras)| {
+        let mut args = vec!["clean".to_string(), force];
+        args.extend(extras);
+        ("git".to_string(), args)
+    })
+}
+
+/// Union: any destructive core. Each variant has equal weight in the
+/// uniform `prop_oneof!` distribution. The set must stay in lockstep with
+/// [`COVERED_DESTRUCTIVE_RULES`] and the destructive subset of
+/// `default_rules()` — see [`coverage_matches_default_rules_destructive_set`].
+fn arb_destructive_core() -> impl Strategy<Value = (String, Vec<String>)> {
+    prop_oneof![
+        arb_rm_core(),
+        arb_find_core(),
+        arb_chmod_core(),
+        arb_rsync_core(),
+        arb_git_push_force_core(),
+        arb_git_clean_force_core(),
+    ]
+}
+
+// ----------------------------------------------------------------------
+// Wrapper generators
+// ----------------------------------------------------------------------
+
+/// Wrapper variants. Each wrapper preserves the destructive intent:
+/// the inner program is what eventually runs (or would run, in the
+/// pipe-to-shell case where the launcher is structurally blocked).
+///
+/// The transparent-wrapper subset (`Sudo / Doas / Pkexec / EnvU /
+/// Timeout / Nice / Nohup / Command / Exec`) covers every entry in
+/// `unwrap::TRANSPARENT_WRAPPERS`; this is pinned by
+/// [`wrapper_kinds_cover_transparent_wrappers_sot`] so SoT additions
+/// fail-loud here.
+#[derive(Debug, Clone, Copy)]
+enum Wrapper {
+    /// `<inner>` — no wrapper.
+    Direct,
+    /// `sudo <inner>` — privilege elevation wrapper.
+    Sudo,
+    /// `doas <inner>` — OpenBSD-derived sudo alternative (PR2 / #180).
+    Doas,
+    /// `pkexec <inner>` — PolicyKit elevation (PR2 / #180).
+    Pkexec,
+    /// `env -u SHLVL <inner>` — env wrapper unsetting a non-detector
+    /// variable. SHLVL is intentional: detector vars (CLAUDECODE etc.)
+    /// would short-circuit Phase 1B (HookCheckResult::BlockMeta) and mask
+    /// the unwrap-stack peeling path being exercised here. Phase 1B
+    /// detector-var coverage is tracked separately for v0.9.7 (#187).
+    EnvU,
+    /// `timeout 30 <inner>` — coreutils timeout wrapper. SoT entry.
+    Timeout,
+    /// `nice <inner>` — process-priority wrapper. SoT entry.
+    Nice,
+    /// `nohup <inner>` — disown-on-hangup wrapper. SoT entry.
+    Nohup,
+    /// `command <inner>` — POSIX `command` builtin / external. SoT entry.
+    Command,
+    /// `exec <inner>` — POSIX `exec` builtin (replaces shell). SoT entry.
+    Exec,
+    /// `bash -c "<inner>"` — shell launcher with `-c`.
+    BashC,
+    /// `echo "<inner>" | bash` — pipe-to-shell, classic v0.9.5 surface.
+    PipeBash,
+    /// `echo "<inner>" | env -S 'bash -e'` — split-string env launcher
+    /// (PR2 / #178).
+    PipeEnvS,
+    /// `echo "<inner>" | bash -c 'source /dev/stdin'` — stdin source
+    /// (PR2 / #179).
+    SourceDevStdin,
+}
+
+/// Names of the transparent-wrapper subset of [`Wrapper`], in the
+/// canonical SoT spelling. Pinned against `unwrap::TRANSPARENT_WRAPPERS`
+/// by [`wrapper_kinds_cover_transparent_wrappers_sot`].
+const WRAPPER_TRANSPARENT_NAMES: &[&str] = &[
+    "sudo", "doas", "pkexec", "env", "timeout", "nice", "nohup", "command", "exec",
+];
+
+fn arb_wrapper() -> impl Strategy<Value = Wrapper> {
+    prop_oneof![
+        Just(Wrapper::Direct),
+        Just(Wrapper::Sudo),
+        Just(Wrapper::Doas),
+        Just(Wrapper::Pkexec),
+        Just(Wrapper::EnvU),
+        Just(Wrapper::Timeout),
+        Just(Wrapper::Nice),
+        Just(Wrapper::Nohup),
+        Just(Wrapper::Command),
+        Just(Wrapper::Exec),
+        Just(Wrapper::BashC),
+        Just(Wrapper::PipeBash),
+        Just(Wrapper::PipeEnvS),
+        Just(Wrapper::SourceDevStdin),
+    ]
+}
+
+/// Assemble the wrapped command string. Inner text is interpolated raw —
+/// the path generator guarantees no whitespace, quotes, `$`, or backticks.
+fn assemble_command(program: &str, args: &[String], wrapper: Wrapper) -> String {
+    let inner = format!("{} {}", program, args.join(" "));
+    match wrapper {
+        Wrapper::Direct => inner,
+        Wrapper::Sudo => format!("sudo {inner}"),
+        Wrapper::Doas => format!("doas {inner}"),
+        Wrapper::Pkexec => format!("pkexec {inner}"),
+        Wrapper::EnvU => format!("env -u SHLVL {inner}"),
+        Wrapper::Timeout => format!("timeout 30 {inner}"),
+        Wrapper::Nice => format!("nice {inner}"),
+        Wrapper::Nohup => format!("nohup {inner}"),
+        Wrapper::Command => format!("command {inner}"),
+        Wrapper::Exec => format!("exec {inner}"),
+        Wrapper::BashC => format!("bash -c \"{inner}\""),
+        Wrapper::PipeBash => format!("echo \"{inner}\" | bash"),
+        Wrapper::PipeEnvS => format!("echo \"{inner}\" | env -S 'bash -e'"),
+        Wrapper::SourceDevStdin => {
+            format!("echo \"{inner}\" | bash -c 'source /dev/stdin'")
+        }
+    }
+}
+
+// ----------------------------------------------------------------------
+// Combined case generator
+// ----------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Case {
+    program: String,
+    args: Vec<String>,
+    wrapper: Wrapper,
+}
+
+impl Case {
+    fn command_string(&self) -> String {
+        assemble_command(&self.program, &self.args, self.wrapper)
+    }
+}
+
+fn arb_case() -> impl Strategy<Value = Case> {
+    (arb_destructive_core(), arb_wrapper()).prop_map(|((program, args), wrapper)| Case {
+        program,
+        args,
+        wrapper,
+    })
+}
+
+// ----------------------------------------------------------------------
+// Drift guards (deterministic unit tests, run always)
+// ----------------------------------------------------------------------
+
+/// Pin [`WRAPPER_TRANSPARENT_NAMES`] against `unwrap::TRANSPARENT_WRAPPERS`
+/// (the single source of truth used by `unwrap_transparent` and
+/// `segment_executes_shell_via_wrappers`). Adding a transparent wrapper
+/// to the SoT without adding a matching `Wrapper::*` variant — and
+/// updating `arb_wrapper`, `assemble_command`, and the doc — fires here.
+///
+/// This closes the prior PR5 review-round gap where the generator
+/// silently covered only 4 of 9 SoT entries and the doc claimed full
+/// SoT coverage.
+#[test]
+fn wrapper_kinds_cover_transparent_wrappers_sot() {
+    let mut sot: Vec<&str> = crate::unwrap::TRANSPARENT_WRAPPERS.to_vec();
+    sot.sort();
+
+    let mut covered: Vec<&str> = WRAPPER_TRANSPARENT_NAMES.to_vec();
+    covered.sort();
+
+    assert_eq!(
+        covered, sot,
+        "Wrapper enum drifted from `unwrap::TRANSPARENT_WRAPPERS`.\n\
+         Expected (WRAPPER_TRANSPARENT_NAMES): {covered:?}\n\
+         Actual   (unwrap::TRANSPARENT_WRAPPERS): {sot:?}\n\
+         Update WRAPPER_TRANSPARENT_NAMES, the Wrapper enum, arb_wrapper, \
+         assemble_command, and the module-level doc when the SoT changes.",
+    );
+}
+
+/// Pin [`COVERED_DESTRUCTIVE_RULES`] against the actual destructive subset
+/// of `default_rules()`. Adding, removing, or renaming a destructive
+/// built-in rule (Block / Trash / MoveTo) without updating both the
+/// generator branch in [`arb_destructive_core`] and this constant fires
+/// here, before any property test runs.
+#[test]
+fn coverage_matches_default_rules_destructive_set() {
+    let config = Config::default();
+    let mut actual: Vec<&str> = config
+        .rules
+        .iter()
+        .filter(|r| {
+            matches!(
+                r.action,
+                ActionKind::Block | ActionKind::Trash | ActionKind::MoveTo
+            )
+        })
+        .map(|r| r.name.as_str())
+        .collect();
+    actual.sort();
+
+    let mut expected: Vec<&str> = COVERED_DESTRUCTIVE_RULES.to_vec();
+    expected.sort();
+
+    assert_eq!(
+        actual, expected,
+        "Generator coverage drifted from default_rules() destructive set.\n\
+         Expected (COVERED_DESTRUCTIVE_RULES): {expected:?}\n\
+         Actual   (default_rules destructive): {actual:?}\n\
+         Update both COVERED_DESTRUCTIVE_RULES and arb_destructive_core when \
+         a destructive built-in rule changes.",
+    );
+}
+
+// ----------------------------------------------------------------------
+// Wrapper-stack smoke (deterministic, depth ≥ 2)
+// ----------------------------------------------------------------------
+
+/// Single-wrapper variants exercise the first iteration of
+/// `unwrap_transparent`'s while-loop (src/unwrap.rs:346) but never test
+/// the recursive peel itself. A regression that breaks transparent-wrapper
+/// chaining (e.g. an early-return after the first wrapper) would slip
+/// past the 256-case property if every generated case has only one
+/// wrapper.
+///
+/// This deterministic smoke covers three representative depth-2 / 3
+/// stacks. Full exhaustive depth 0–3 coverage is deferred to v0.9.7
+/// (#187, "stacked-unwrap-implication" property).
+#[test]
+fn wrapper_stack_smoke_pins_layer2_block() {
+    let config = Config::default();
+
+    // Each entry must produce a Layer 2 Block verdict (any variant) when
+    // evaluated against the default rule set. Picked to span:
+    //   1. transparent + transparent + destructive
+    //   2. coreutils-only stack with no privilege-elevation arms
+    //   3. transparent + shell-launcher (mixed peel + structural block)
+    let stacks: &[&str] = &[
+        "sudo env -u SHLVL rm -rf /tmp/foo",
+        "timeout 30 nohup rm -rf /tmp/foo",
+        "sudo env bash -c \"rm -rf /tmp/foo\"",
+    ];
+
+    for cmd in stacks {
+        assert!(
+            layer2_blocks(cmd, &config.rules),
+            "Wrapper-stack smoke must Layer 2 Block: {cmd}",
+        );
+    }
+}
+
+// ----------------------------------------------------------------------
+// Property tests
+// ----------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        ..ProptestConfig::default()
+    })]
+
+    /// Cross-layer one-way implication: Layer 1 destructive → Layer 2 blocks.
+    ///
+    /// Antecedent `layer1_destructive(program, args)` evaluates the inner
+    /// core invocation against `default_rules()` — what the shim would see
+    /// after the wrapper resolves. Consequent `layer2_blocks(cmd)` evaluates
+    /// the full wrapped string through the hook pipeline against the same
+    /// rule slice (hermetic; ambient user config has no effect).
+    ///
+    /// A failure means the hook would forward an AI-emitted command string
+    /// that the shim would later block — i.e. a Layer 2 detection gap.
+    #[test]
+    fn cross_layer_layer1_destructive_implies_layer2_blocks(case in arb_case()) {
+        let config = Config::default();
+        let l1 = layer1_destructive(&case.program, &case.args, &config.rules);
+        if l1 {
+            let cmd = case.command_string();
+            let l2 = layer2_blocks(&cmd, &config.rules);
+            prop_assert!(
+                l2,
+                "Layer 1 destructive but Layer 2 allowed:\n  program: {}\n  args:    {:?}\n  wrapper: {:?}\n  cmd:     {}",
+                case.program,
+                case.args,
+                case.wrapper,
+                cmd,
+            );
+        }
+    }
+
+    /// Generator sanity guard: every emitted core IS destructive at Layer 1.
+    ///
+    /// This pins the generator against `default_rules()` drift. If a future
+    /// PR removes a flag from a built-in rule's `match_any` (e.g. drops
+    /// `-fr` from `rm-recursive-to-trash`), this property fires and forces
+    /// the generator to be updated rather than silently emitting cores
+    /// where the implication's antecedent is false (vacuous coverage).
+    #[test]
+    fn generator_emits_only_destructive_cores(case in arb_case()) {
+        let config = Config::default();
+        prop_assert!(
+            layer1_destructive(&case.program, &case.args, &config.rules),
+            "Generator emitted a non-destructive core:\n  program: {}\n  args:    {:?}\n  cmd:     {}",
+            case.program,
+            case.args,
+            case.command_string(),
+        );
+    }
+}

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -26,7 +26,12 @@ const SHELL_NAMES: &[&str] = &["bash", "sh", "zsh", "dash", "ksh"];
 // matching arg-consumption arm to `unwrap_transparent` silently reopens the
 // bypass, so `scripts/check-invariants.sh` invariant #9 enforces that every
 // entry here appears in both sites.
-const TRANSPARENT_WRAPPERS: &[&str] = &[
+//
+// `pub(crate)` exposure: the cross-layer property test
+// (`crate::property_tests`, v0.9.6 PR5) compares this SoT against its own
+// wrapper-kind enum to catch generator drift when a new transparent wrapper
+// is added here without matching property coverage.
+pub(crate) const TRANSPARENT_WRAPPERS: &[&str] = &[
     "sudo", "env", "timeout", "nice", "nohup", "command", "exec", "doas", "pkexec",
 ];
 


### PR DESCRIPTION
## Summary

v0.9.6 PR5 (scope 3, plan: `~/.claude/plans/moonlit-sparking-meadow.md`). Pins the cross-layer one-way implication via proptest 1.11:

> Layer 1 (PATH shim) destructive verdict (Block / Trash / MoveTo) ⟹ Layer 2 (PreToolUse hook) Block

The reverse direction is intentionally not pinned — Layer 2 may legitimately block strings whose tokenized form Layer 1 allows (parse errors, env-var tampering on non-shim verbs, structural pipe-to-shell, meta-pattern path bypass).

## Tests (lib unit tests 595 → 600)

`src/property_tests.rs` (new, `#[cfg(test)] mod`):
- 2 proptest properties (256 cases each)
- 3 deterministic drift / smoke guards

Generator: 6 destructive built-in rules × 14 wrapper variants (Direct + 9 `TRANSPARENT_WRAPPERS` SoT entries + 4 shell launchers).

## Trust boundary

- `check_command_for_hook_with_rules` is `#[cfg(test)]` — symbol does not exist in the released binary, so downstream callers cannot bypass on-disk policy
- `HookCheckResult` and `check_command_for_hook` remain `pub(crate)` — no public API additions over v0.9.5
- Production `check_command_for_hook` refactored to share helpers (`check_pre_phase_2` + `match_invocations_against_rules`) with the test entry point, with `load_config(None)` deferred until Phase 2 reaches rule matching (Phase 1A/1B/structural short-circuits pay zero disk I/O)

## Drift guards (deterministic)

- `coverage_matches_default_rules_destructive_set` — pins generator coverage against `default_rules()` destructive subset
- `wrapper_kinds_cover_transparent_wrappers_sot` — pins `Wrapper` enum against `unwrap::TRANSPARENT_WRAPPERS` SoT
- `wrapper_stack_smoke_pins_layer2_block` — depth ≥ 2 transparent-wrapper-stack trip-wire

## Review history

| Round | Verdict | Outcome |
|-------|---------|---------|
| R1 (adversarial-review) | needs-attention (high+medium) | git-clean coverage + ambient config dependency → fixed |
| R2 (adversarial-review) | needs-attention (high) | trust-boundary regression on `pub use` → reverted to `pub(crate)` + `#[cfg(test)]` gate, moved to `src/property_tests.rs` |
| R3 (adversarial-review) | approve | no material findings |
| R4 (Phase 6-B test adversarial) | FAIL | `-fr` comment factual error + Wrapper SoT misalignment + wrapper-stack smoke gap → fixed |
| R5 ('all-out' enumeration) | REVISE-WITH-ADDITIONS | 4/10 fixed, 6/10 deferred as vacuous (validated by Claude proxy review) |
| Proxy R6 | B+ alternative | confirmed PR5 ship-blocking guard satisfies 4 minimum conditions |
| /simplify (3-agent triage) | 5 findings | A3-F1 (semantic regression: load_config eager → lazy) + A2-#2 (API surface revoke) + 3 polish — all fixed |

## Test plan
- [x] \`cargo fmt --check\` — pass
- [x] \`cargo clippy --all-targets --locked -- -D warnings\` — 0 warnings
- [x] \`cargo test --locked\` — all pass (lib 595 → 600)
- [x] \`scripts/check-invariants.sh\` — #1-#9 OK (TRANSPARENT_WRAPPERS sync intact)
- [x] \`scripts/check-lockfile-regressions.sh\` — lockfile-sanity OK
- [x] \`scripts/check-action-pins.sh\` — OK
- [x] \`scripts/check-crate-contents.sh\` — \`src/property_tests.rs\` matches \`src/**/*.rs\` allowlist

## Defer to v0.9.7 (#187)

| Item | Rationale |
|------|-----------|
| Detector env tampering × destructive core property | Phase 1B single-axis property, off PR5 thesis |
| rsync 8-flag deterministic explicit table | 256 cases probabilistically cover; rigor uplift marginal |
| git push / rm flag-position variants | \`match_any\` is position-independent → vacuous |
| Full wrapper-stack depth 0–3 exhaustive | Combinatorial explosion; smoke 2–3 covers regression trip-wire |
| POSIX \`--\` separator across wrappers | Different invariant family (\`match_rule\` evaluates expanded args, not \`target_args\`) |
| Per-rule representative argv manifest | Separate design decision |

## Plan & v0.9.6 series

- Plan: \`~/.claude/plans/moonlit-sparking-meadow.md\`
- v0.9.6 PR series: PR1 [#183] / PR2 [#184] / PR3 [#185] / PR4 [#186] merged. PR5 (this), PR6, PR7 remaining.

Refs: #146 P1-4, #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)