### PR TITLE
feat(hook): PR6 — structure-based routing for unknown tools (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ The format is based on Keep a Changelog.
 ### Notes for users
 
 - No config or installation change. macOS-only.
+- **Protection guarantee is unchanged**: any payload carrying a recognised dangerous shape (`command`/`cmd`/`file_path`/`path`) still routes through the full pipeline regardless of `tool_name`. The new `unknown_tool_fail_open` events are observability noise on legitimate tools whose `tool_input` shape is not yet in the catalogue, not a regression in protection.
 - Existing audit logs continue to verify against the same hash chain; `CHAIN_VERSION` is unchanged. `omamori audit verify` should pass after upgrading.
-- If you have downstream tooling parsing audit JSON: the `action` field can now carry the new value `"unknown_tool_fail_open"` (in addition to the existing `passthrough`/`block`/`trash`/etc.), and `detection_layer` can now carry the new value `"shape-routing"` for those events. `result` is `"allow"`, `command` borrows the unrecognised tool name, and `target_count` borrows the count of recognised top-level keys in `tool_input`. Filter on `action == "unknown_tool_fail_open"` rather than relying on the borrowed semantics of `command` or `target_count`; dedicated columns will land in a future release.
+- If you have downstream tooling parsing audit JSON: **filter on `action == "unknown_tool_fail_open"` first** to isolate these events from your existing aggregations. Within those events, `result` is `"allow"`, `detection_layer` is `"shape-routing"`, and `command` / `target_count` are borrowed columns (carrying `tool_name` and `tool_input` top-level key count respectively); aggregations across action types over either column will be skewed. Dedicated columns are tracked for a future omamori release.
 
 ### Known limitations carried into a future release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [Unreleased]
+
+### Changed
+
+- **Unknown / forward-compat tools now route by `tool_input` shape, not `tool_name`** ([#182](https://github.com/yottayoshida/omamori/issues/182)). The previous `HookInput::UnknownTool` branch unconditionally allowed any tool whose name omamori did not recognise — meaning a provider-side rename (Claude Code → Cursor → Codex → next-week's CLI) of a write or exec tool would silently bypass Layer 2 protection. The hook now inspects `tool_input` field structure independently of the tool name: a `command`/`cmd` string routes through the full Bash pipeline; a `file_path`/`path` string routes through FileOp / protected-path checks; a `url` string is treated as read-only (allowed); anything else falls through to an *observable* fail-open. Wrong-type routing fields (e.g. `command: 42`) now fail closed rather than dropping into the unknown branch.
+- **Observable fail-open for genuinely unknown shapes**. When a tool's `tool_input` matches none of the recognised shapes, omamori still allows the call (we keep user workflow alive rather than starting to block unreviewed tools retroactively), but the silence is gone: stderr now carries a one-line, tool-name-deduplicated hint pointing at the new review surface, and an `unknown_tool_fail_open` event is appended to the audit chain. The `tool_input` payload structure (number of recognised top-level keys) is recorded so an analyst can see at a glance whether the tool sent zero fields, one field, or many. No `CHAIN_VERSION` bump — this is a new value for the existing `action` field, parsers that don't recognise the value treat it as opaque.
+
+### Added
+
+- **`omamori audit unknown`** subcommand. Surfaces every `unknown_tool_fail_open` event in the audit log, paginated like `audit show` (`--last N`, `--json`); defaults to `--all` so review is complete by default. This is the user-facing endpoint of the stderr hint above — an answer to "review what?".
+- **`omamori audit show --action <name>`**. Generic exact-match filter on the `action` field; `audit unknown` is sugar over this.
+- **`omamori doctor` "Last 30 days" line**. When the audit log carries any `unknown_tool_fail_open` events from the last 30 days, doctor surfaces the count and points at `omamori audit unknown`. Skipped when zero so doctor stays quiet on healthy installs.
+
+### Security
+
+- **Forward-compat fail-open closed** ([#182](https://github.com/yottayoshida/omamori/issues/182), Codex adversarial-review ② A-2 critical). Before this change, a hostile or merely renamed tool could carry a payload like `{"tool_name":"FuturePlanWriter","tool_input":{"command":"/bin/rm -rf /"}}` and the entire shell pipeline (meta-pattern detection, env-tampering checks, unwrap stack) would never run because `HookInput::UnknownTool` short-circuited to allow. Equivalent payloads now Block at exit code 2.
+
+### Notes for users
+
+- No config or installation change. macOS-only.
+- Existing audit logs continue to verify against the same hash chain; `CHAIN_VERSION` is unchanged. `omamori audit verify` should pass after upgrading.
+- If you have downstream tooling parsing audit JSON: the `action` field can now carry the new value `"unknown_tool_fail_open"` (in addition to the existing `passthrough`/`block`/`trash`/etc.). `result` for those events is `"allow"`, `command` carries the unrecognised tool name, and `target_count` is the count of recognised top-level keys in `tool_input`.
+
 ## [0.9.5] - 2026-04-20
 
 **Summary**: Security patch ([#146](https://github.com/yottayoshida/omamori/issues/146) P1-1) + Ubuntu CI quarantine ([#164](https://github.com/yottayoshida/omamori/issues/164)) + docs refresh ([#167](https://github.com/yottayoshida/omamori/issues/167)). Closes the documented `curl URL | env bash` / `curl URL | sudo bash` wrapper-evasion gap. Runtime behavior is otherwise unchanged — omamori remains macOS-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on Keep a Changelog.
 ### Changed
 
 - **Unknown / forward-compat tools now route by `tool_input` shape, not `tool_name`** ([#182](https://github.com/yottayoshida/omamori/issues/182)). The previous `HookInput::UnknownTool` branch unconditionally allowed any tool whose name omamori did not recognise — meaning a provider-side rename (Claude Code → Cursor → Codex → next-week's CLI) of a write or exec tool would silently bypass Layer 2 protection. The hook now inspects `tool_input` field structure independently of the tool name: a `command`/`cmd` string routes through the full Bash pipeline; a `file_path`/`path` string routes through FileOp / protected-path checks; a `url` string is treated as read-only (allowed); anything else falls through to an *observable* fail-open. Wrong-type routing fields (e.g. `command: 42`) now fail closed rather than dropping into the unknown branch.
-- **Observable fail-open for genuinely unknown shapes**. When a tool's `tool_input` matches none of the recognised shapes, omamori still allows the call (we keep user workflow alive rather than starting to block unreviewed tools retroactively), but the silence is gone: stderr now carries a one-line, tool-name-deduplicated hint pointing at the new review surface, and an `unknown_tool_fail_open` event is appended to the audit chain. The `tool_input` payload structure (number of recognised top-level keys) is recorded so an analyst can see at a glance whether the tool sent zero fields, one field, or many. No `CHAIN_VERSION` bump — this is a new value for the existing `action` field, parsers that don't recognise the value treat it as opaque.
+- **Observable fail-open for genuinely unknown shapes**. When a tool's `tool_input` matches none of the recognised shapes, omamori still allows the call (we keep user workflow alive rather than starting to block unreviewed tools retroactively), but the silence is gone: stderr now carries a one-line hint pointing at the new review surface, and an `unknown_tool_fail_open` event is appended to the audit chain. The `tool_input` payload structure (number of recognised top-level keys) is recorded so an analyst can see at a glance whether the tool sent zero fields, one field, or many. No `CHAIN_VERSION` bump — this introduces new values for the existing `action` field (`"unknown_tool_fail_open"`) and `detection_layer` field (`"shape-routing"`); parsers that don't recognise the values treat them as opaque.
 
 ### Added
 
@@ -25,7 +25,17 @@ The format is based on Keep a Changelog.
 
 - No config or installation change. macOS-only.
 - Existing audit logs continue to verify against the same hash chain; `CHAIN_VERSION` is unchanged. `omamori audit verify` should pass after upgrading.
-- If you have downstream tooling parsing audit JSON: the `action` field can now carry the new value `"unknown_tool_fail_open"` (in addition to the existing `passthrough`/`block`/`trash`/etc.). `result` for those events is `"allow"`, `command` carries the unrecognised tool name, and `target_count` is the count of recognised top-level keys in `tool_input`.
+- If you have downstream tooling parsing audit JSON: the `action` field can now carry the new value `"unknown_tool_fail_open"` (in addition to the existing `passthrough`/`block`/`trash`/etc.), and `detection_layer` can now carry the new value `"shape-routing"` for those events. `result` is `"allow"`, `command` borrows the unrecognised tool name, and `target_count` borrows the count of recognised top-level keys in `tool_input`. Filter on `action == "unknown_tool_fail_open"` rather than relying on the borrowed semantics of `command` or `target_count`; dedicated columns will land in a future release.
+
+### Known limitations carried into a future release
+
+The recognised shape catalogue (`command`/`cmd`/`file_path`/`path`/`url`) is intentionally narrow in this release. Several known-good Claude Code tools — `NotebookEdit` (`notebook_path`), `Task` (`subagent_type`/`prompt`), `TodoWrite` (`todos`), `WebSearch` (`query`), and similar — currently land in the unknown branch and emit a fail-open event on every invocation. Practical implications:
+
+- `omamori audit unknown` and `omamori doctor`'s 30-day count are an **upper bound on adversarial activity, not a lower bound** — they include this routine legitimate-tool noise. Treat the count as a drift indicator: a sudden spike or an unfamiliar tool name is the actionable signal, not a steady non-zero baseline.
+- The protection guarantee is **unchanged**: payloads carrying a recognised dangerous shape (`command`/`cmd`/`file_path`/`path`) reach the full pipeline regardless of `tool_name`. The noise is an observability artefact, not a hole in the routing.
+- `target_count` and `command` borrow existing audit columns with adjusted semantics for `unknown_tool_fail_open` events specifically; downstream analytics that aggregate either column across action types will see skewed distributions. Filter by `action` first.
+
+A future omamori release will widen the shape catalogue, add dedicated audit columns, ship opt-in `strict-mode` (fail-closed on unrecognised shapes), and add session-level stderr dedup. See `SECURITY.md` → "Scope: unknown / new tools" for the full trade-off.
 
 ## [0.9.5] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,32 @@ For what omamori **cannot** catch, see [Structural Limitations](#structural-limi
 | **Community** | Gemini CLI, Cline, others | Layer 1 only. Not E2E tested. |
 | **Fallback** | Any tool setting `AI_GUARD=1` | Layer 1 only. |
 
+### How omamori handles new / renamed tools
+
+AI tools rotate fast: Claude Code adds a tool one week, Cursor renames one the next, a third CLI ships next month. omamori is installed locally and updated by `brew upgrade` on your schedule, so a tool-name allowlist baked into the binary would always be slightly behind reality.
+
+Instead of recognising tools by name, omamori inspects the **shape** of the `tool_input` payload that the AI agent sends:
+
+| Shape we recognise | Routes to |
+|---|---|
+| `tool_input.command` or `tool_input.cmd` is a string | Full Bash pipeline (meta-patterns, env-tampering, unwrap stack) |
+| `tool_input.file_path` or `tool_input.path` is a string | FileOp / protected-path checks |
+| `tool_input.url` is a string (and no shell/file fields) | Read-only — allowed |
+| Wrong type on any of the above (e.g. `command: 42`) | Fails closed (Block) |
+| None of the above | *Observable fail-open* — see below |
+
+A tool calling itself `FuturePlanWriter` but carrying a `command` field still reaches the shell pipeline. A renamed Edit tool with `file_path` still reaches the protected-path check. The classifier prioritises shell-shape over file-shape over url-shape, so a payload that mixes `command` and `url` cannot dodge into the read-only branch.
+
+**Observable fail-open** (`tool_input` has no shape we recognise): omamori still allows the call — we won't start blocking unreviewed tools retroactively, that breaks user workflows on every legitimate AI update — but the silence is gone. `stderr` carries a one-line hint per unique tool name, and an `unknown_tool_fail_open` event is appended to the audit chain. Review them later with:
+
+```bash
+omamori audit unknown
+```
+
+`omamori doctor` also surfaces a "Last 30 days: N unknown-tool fail-opens" line whenever the count is non-zero, so you don't have to remember to look.
+
+This trade-off is deliberate: stricter (block-by-default-on-unknown-shape) would close the protection gap further but would also block every legitimate new tool until omamori shipped a release. Opt-in strict mode is tracked for a follow-up release.
+
 ## Context-Aware Evaluation
 
 omamori can adjust actions based on what the command targets:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Instead of recognising tools by name, omamori inspects the **shape** of the `too
 
 A tool calling itself `FuturePlanWriter` but carrying a `command` field still reaches the shell pipeline. A renamed Edit tool with `file_path` still reaches the protected-path check. The classifier prioritises shell-shape over file-shape over url-shape, so a payload that mixes `command` and `url` cannot dodge into the read-only branch.
 
-**Observable fail-open** (`tool_input` has no shape we recognise): omamori still allows the call — we won't start blocking unreviewed tools retroactively, that breaks user workflows on every legitimate AI update — but the silence is gone. `stderr` carries a one-line hint per unique tool name, and an `unknown_tool_fail_open` event is appended to the audit chain. Review them later with:
+**Observable fail-open** (`tool_input` has no shape we recognise): omamori still allows the call — we won't start blocking unreviewed tools retroactively, that breaks user workflows on every legitimate AI update — but the silence is gone. `stderr` carries a one-line hint per invocation, and an `unknown_tool_fail_open` event is appended to the audit chain. Review them later with:
 
 ```bash
 omamori audit unknown
@@ -155,7 +155,16 @@ omamori audit unknown
 
 `omamori doctor` also surfaces a "Last 30 days: N unknown-tool fail-opens" line whenever the count is non-zero, so you don't have to remember to look.
 
-This trade-off is deliberate: stricter (block-by-default-on-unknown-shape) would close the protection gap further but would also block every legitimate new tool until omamori shipped a release. Opt-in strict mode is tracked for a follow-up release.
+#### Scope and limitations
+
+The recognised shape catalogue today (`command`/`cmd`/`file_path`/`path`/`url`) is intentionally narrow. Several legitimate Claude Code tools — for instance `NotebookEdit` (`notebook_path`), `Task` (`subagent_type` / `prompt`), `TodoWrite` (`todos`), `WebSearch` (`query`) — currently land in the unknown branch and emit a fail-open event on every invocation.
+
+Practical implications:
+
+- **The `audit unknown` review surface and `doctor`'s 30-day count are an *upper bound* on adversarial activity, not a lower bound.** They include this legitimate-tool noise. If you see "Last 30 days: 50 unknown-tool fail-opens", most of those are routine `Glob` / `Task` / `TodoWrite` calls, not bypass attempts. Treat the count as a "drift indicator" — a sudden spike or a tool name you don't recognise is worth investigating; a steady non-zero baseline is expected.
+- **The protection guarantee is unchanged**: payloads carrying a recognised dangerous shape (`command`, `cmd`, `file_path`, `path`) still route through the full pipeline regardless of `tool_name`. The noise issue is about observability, not the protection layer.
+
+A future omamori release will offer **opt-in strict-mode** so that users can choose between the current fail-open and a fail-closed posture for unrecognised shapes, plus a wider shape catalogue and dedicated audit columns to separate signal from noise. Until then the trade-off above is the deliberate posture.
 
 ## Context-Aware Evaluation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -189,12 +189,26 @@ AI tool platforms ship new tools and rename existing ones on their own cadence; 
 
 The threat we care about: a provider-side rename of a write/exec tool silently bypasses Layer 2. Pre-v0.9.6, `HookInput::UnknownTool` short-circuited to allow regardless of the carried `tool_input`. Codex adversarial-review ② A-2 (2026-04-23, critical) flagged this as a forward-compat fail-open, and v0.9.6 closes it: a payload like `{"tool_name":"FuturePlanWriter","tool_input":{"command":"/bin/rm -rf /"}}` now reaches the full shell pipeline (meta-patterns, env-tampering, unwrap stack) on the strength of the `command` field alone. Wrong-type routing fields (`command: 42`) fail closed.
 
-The residual risk is `tool_input` shapes we don't recognise at all (no `command`/`cmd`/`file_path`/`path`/`url`). That's still **Allow**, on purpose: starting to block unreviewed payload shapes would break user workflow on every legitimate AI tool update. But the silence is gone — the call is recorded as an `unknown_tool_fail_open` event in the audit chain, stderr carries a one-line dedup'd hint, and `omamori doctor` surfaces a 30-day count. Users review the events with `omamori audit unknown`.
+The residual risk is `tool_input` shapes we don't recognise at all (no `command`/`cmd`/`file_path`/`path`/`url`). That's still **Allow**, on purpose: starting to block unreviewed payload shapes would break user workflow on every legitimate AI tool update. But the silence is gone — the call is recorded as an `unknown_tool_fail_open` event in the audit chain, stderr carries a one-line hint, and `omamori doctor` surfaces a 30-day count. Users review the events with `omamori audit unknown`.
 
 This is a **trade-off, not a complete mitigation**. Threat-model implications:
+
 - An adversary aware of this scope could intentionally craft a `tool_input` shape that matches none of our known fields — say `{"prompt":"...","payload":"..."}` — to land in the observable fail-open branch. The damage they can do that way is limited (whatever the AI tool itself ends up doing with that payload is outside omamori's enforcement layer), and the call leaves a trail in `audit unknown`.
 - Stricter posture (block-by-default-on-unrecognised-shape) is tracked as opt-in `strict-mode` for a follow-up release, for users who would rather break workflow than allow an unobserved tool.
-- Audit log integrity: events use the existing `action` field with a new value (`"unknown_tool_fail_open"`); no `CHAIN_VERSION` bump, no schema break, parsers that don't recognise the value treat it as opaque.
+- Audit log integrity: events use the existing `action` field with a new value (`"unknown_tool_fail_open"`) and the existing `detection_layer` field with a new value (`"shape-routing"`); no `CHAIN_VERSION` bump, no schema break, parsers that don't recognise the values treat them as opaque.
+
+#### Known limitations carried into v0.9.6
+
+The shape catalogue is intentionally narrow in v0.9.6 and several known-good Claude Code tools land in the unknown branch — `NotebookEdit` (`notebook_path`), `Task` (`subagent_type`/`prompt`), `TodoWrite` (`todos`), `WebSearch` (`query`), and similar. Operationally:
+
+| Surface | Behavior in v0.9.6 | Honest read |
+|---|---|---|
+| **Protection** (does the dangerous shape reach the unwrap stack?) | Routes correctly: `command`/`cmd`/`file_path`/`path` always reach the full pipeline regardless of `tool_name` | Effective. The forward-compat fail-open Codex ② A-2 flagged is closed for the dangerous-shape class. |
+| **Observability** (`audit unknown` count, `doctor` 30-day line) | Includes legitimate-tool noise on every `Glob` / `Task` / `TodoWrite` / `WebSearch` invocation | **Upper bound on adversarial activity, not a lower bound**. A baseline of routine fail-opens is expected; spikes or unfamiliar tool names are the actionable signal. |
+| **Audit schema borrowing** | `target_count` re-used to record `tool_input` top-level key count for `unknown_tool_fail_open` events; `command` field re-used to carry `tool_name` | Downstream analytics that aggregate these columns across action types will see skewed distributions. Use `action == "unknown_tool_fail_open"` as the filter, not field semantics. |
+| **stderr dedup** (per the original release-blocker UX wording) | One stderr line per hook-check invocation; no in-process dedup — `omamori hook-check` is short-lived (1 process = 1 dispatch), so a process-local guard would be dead code | Each fail-open emits one line. If user noise becomes a problem, session-level dedup will land alongside strict-mode. |
+
+A future omamori release will address these by (1) widening the shape catalogue to cover known legitimate tool fields, (2) adding dedicated audit columns so `unknown_tool_fail_open` events do not borrow `target_count` / `command` semantics, (3) opt-in `strict-mode` so users can fail-closed on unrecognised shapes, and (4) session-level stderr dedup.
 
 ### Hook Limitations
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -183,6 +183,19 @@ The `omamori cursor-hook` subcommand uses the same `check_command_for_hook()` pi
 | `$(...)` or backtick in shell launcher inner | BLOCK |
 | OOM / panic | Process exit (hook failure = AI tool blocks) |
 
+### Scope: unknown / new tools (v0.9.6+)
+
+AI tool platforms ship new tools and rename existing ones on their own cadence; omamori is locally installed and updated on the user's cadence. A `tool_name` allowlist baked into the binary would always be slightly behind reality, so we route by **payload shape** instead of by name. See `README.md` → "How omamori handles new / renamed tools" for the full table.
+
+The threat we care about: a provider-side rename of a write/exec tool silently bypasses Layer 2. Pre-v0.9.6, `HookInput::UnknownTool` short-circuited to allow regardless of the carried `tool_input`. Codex adversarial-review ② A-2 (2026-04-23, critical) flagged this as a forward-compat fail-open, and v0.9.6 closes it: a payload like `{"tool_name":"FuturePlanWriter","tool_input":{"command":"/bin/rm -rf /"}}` now reaches the full shell pipeline (meta-patterns, env-tampering, unwrap stack) on the strength of the `command` field alone. Wrong-type routing fields (`command: 42`) fail closed.
+
+The residual risk is `tool_input` shapes we don't recognise at all (no `command`/`cmd`/`file_path`/`path`/`url`). That's still **Allow**, on purpose: starting to block unreviewed payload shapes would break user workflow on every legitimate AI tool update. But the silence is gone — the call is recorded as an `unknown_tool_fail_open` event in the audit chain, stderr carries a one-line dedup'd hint, and `omamori doctor` surfaces a 30-day count. Users review the events with `omamori audit unknown`.
+
+This is a **trade-off, not a complete mitigation**. Threat-model implications:
+- An adversary aware of this scope could intentionally craft a `tool_input` shape that matches none of our known fields — say `{"prompt":"...","payload":"..."}` — to land in the observable fail-open branch. The damage they can do that way is limited (whatever the AI tool itself ends up doing with that payload is outside omamori's enforcement layer), and the call leaves a trail in `audit unknown`.
+- Stricter posture (block-by-default-on-unrecognised-shape) is tracked as opt-in `strict-mode` for a follow-up release, for users who would rather break workflow than allow an unobserved tool.
+- Audit log integrity: events use the existing `action` field with a new value (`"unknown_tool_fail_open"`); no `CHAIN_VERSION` bump, no schema break, parsers that don't recognise the value treat it as opaque.
+
 ### Hook Limitations
 
 The unwrap stack is a static analyzer, not a shell interpreter. It cannot detect:

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -14,7 +14,8 @@ pub mod verify;
 // --- Public re-exports (maintain `omamori::audit::*` API paths) ---
 pub use secret::{RotationResult, rotate_key};
 pub use verify::{
-    AuditError, AuditSummary, ShowOptions, VerifyResult, audit_summary, show_entries, verify_chain,
+    AuditError, AuditSummary, ShowOptions, VerifyResult, audit_summary,
+    count_unknown_tool_fail_opens_within, show_entries, verify_chain,
 };
 
 // --- Internal imports from submodules (used by AuditLogger + tests) ---
@@ -1051,6 +1052,7 @@ mod tests {
             rule: None,
             provider: None,
             json: false,
+            action: None,
         };
         let mut buf = Vec::new();
         show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
@@ -1087,6 +1089,7 @@ mod tests {
             rule: Some("rm".to_string()),
             provider: None,
             json: false,
+            action: None,
         };
         let mut buf = Vec::new();
         show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
@@ -1107,6 +1110,7 @@ mod tests {
             rule: None,
             provider: None,
             json: true,
+            action: None,
         };
         let mut buf = Vec::new();
         show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
@@ -1134,6 +1138,7 @@ mod tests {
             rule: None,
             provider: None,
             json: false,
+            action: None,
         };
         let mut buf = Vec::new();
         show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
@@ -1160,6 +1165,7 @@ mod tests {
             rule: None,
             provider: None,
             json: false,
+            action: None,
         };
         let mut buf = Vec::new();
         show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
@@ -1621,6 +1627,7 @@ mod tests {
             rule: None,
             provider: None,
             json: false,
+            action: None,
         };
         let mut buf = Vec::new();
         show_entries(&verify_config(&dir), &opts, &mut buf).unwrap();
@@ -1789,6 +1796,7 @@ mod tests {
             rule: None,
             provider: None,
             json: false,
+            action: None,
         };
         let mut buf = Vec::new();
         let err = show_entries(&config, &opts, &mut buf).unwrap_err();

--- a/src/audit/verify.rs
+++ b/src/audit/verify.rs
@@ -55,6 +55,11 @@ pub struct ShowOptions {
     pub rule: Option<String>,
     pub provider: Option<String>,
     pub json: bool,
+    /// PR6 (#182): exact-match filter on `action`. Used by
+    /// `omamori audit unknown` to surface the `unknown_tool_fail_open`
+    /// events the hook layer records when a tool drifts past
+    /// shape-based routing.
+    pub action: Option<String>,
 }
 
 pub struct AuditSummary {
@@ -255,6 +260,13 @@ pub fn show_entries(
         {
             continue;
         }
+        // PR6 (#182): action is an exact-match filter (not substring)
+        // because action labels are a small closed enum; substring
+        // would let `--action allow` match the `unknown_tool_fail_open`
+        // result label and confuse users.
+        if opts.action.as_ref().is_some_and(|f| event.action != *f) {
+            continue;
+        }
 
         entries.push_back(event);
         if entries.len() > capacity {
@@ -337,6 +349,59 @@ pub fn audit_summary(config: &AuditConfig) -> AuditSummary {
         retention_days: config.retention_days,
         path_error,
     }
+}
+
+// ---------------------------------------------------------------------------
+// PR6 (#182): unknown-tool fail-open observability
+// ---------------------------------------------------------------------------
+
+/// Count `unknown_tool_fail_open` audit events whose timestamp falls
+/// within the last `days` days. Used by `omamori doctor` to surface
+/// silent forward-compat fail-opens that drifted past structure-based
+/// routing.
+///
+/// Returns 0 on any read/parse failure — this is a UX surface, not a
+/// security gate, and doctor must never error out a healthy install
+/// because the audit log happened to be unreadable.
+pub fn count_unknown_tool_fail_opens_within(config: &AuditConfig, days: u32) -> u64 {
+    if !config.enabled {
+        return 0;
+    }
+    let path = config.path.clone().unwrap_or_else(default_audit_path);
+    let file = match open_read_nofollow(&path) {
+        Ok(f) => f,
+        Err(_) => return 0,
+    };
+
+    use time::OffsetDateTime;
+    use time::format_description::well_known::Rfc3339;
+
+    let cutoff = OffsetDateTime::now_utc() - time::Duration::days(i64::from(days));
+
+    let reader = std::io::BufReader::new(file);
+    let mut count: u64 = 0;
+    for line in reader.lines() {
+        let Ok(line) = line else { continue };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let event: AuditEvent = match serde_json::from_str(trimmed) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if event.action != "unknown_tool_fail_open" {
+            continue;
+        }
+        let ts = match OffsetDateTime::parse(&event.timestamp, &Rfc3339) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if ts >= cutoff {
+            count += 1;
+        }
+    }
+    count
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -13,6 +13,9 @@ pub(crate) fn run_audit_command(args: &[OsString]) -> Result<i32, AppError> {
         Some("verify") => run_audit_verify(args),
         Some("show") => run_audit_show(args),
         Some("key") => run_audit_key(args),
+        // PR6 (#182): surface unknown-tool fail-open events.
+        // Sugar over `audit show --action unknown_tool_fail_open --all`.
+        Some("unknown") => run_audit_unknown(args),
         Some(other) => Err(AppError::Usage(format!(
             "unknown audit subcommand: {other}\n\n{}",
             audit_usage()
@@ -85,6 +88,7 @@ fn run_audit_show(args: &[OsString]) -> Result<i32, AppError> {
         rule: None,
         provider: None,
         json: false,
+        action: None,
     };
 
     let mut index = 3usize;
@@ -123,6 +127,15 @@ fn run_audit_show(args: &[OsString]) -> Result<i32, AppError> {
                 );
                 index += 2;
             }
+            "--action" => {
+                opts.action = Some(
+                    args.get(index + 1)
+                        .and_then(|v| v.to_str())
+                        .ok_or_else(|| AppError::Usage("--action requires a value".to_string()))?
+                        .to_string(),
+                );
+                index += 2;
+            }
             "--json" => {
                 opts.json = true;
                 index += 1;
@@ -146,6 +159,64 @@ fn run_audit_show(args: &[OsString]) -> Result<i32, AppError> {
         }
         Err(e) => {
             eprintln!("omamori audit show: {e}");
+            Ok(1)
+        }
+    }
+}
+
+/// `omamori audit unknown` — show all `unknown_tool_fail_open` events.
+///
+/// This is the user-facing review surface promised in the stderr hint
+/// emitted by the hook layer when a tool drifts past structure-based
+/// routing. We default to `--all` so users see every fail-open since
+/// the audit log started; `--last N` and `--json` work the same as
+/// `audit show`.
+fn run_audit_unknown(args: &[OsString]) -> Result<i32, AppError> {
+    let mut opts = audit::ShowOptions {
+        last: None, // default --all so review is complete
+        rule: None,
+        provider: None,
+        json: false,
+        action: Some("unknown_tool_fail_open".to_string()),
+    };
+
+    let mut index = 3usize;
+    while let Some(arg) = args.get(index).and_then(|item| item.to_str()) {
+        match arg {
+            "--last" => {
+                let value = args
+                    .get(index + 1)
+                    .and_then(|v| v.to_str())
+                    .ok_or_else(|| AppError::Usage("--last requires a number".to_string()))?;
+                opts.last =
+                    Some(value.parse::<usize>().map_err(|_| {
+                        AppError::Usage(format!("invalid number for --last: {value}"))
+                    })?);
+                index += 2;
+            }
+            "--json" => {
+                opts.json = true;
+                index += 1;
+            }
+            other => {
+                return Err(AppError::Usage(format!(
+                    "unknown 'audit unknown' flag: {other}\n\n{}",
+                    audit_usage()
+                )));
+            }
+        }
+    }
+
+    let load_result = load_config(None)?;
+    let mut stdout = std::io::stdout().lock();
+    match audit::show_entries(&load_result.config.audit, &opts, &mut stdout) {
+        Ok(()) => Ok(0),
+        Err(audit::AuditError::FileNotFound) => {
+            println!("omamori audit: no entries recorded yet");
+            Ok(0)
+        }
+        Err(e) => {
+            eprintln!("omamori audit unknown: {e}");
             Ok(1)
         }
     }
@@ -197,5 +268,7 @@ fn audit_usage() -> &'static str {
   omamori audit show --all                       View all entries
   omamori audit show --rule <name>               Filter by rule (substring match)
   omamori audit show --provider <name>           Filter by provider
+  omamori audit show --action <name>             Filter by action (exact match)
+  omamori audit unknown [--last N] [--json]      Show forward-compat fail-opens for unknown tools (#182)
   omamori audit key rotate                       Rotate HMAC signing key"
 }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -95,6 +95,7 @@ fn run_diagnose(items: &[CheckItem], verbose: bool) -> Result<i32, AppError> {
         let ok_count = items.iter().filter(|i| i.status == CheckStatus::Ok).count();
         println!("omamori: all healthy");
         println!("  {ok_count}/{total} checks passed");
+        print_unknown_tool_fail_open_summary();
         if verbose {
             println!();
             print_all_items(items);
@@ -119,6 +120,7 @@ fn run_diagnose(items: &[CheckItem], verbose: bool) -> Result<i32, AppError> {
     }
 
     println!();
+    print_unknown_tool_fail_open_summary();
     let has_fixable = problems.iter().any(|i| {
         i.remediation
             .as_ref()
@@ -139,6 +141,23 @@ fn run_diagnose(items: &[CheckItem], verbose: bool) -> Result<i32, AppError> {
         Ok(1)
     } else {
         Ok(2)
+    }
+}
+
+/// PR6 (#182): print a summary of `unknown_tool_fail_open` events from
+/// the last 30 days. Skipped when zero so doctor stays quiet on healthy
+/// installs (per UX release blocker: ゼロは noise 回避).
+///
+/// Best-effort: any error loading config / reading the audit log makes
+/// this a silent no-op rather than failing doctor.
+fn print_unknown_tool_fail_open_summary() {
+    let Ok(load_result) = crate::config::load_config(None) else {
+        return;
+    };
+    let count = crate::audit::count_unknown_tool_fail_opens_within(&load_result.config.audit, 30);
+    if count > 0 {
+        println!("  Last 30 days: {count} unknown-tool fail-open(s) detected");
+        println!("  Review: omamori audit unknown");
     }
 }
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -146,7 +146,7 @@ fn run_diagnose(items: &[CheckItem], verbose: bool) -> Result<i32, AppError> {
 
 /// PR6 (#182): print a summary of `unknown_tool_fail_open` events from
 /// the last 30 days. Skipped when zero so doctor stays quiet on healthy
-/// installs (per UX release blocker: ゼロは noise 回避).
+/// installs (per UX release blocker: zero must not generate noise).
 ///
 /// Best-effort: any error loading config / reading the audit log makes
 /// this a silent no-op rather than failing doctor.

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -739,16 +739,34 @@ fn has_routing_field_with_wrong_type(tool_input: &serde_json::Value) -> bool {
 
 /// Parse PreToolUse hook stdin into a typed `HookInput`.
 ///
-/// **Priority order (Codex PR6 round 1 regression fix)**: `tool_input`
-/// is inspected *before* the top-level `command` field. A mixed payload
-/// like `{"command":"echo ok","tool_input":{"command":"rm -rf /"}}` —
-/// either a probe or a legitimate Cursor-then-Claude-Code dual-shape
-/// hook — must route through the dangerous inner `tool_input.command`,
-/// not the safe-looking top-level one. The top-level `command` field is
-/// a legacy Cursor-style fallback used *only* when `tool_input` is
-/// absent. An earlier draft of this function flipped that priority and
-/// reopened a forward-compat fail-open within the very PR meant to
-/// close it; Codex caught it.
+/// **Priority chain** — pre-PR6 ordering preserved + extended for v0.9.6:
+///
+/// 1. `tool_input.command` / `tool_input.cmd` (most-specific dangerous shape)
+/// 2. top-level `command` (legacy Cursor-style fallback; *also* the
+///    safety net for mixed Cursor-and-Claude-Code payloads where a
+///    dangerous top-level command would otherwise be ignored if
+///    `tool_input` happened to carry only a non-shell shape)
+/// 3. `tool_input.file_path` / `tool_input.path` (FileOp routing)
+/// 4. `tool_input.url` (ReadOnlyUrl)
+/// 5. `tool_input` present but unrecognised shape → `UnknownTool`
+///    (observable fail-open downstream)
+/// 6. Bare `tool_name` with neither shape → `UnknownTool` with null input
+///
+/// Two regression-driven priority pins worth calling out:
+///
+/// - **PR6 R1 (Codex round 1)**: tool_input shell-command must beat
+///   top-level command. Mixed payload `{"command":"echo ok",
+///   "tool_input":{"command":"rm -rf /"}}` MUST route through the
+///   inner command. An earlier draft inverted this and reopened the
+///   very forward-compat fail-open this PR set out to close.
+///
+/// - **PR6 R2 (Codex round 2)**: top-level command must beat
+///   tool_input non-shell shapes. Mixed payload
+///   `{"command":"/bin/rm -rf /tmp/x","tool_name":"X","tool_input":
+///   {"query":"x"}}` MUST route the top-level shell command, not
+///   silently allow as UnknownTool. Pre-PR6 code did this; my round-1
+///   fix collapsed steps 2–5 into one tool_input dispatch and lost
+///   the middle priority. This priority chain restores all 6 steps.
 fn extract_hook_input(input: &str) -> HookInput {
     let v = match serde_json::from_str::<serde_json::Value>(input) {
         Ok(v) => v,
@@ -756,38 +774,36 @@ fn extract_hook_input(input: &str) -> HookInput {
     };
 
     let tool_name = v.get("tool_name").and_then(|t| t.as_str());
+    let ti = v.get("tool_input");
 
-    // Priority 1: tool_input present → route by structure.
-    if let Some(ti) = v.get("tool_input") {
-        match ti.as_object() {
-            Some(obj) if !obj.is_empty() => {}
-            _ => return HookInput::MalformedMissingField,
-        }
-        // SECURITY: a recognised field with the wrong type is a malformed
-        // payload, not a fall-through to UnknownTool fail-open.
-        if has_routing_field_with_wrong_type(ti) {
-            return HookInput::MalformedMissingField;
-        }
-        return match classify_input_shape(ti) {
-            InputShape::ShellCommand(cmd) => HookInput::Command(cmd.to_string()),
-            InputShape::FileOp(path) => HookInput::FileOp {
-                tool: tool_name.unwrap_or("unknown").to_string(),
-                path: path.to_string(),
-            },
-            InputShape::ReadOnlyUrl | InputShape::Unknown => match tool_name {
-                Some(name) => HookInput::UnknownTool {
-                    tool_name: name.to_string(),
-                    tool_input: ti.clone(),
-                },
-                None => HookInput::MalformedMissingField,
-            },
-        };
+    // Pre-classify tool_input once so each priority gate can consult
+    // the result without re-parsing. Type validation (wrong-type
+    // routing fields → MalformedMissingField) happens here so that a
+    // bad payload short-circuits before any priority gate.
+    let ti_object_check = ti.map(|t| {
+        let object_ok = matches!(t.as_object(), Some(obj) if !obj.is_empty());
+        let wrong_type = has_routing_field_with_wrong_type(t);
+        (t, object_ok, wrong_type)
+    });
+
+    if let Some((_, false, _)) = ti_object_check {
+        return HookInput::MalformedMissingField;
+    }
+    if let Some((_, _, true)) = ti_object_check {
+        return HookInput::MalformedMissingField;
     }
 
-    // Priority 2: no tool_input — try legacy Cursor-style top-level
-    // `command`. This branch is the historical Cursor hook contract;
-    // PreToolUse from Claude Code always carries `tool_input`, so this
-    // path should not trigger for Claude-Code-shaped hooks.
+    let ti_shape = ti.map(classify_input_shape);
+
+    // Priority 1: tool_input shell-command shape (highest danger surface).
+    if let Some(InputShape::ShellCommand(cmd)) = ti_shape {
+        return HookInput::Command(cmd.to_string());
+    }
+
+    // Priority 2: top-level `command` — legacy Cursor-style fallback,
+    // also the safety net so a dangerous top-level command paired with
+    // a benign `tool_input` (e.g. `{"query":"…"}`) cannot dodge into
+    // UnknownTool fail-open.
     if let Some(cmd_val) = v.get("command") {
         return match cmd_val.as_str() {
             Some(cmd) => HookInput::Command(cmd.to_string()),
@@ -795,7 +811,26 @@ fn extract_hook_input(input: &str) -> HookInput {
         };
     }
 
-    // Priority 3: bare tool_name with neither tool_input nor command.
+    // Priority 3-5: remaining tool_input shapes (FileOp / ReadOnlyUrl /
+    // Unknown). Reached only when no shell-command surface fired.
+    if let Some(shape) = ti_shape {
+        return match shape {
+            InputShape::ShellCommand(_) => unreachable!("handled at Priority 1"),
+            InputShape::FileOp(path) => HookInput::FileOp {
+                tool: tool_name.unwrap_or("unknown").to_string(),
+                path: path.to_string(),
+            },
+            InputShape::ReadOnlyUrl | InputShape::Unknown => match tool_name {
+                Some(name) => HookInput::UnknownTool {
+                    tool_name: name.to_string(),
+                    tool_input: ti.expect("ti_shape implies ti was Some").clone(),
+                },
+                None => HookInput::MalformedMissingField,
+            },
+        };
+    }
+
+    // Priority 6: bare tool_name with neither tool_input nor command.
     if let Some(name) = tool_name {
         return HookInput::UnknownTool {
             tool_name: name.to_string(),
@@ -1140,15 +1175,69 @@ mod tests {
         }
     }
 
-    /// Counterpart pin: top-level `command` is consulted ONLY when
-    /// `tool_input` is absent. Without this pin a future refactor could
-    /// silently drop the legacy Cursor-style fallback.
+    /// Counterpart pin: top-level `command` is consulted when
+    /// `tool_input` is absent OR carries no shell-command shape.
+    /// Without this pin a future refactor could silently drop the
+    /// legacy Cursor-style fallback.
     #[test]
     fn extract_hook_input_top_level_command_used_when_tool_input_absent() {
         let input = r#"{"command":"ls -la"}"#;
         match extract_hook_input(input) {
             HookInput::Command(cmd) => assert_eq!(cmd, "ls -la"),
             other => panic!("expected legacy top-level Command, got: {other:?}"),
+        }
+    }
+
+    /// PR6 Codex round 2 regression guard: a mixed payload where the
+    /// dangerous shell command sits at top-level and `tool_input`
+    /// carries a benign non-shell shape (`query`, `text`, etc.) MUST
+    /// route the top-level command. Round 1 fix collapsed all
+    /// `tool_input`-present cases into the tool_input dispatch and
+    /// silently turned this scenario into UnknownTool fail-open.
+    #[test]
+    fn extract_hook_input_top_level_command_wins_over_unknown_shape() {
+        let input = r#"{
+            "command": "/bin/rm -rf /tmp/x",
+            "tool_name": "FutureSearch",
+            "tool_input": { "query": "x" }
+        }"#;
+        match extract_hook_input(input) {
+            HookInput::Command(cmd) => assert_eq!(
+                cmd, "/bin/rm -rf /tmp/x",
+                "top-level command must win over tool_input non-shell shape"
+            ),
+            other => panic!("expected top-level Command (R2 regression guard), got: {other:?}"),
+        }
+    }
+
+    /// Variant: top-level command + `tool_input.url` (read-only fetch
+    /// shape). The dangerous top-level command must still win — the
+    /// read-only routing must not provide cover for shell commands.
+    #[test]
+    fn extract_hook_input_top_level_command_wins_over_url_shape() {
+        let input = r#"{
+            "command": "/bin/rm -rf /tmp/x",
+            "tool_name": "FutureFetch",
+            "tool_input": { "url": "https://example.com" }
+        }"#;
+        match extract_hook_input(input) {
+            HookInput::Command(cmd) => assert_eq!(cmd, "/bin/rm -rf /tmp/x"),
+            other => panic!("expected top-level Command, got: {other:?}"),
+        }
+    }
+
+    /// Variant: top-level command + `tool_input.file_path`. File-op
+    /// routing must NOT shadow the dangerous shell command.
+    #[test]
+    fn extract_hook_input_top_level_command_wins_over_file_op_shape() {
+        let input = r#"{
+            "command": "/bin/rm -rf /tmp/x",
+            "tool_name": "FutureEditor",
+            "tool_input": { "file_path": "/tmp/x" }
+        }"#;
+        match extract_hook_input(input) {
+            HookInput::Command(cmd) => assert_eq!(cmd, "/bin/rm -rf /tmp/x"),
+            other => panic!("expected top-level Command, got: {other:?}"),
         }
     }
 

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -486,8 +486,16 @@ fn log_unknown_tool_hint_dedup(tool_name: &str) {
 }
 
 /// Append an `unknown_tool_fail_open` event to the audit chain.
-/// Best-effort — failure to load config or write the audit log must
-/// never block the hook decision (we already decided to allow).
+///
+/// Best-effort with respect to the hook *decision* (we already decided
+/// to allow; an audit failure must never flip that), but **not silent**
+/// with respect to observability. PR6 promises users that they can
+/// review fail-opens via `omamori audit unknown`; if the append fails
+/// the user must learn that the promise is unreliable for this event,
+/// otherwise the stderr hint and the doctor count line both become
+/// false advertising in the exact failure mode where they matter most
+/// (broken audit log / missing HMAC secret / disk full / permissions).
+/// Codex round 3 P2.
 fn audit_log_unknown_tool_fail_open(
     tool_name: &str,
     tool_input: &serde_json::Value,
@@ -495,11 +503,23 @@ fn audit_log_unknown_tool_fail_open(
 ) {
     let load_result = match load_config(None) {
         Ok(r) => r,
-        Err(_) => return,
+        Err(e) => {
+            eprintln!(
+                "omamori warning: could not record unknown_tool_fail_open event for '{tool_name}' \
+                 — config load failed: {e}. The 'omamori audit unknown' review surface is \
+                 incomplete for this event."
+            );
+            return;
+        }
     };
     let logger = match crate::audit::AuditLogger::from_config(&load_result.config.audit) {
         Some(l) => l,
-        None => return,
+        None => {
+            // Audit disabled in config — that's a user choice, not an
+            // error, so stay quiet (the user opted out of the review
+            // surface entirely).
+            return;
+        }
     };
 
     // Synthetic invocation: the "command" field of the audit event will
@@ -521,7 +541,12 @@ fn audit_log_unknown_tool_fail_open(
     // didn't classify").
     event.target_count = tool_input.as_object().map(|o| o.len()).unwrap_or(0);
 
-    let _ = logger.append(event);
+    if let Err(e) = logger.append(event) {
+        eprintln!(
+            "omamori warning: failed to record unknown_tool_fail_open event for '{tool_name}': {e}. \
+             The 'omamori audit unknown' review surface is incomplete for this event."
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -535,7 +535,9 @@ fn audit_log_unknown_tool_fail_open(
     // Override action label so `omamori audit unknown` (and SIEM filters)
     // can pick these out without parsing detection_layer. New string
     // value — old parsers treat it as opaque, no schema break, no
-    // CHAIN_VERSION bump needed (Codex ② C-1 裁定維持).
+    // CHAIN_VERSION bump needed (preserves the Codex ② C-1 ruling that
+    // detection_layer's semantic contract must not silently shift in a
+    // patch release).
     event.action = "unknown_tool_fail_open".to_string();
     event.result = "allow".to_string();
     // Override detection_layer: `create_event` defaults to "layer1"

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -738,13 +738,56 @@ fn has_routing_field_with_wrong_type(tool_input: &serde_json::Value) -> bool {
 }
 
 /// Parse PreToolUse hook stdin into a typed `HookInput`.
+///
+/// **Priority order (Codex PR6 round 1 regression fix)**: `tool_input`
+/// is inspected *before* the top-level `command` field. A mixed payload
+/// like `{"command":"echo ok","tool_input":{"command":"rm -rf /"}}` —
+/// either a probe or a legitimate Cursor-then-Claude-Code dual-shape
+/// hook — must route through the dangerous inner `tool_input.command`,
+/// not the safe-looking top-level one. The top-level `command` field is
+/// a legacy Cursor-style fallback used *only* when `tool_input` is
+/// absent. An earlier draft of this function flipped that priority and
+/// reopened a forward-compat fail-open within the very PR meant to
+/// close it; Codex caught it.
 fn extract_hook_input(input: &str) -> HookInput {
     let v = match serde_json::from_str::<serde_json::Value>(input) {
         Ok(v) => v,
         Err(_) => return HookInput::MalformedJson,
     };
 
-    // Cursor-style top-level "command" takes precedence (legacy contract).
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str());
+
+    // Priority 1: tool_input present → route by structure.
+    if let Some(ti) = v.get("tool_input") {
+        match ti.as_object() {
+            Some(obj) if !obj.is_empty() => {}
+            _ => return HookInput::MalformedMissingField,
+        }
+        // SECURITY: a recognised field with the wrong type is a malformed
+        // payload, not a fall-through to UnknownTool fail-open.
+        if has_routing_field_with_wrong_type(ti) {
+            return HookInput::MalformedMissingField;
+        }
+        return match classify_input_shape(ti) {
+            InputShape::ShellCommand(cmd) => HookInput::Command(cmd.to_string()),
+            InputShape::FileOp(path) => HookInput::FileOp {
+                tool: tool_name.unwrap_or("unknown").to_string(),
+                path: path.to_string(),
+            },
+            InputShape::ReadOnlyUrl | InputShape::Unknown => match tool_name {
+                Some(name) => HookInput::UnknownTool {
+                    tool_name: name.to_string(),
+                    tool_input: ti.clone(),
+                },
+                None => HookInput::MalformedMissingField,
+            },
+        };
+    }
+
+    // Priority 2: no tool_input — try legacy Cursor-style top-level
+    // `command`. This branch is the historical Cursor hook contract;
+    // PreToolUse from Claude Code always carries `tool_input`, so this
+    // path should not trigger for Claude-Code-shaped hooks.
     if let Some(cmd_val) = v.get("command") {
         return match cmd_val.as_str() {
             Some(cmd) => HookInput::Command(cmd.to_string()),
@@ -752,45 +795,15 @@ fn extract_hook_input(input: &str) -> HookInput {
         };
     }
 
-    let tool_name = v.get("tool_name").and_then(|t| t.as_str());
-
-    let Some(ti) = v.get("tool_input") else {
-        // No tool_input at all — only a bare tool_name is degenerate.
-        return match tool_name {
-            Some(name) => HookInput::UnknownTool {
-                tool_name: name.to_string(),
-                tool_input: serde_json::Value::Null,
-            },
-            None => HookInput::MalformedMissingField,
+    // Priority 3: bare tool_name with neither tool_input nor command.
+    if let Some(name) = tool_name {
+        return HookInput::UnknownTool {
+            tool_name: name.to_string(),
+            tool_input: serde_json::Value::Null,
         };
-    };
-
-    // tool_input must be a non-empty object.
-    match ti.as_object() {
-        Some(obj) if !obj.is_empty() => {}
-        _ => return HookInput::MalformedMissingField,
     }
 
-    // SECURITY: a recognised field with the wrong type is a malformed
-    // payload, not a fall-through to UnknownTool fail-open.
-    if has_routing_field_with_wrong_type(ti) {
-        return HookInput::MalformedMissingField;
-    }
-
-    match classify_input_shape(ti) {
-        InputShape::ShellCommand(cmd) => HookInput::Command(cmd.to_string()),
-        InputShape::FileOp(path) => HookInput::FileOp {
-            tool: tool_name.unwrap_or("unknown").to_string(),
-            path: path.to_string(),
-        },
-        InputShape::ReadOnlyUrl | InputShape::Unknown => match tool_name {
-            Some(name) => HookInput::UnknownTool {
-                tool_name: name.to_string(),
-                tool_input: ti.clone(),
-            },
-            None => HookInput::MalformedMissingField,
-        },
-    }
+    HookInput::MalformedMissingField
 }
 
 // ---------------------------------------------------------------------------
@@ -1085,6 +1098,58 @@ mod tests {
             classify_input_shape(&v),
             InputShape::ShellCommand("rm -rf /")
         );
+    }
+
+    /// PR6 Codex round 1 regression guard: when a payload carries BOTH
+    /// a top-level `command` (Cursor-style legacy) and a `tool_input`
+    /// object, the dangerous `tool_input.command` MUST win — top-level
+    /// `command` is only the fallback when `tool_input` is absent. An
+    /// earlier draft inverted this and let `{"command":"safe",
+    /// "tool_input":{"command":"rm -rf /tmp/x"}}` route through the
+    /// safe top-level, reopening the very forward-compat fail-open
+    /// this PR set out to close.
+    #[test]
+    fn extract_hook_input_mixed_payload_prefers_tool_input() {
+        let input = r#"{
+            "command": "echo ok",
+            "tool_name": "Bash",
+            "tool_input": { "command": "rm -rf /tmp/x" }
+        }"#;
+        match extract_hook_input(input) {
+            HookInput::Command(cmd) => assert_eq!(
+                cmd, "rm -rf /tmp/x",
+                "tool_input.command must take priority over top-level command"
+            ),
+            other => panic!("expected Command from tool_input, got: {other:?}"),
+        }
+    }
+
+    /// Same priority pin, but with an unknown tool_name and an alias
+    /// `cmd` field. Mixed payload via the alias path must still prefer
+    /// `tool_input`.
+    #[test]
+    fn extract_hook_input_mixed_payload_prefers_tool_input_alias() {
+        let input = r#"{
+            "command": "echo ok",
+            "tool_name": "FutureExec",
+            "tool_input": { "cmd": "/bin/rm -rf /tmp/x" }
+        }"#;
+        match extract_hook_input(input) {
+            HookInput::Command(cmd) => assert_eq!(cmd, "/bin/rm -rf /tmp/x"),
+            other => panic!("expected Command from tool_input.cmd, got: {other:?}"),
+        }
+    }
+
+    /// Counterpart pin: top-level `command` is consulted ONLY when
+    /// `tool_input` is absent. Without this pin a future refactor could
+    /// silently drop the legacy Cursor-style fallback.
+    #[test]
+    fn extract_hook_input_top_level_command_used_when_tool_input_absent() {
+        let input = r#"{"command":"ls -la"}"#;
+        match extract_hook_input(input) {
+            HookInput::Command(cmd) => assert_eq!(cmd, "ls -la"),
+            other => panic!("expected legacy top-level Command, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -396,11 +396,24 @@ fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Resul
 // `tool_name` Claude Code added or renamed silently bypassed Layer 2.
 // We now (1) re-classify the carried `tool_input` against `InputShape`
 // in case an alias field (`cmd`/`path`) slipped past extract, (2) for
-// truly unknown shapes, log to stderr (deduplicated by tool_name) and
-// append a marked event to the audit chain so users can review what
-// drifted past omamori. The final disposition stays *allow* — we
-// preserve user workflow rather than start blocking unreviewed tools
-// retroactively, but the silence is gone.
+// truly unknown shapes, log to stderr and append a marked event to the
+// audit chain so users can review what drifted past omamori. The final
+// disposition stays *allow* — we preserve user workflow rather than
+// start blocking unreviewed tools retroactively, but the silence is
+// gone.
+//
+// **Scope and known noise (Known Limitation)**: legitimate Claude Code
+// tools whose `tool_input` shape is not in our recognised set (e.g.
+// NotebookEdit's `notebook_path`, Task's `subagent_type`, TodoWrite's
+// `todos`, WebSearch's `query`) currently land in the unknown branch
+// and emit fail-open events on every invocation. Counts surfaced via
+// `omamori audit unknown` and `omamori doctor`'s 30-day line are an
+// **upper bound on adversarial activity**, not a lower bound — they
+// include this legitimate noise. An opt-in strict-mode that lets users
+// choose between fail-open (today) and fail-closed (block) for
+// unrecognised shapes is planned for a future omamori release. See
+// `SECURITY.md` → "Scope: unknown / new tools" for the trade-off
+// rationale.
 
 fn run_hook_check_unknown_tool(
     tool_name: &str,
@@ -450,38 +463,24 @@ fn run_hook_check_unknown_tool(
             Ok(0)
         }
         InputShape::Unknown => {
-            // Observable fail-open: stderr hint (dedup'd) + audit event
-            // + allow. The allow keeps user workflow alive; the hint +
-            // audit make the silence a thing of the past.
-            log_unknown_tool_hint_dedup(tool_name);
+            // Observable fail-open: stderr hint + audit event + allow.
+            // The allow keeps user workflow alive; the hint + audit
+            // make the silence a thing of the past. One stderr line
+            // per invocation — `omamori hook-check` is a short-lived
+            // process (1 invocation = 1 dispatch), so a process-local
+            // dedup guard would be dead code. If user noise becomes a
+            // problem, session-level dedup is tracked for a future
+            // release alongside opt-in strict-mode.
+            eprintln!(
+                "omamori: unknown tool '{tool_name}' routed as fail-open. \
+                 Review via 'omamori audit unknown'"
+            );
             audit_log_unknown_tool_fail_open(tool_name, tool_input, provider);
             print_hook_check_allow_response(&format!(
                 "omamori: unknown tool '{tool_name}' routed as fail-open — allowed"
             ));
             Ok(0)
         }
-    }
-}
-
-/// Process-local dedup guard so the same `tool_name` does not spam stderr
-/// inside a single hook-check invocation. (Each hook-check runs in its
-/// own short-lived process, so the guard's effective lifetime is one
-/// invocation — but if a future caller batches multiple checks, the
-/// dedup still holds.)
-fn log_unknown_tool_hint_dedup(tool_name: &str) {
-    use std::collections::HashSet;
-    use std::sync::{Mutex, OnceLock};
-
-    static SEEN: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-    let dedup = SEEN.get_or_init(|| Mutex::new(HashSet::new()));
-    let inserted = match dedup.lock() {
-        Ok(mut guard) => guard.insert(tool_name.to_string()),
-        Err(_) => true, // poisoned: log anyway, don't go silent
-    };
-    if inserted {
-        eprintln!(
-            "omamori: unknown tool '{tool_name}' routed as fail-open. Review via 'omamori audit unknown'"
-        );
     }
 }
 
@@ -536,9 +535,22 @@ fn audit_log_unknown_tool_fail_open(
     // CHAIN_VERSION bump needed (Codex ② C-1 裁定維持).
     event.action = "unknown_tool_fail_open".to_string();
     event.result = "allow".to_string();
+    // Override detection_layer: `create_event` defaults to "layer1"
+    // because every existing caller is a Layer 1 / Layer 2 verdict.
+    // Unknown-tool fail-open is neither — it's the shape-routing
+    // dispatch deciding "no recognised shape, allow + record". A SIEM
+    // counting "Layer 1 detector hits" would otherwise inflate with
+    // these events. Like `action`, `detection_layer` is a string field
+    // that older parsers treat as opaque — no schema break.
+    event.detection_layer = Some("shape-routing".to_string());
     // target_count = number of recognised top-level keys in tool_input
     // (helps analysts see "shape we saw was empty" vs. "had keys we
-    // didn't classify").
+    // didn't classify"). Note: this borrows the existing `target_count`
+    // column with a different semantic for `unknown_tool_fail_open`
+    // events specifically; downstream analytics that aggregate
+    // `target_count` across action types will be skewed by these
+    // events. A dedicated column is tracked for a future omamori
+    // release.
     event.target_count = tool_input.as_object().map(|o| o.len()).unwrap_or(0);
 
     if let Err(e) = logger.append(event) {

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -469,8 +469,11 @@ fn run_hook_check_unknown_tool(
             // per invocation — `omamori hook-check` is a short-lived
             // process (1 invocation = 1 dispatch), so a process-local
             // dedup guard would be dead code. If user noise becomes a
-            // problem, session-level dedup is tracked for a future
-            // release alongside opt-in strict-mode.
+            // problem, session-level dedup is one of the follow-ups
+            // tracked for a future release. See `SECURITY.md` →
+            // "Scope: unknown / new tools" for the full set
+            // (catalogue widening, dedicated audit columns, opt-in
+            // strict-mode, session-level dedup).
             eprintln!(
                 "omamori: unknown tool '{tool_name}' routed as fail-open. \
                  Review via 'omamori audit unknown'"

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -308,12 +308,10 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
             }
             Ok(2)
         }
-        HookInput::UnknownTool(tool_name) => {
-            print_hook_check_allow_response(&format!(
-                "omamori: unrecognized tool '{tool_name}' — allowed for forward compatibility"
-            ));
-            Ok(0)
-        }
+        HookInput::UnknownTool {
+            tool_name,
+            tool_input,
+        } => run_hook_check_unknown_tool(&tool_name, &tool_input, &provider, verbose),
         HookInput::FileOp { tool, path } => {
             if let Some(reason) = is_protected_file_path(&path) {
                 eprintln!("omamori hook: blocked {tool} to protected file — {reason}");
@@ -388,6 +386,142 @@ fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Resul
             Ok(2)
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Unknown-tool routing (#182, v0.9.6 PR6)
+// ---------------------------------------------------------------------------
+//
+// `HookInput::UnknownTool` was previously a forward-compat fail-open: any
+// `tool_name` Claude Code added or renamed silently bypassed Layer 2.
+// We now (1) re-classify the carried `tool_input` against `InputShape`
+// in case an alias field (`cmd`/`path`) slipped past extract, (2) for
+// truly unknown shapes, log to stderr (deduplicated by tool_name) and
+// append a marked event to the audit chain so users can review what
+// drifted past omamori. The final disposition stays *allow* — we
+// preserve user workflow rather than start blocking unreviewed tools
+// retroactively, but the silence is gone.
+
+fn run_hook_check_unknown_tool(
+    tool_name: &str,
+    tool_input: &serde_json::Value,
+    provider: &str,
+    verbose: bool,
+) -> Result<i32, AppError> {
+    match classify_input_shape(tool_input) {
+        // Shell-shape and file-op-shape *should* have been resolved at
+        // extract time. Re-routing here is the safety net for any future
+        // refactor where extract_hook_input grows a fall-through path —
+        // we re-enter the same checks rather than silently allowing.
+        InputShape::ShellCommand(cmd) => {
+            if cmd.is_empty() {
+                print_hook_check_allow_response("omamori: empty command");
+                return Ok(0);
+            }
+            run_hook_check_command(cmd, provider, verbose)
+        }
+        InputShape::FileOp(path) => {
+            if let Some(reason) = is_protected_file_path(path) {
+                eprintln!("omamori hook: blocked {tool_name} to protected file — {reason}");
+                eprintln!("  AI agents cannot modify omamori configuration or security files.");
+                eprintln!(
+                    "  To edit config: use `omamori config` CLI or edit the file directly in your terminal."
+                );
+                if verbose {
+                    eprintln!("  provider: {provider}");
+                    eprintln!("  tool: {tool_name}");
+                    eprintln!("  path: {path}");
+                }
+                Ok(2)
+            } else {
+                print_hook_check_allow_response(&format!(
+                    "omamori: '{tool_name}' file op to non-protected path — allowed"
+                ));
+                Ok(0)
+            }
+        }
+        InputShape::ReadOnlyUrl => {
+            // url-shape inputs are read-only fetch tools (WebFetch,
+            // WebSearch, …). Allow without hint — these are not the
+            // class of fail-open we set out to make observable.
+            print_hook_check_allow_response(&format!(
+                "omamori: '{tool_name}' read-only url tool — allowed"
+            ));
+            Ok(0)
+        }
+        InputShape::Unknown => {
+            // Observable fail-open: stderr hint (dedup'd) + audit event
+            // + allow. The allow keeps user workflow alive; the hint +
+            // audit make the silence a thing of the past.
+            log_unknown_tool_hint_dedup(tool_name);
+            audit_log_unknown_tool_fail_open(tool_name, tool_input, provider);
+            print_hook_check_allow_response(&format!(
+                "omamori: unknown tool '{tool_name}' routed as fail-open — allowed"
+            ));
+            Ok(0)
+        }
+    }
+}
+
+/// Process-local dedup guard so the same `tool_name` does not spam stderr
+/// inside a single hook-check invocation. (Each hook-check runs in its
+/// own short-lived process, so the guard's effective lifetime is one
+/// invocation — but if a future caller batches multiple checks, the
+/// dedup still holds.)
+fn log_unknown_tool_hint_dedup(tool_name: &str) {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+
+    static SEEN: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    let dedup = SEEN.get_or_init(|| Mutex::new(HashSet::new()));
+    let inserted = match dedup.lock() {
+        Ok(mut guard) => guard.insert(tool_name.to_string()),
+        Err(_) => true, // poisoned: log anyway, don't go silent
+    };
+    if inserted {
+        eprintln!(
+            "omamori: unknown tool '{tool_name}' routed as fail-open. Review via 'omamori audit unknown'"
+        );
+    }
+}
+
+/// Append an `unknown_tool_fail_open` event to the audit chain.
+/// Best-effort — failure to load config or write the audit log must
+/// never block the hook decision (we already decided to allow).
+fn audit_log_unknown_tool_fail_open(
+    tool_name: &str,
+    tool_input: &serde_json::Value,
+    provider: &str,
+) {
+    let load_result = match load_config(None) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    let logger = match crate::audit::AuditLogger::from_config(&load_result.config.audit) {
+        Some(l) => l,
+        None => return,
+    };
+
+    // Synthetic invocation: the "command" field of the audit event will
+    // hold the tool_name; targets are the recognised top-level keys of
+    // tool_input so analysts can spot which shape we saw.
+    let invocation = CommandInvocation::new(tool_name.to_string(), Vec::new());
+    let detectors = vec![provider.to_string()];
+    let outcome = crate::actions::ActionOutcome::PassedThrough { exit_code: 0 };
+
+    let mut event = logger.create_event(&invocation, None, &detectors, &outcome);
+    // Override action label so `omamori audit unknown` (and SIEM filters)
+    // can pick these out without parsing detection_layer. New string
+    // value — old parsers treat it as opaque, no schema break, no
+    // CHAIN_VERSION bump needed (Codex ② C-1 裁定維持).
+    event.action = "unknown_tool_fail_open".to_string();
+    event.result = "allow".to_string();
+    // target_count = number of recognised top-level keys in tool_input
+    // (helps analysts see "shape we saw was empty" vs. "had keys we
+    // didn't classify").
+    event.target_count = tool_input.as_object().map(|o| o.len()).unwrap_or(0);
+
+    let _ = logger.append(event);
 }
 
 // ---------------------------------------------------------------------------
@@ -526,10 +660,81 @@ fn is_protected_file_path(path: &str) -> Option<&'static str> {
 #[derive(Debug)]
 enum HookInput {
     Command(String),
-    FileOp { tool: String, path: String },
-    UnknownTool(String),
+    FileOp {
+        tool: String,
+        path: String,
+    },
+    /// A tool whose `tool_name` we don't recognise *and* whose `tool_input`
+    /// shape did not match any known classifier (`command`/`cmd` →
+    /// shell, `file_path`/`path` → file op, `url` → read-only).
+    /// Carries the full `tool_input` so the routing layer can re-classify
+    /// and so the audit/observability layer can record the shape we saw.
+    UnknownTool {
+        tool_name: String,
+        tool_input: serde_json::Value,
+    },
     MalformedJson,
     MalformedMissingField,
+}
+
+/// Classified shape of `tool_input` for routing.
+///
+/// **Forward-compat fail-open fix (#182, v0.9.6 PR6).** The previous
+/// implementation dispatched `HookInput::UnknownTool` to an unconditional
+/// allow; any provider-side rename of a write/exec tool would silently
+/// bypass Layer 2. We now route by `tool_input` *structure* — independent
+/// of `tool_name` — so a tool calling itself `FuturePlanWriter` but
+/// carrying a `command` field still reaches the shell pipeline.
+#[derive(Debug, PartialEq, Eq)]
+enum InputShape<'a> {
+    /// `tool_input.command` or `tool_input.cmd` is a string → route as Bash.
+    ShellCommand(&'a str),
+    /// `tool_input.file_path` or `tool_input.path` is a string → route as FileOp.
+    FileOp(&'a str),
+    /// `tool_input.url` is a string and no shell/file fields are present
+    /// → read-only fetch, allow.
+    ReadOnlyUrl,
+    /// No recognised shape — observable fail-open (hint + audit + allow).
+    Unknown,
+}
+
+/// Inspect `tool_input` and return its routed shape.
+///
+/// Order matters: shell command takes priority over file path takes
+/// priority over url, so a malicious tool sending both `command` and
+/// `url` cannot dodge into the read-only branch.
+fn classify_input_shape(tool_input: &serde_json::Value) -> InputShape<'_> {
+    if let Some(s) = tool_input.get("command").and_then(|v| v.as_str()) {
+        return InputShape::ShellCommand(s);
+    }
+    if let Some(s) = tool_input.get("cmd").and_then(|v| v.as_str()) {
+        return InputShape::ShellCommand(s);
+    }
+    if let Some(s) = tool_input.get("file_path").and_then(|v| v.as_str()) {
+        return InputShape::FileOp(s);
+    }
+    if let Some(s) = tool_input.get("path").and_then(|v| v.as_str()) {
+        return InputShape::FileOp(s);
+    }
+    if tool_input.get("url").and_then(|v| v.as_str()).is_some() {
+        return InputShape::ReadOnlyUrl;
+    }
+    InputShape::Unknown
+}
+
+/// Whether a recognised routing field exists but with the wrong JSON type.
+/// Such inputs must fail-close (MalformedMissingField), not silently fall
+/// through to UnknownTool — otherwise an attacker can present a
+/// `command: 42` payload and bypass shell checks.
+fn has_routing_field_with_wrong_type(tool_input: &serde_json::Value) -> bool {
+    for field in ["command", "cmd", "file_path", "path", "url"] {
+        if let Some(val) = tool_input.get(field)
+            && val.as_str().is_none()
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Parse PreToolUse hook stdin into a typed `HookInput`.
@@ -539,15 +744,7 @@ fn extract_hook_input(input: &str) -> HookInput {
         Err(_) => return HookInput::MalformedJson,
     };
 
-    let tool_input = v.get("tool_input");
-
-    if let Some(cmd_val) = tool_input.and_then(|ti| ti.get("command")) {
-        return match cmd_val.as_str() {
-            Some(cmd) => HookInput::Command(cmd.to_string()),
-            None => HookInput::MalformedMissingField,
-        };
-    }
-
+    // Cursor-style top-level "command" takes precedence (legacy contract).
     if let Some(cmd_val) = v.get("command") {
         return match cmd_val.as_str() {
             Some(cmd) => HookInput::Command(cmd.to_string()),
@@ -555,38 +752,45 @@ fn extract_hook_input(input: &str) -> HookInput {
         };
     }
 
-    if let Some(path_val) = tool_input.and_then(|ti| ti.get("file_path")) {
-        return match path_val.as_str() {
-            Some(path) => {
-                let tool = v
-                    .get("tool_name")
-                    .and_then(|t| t.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                HookInput::FileOp {
-                    tool,
-                    path: path.to_string(),
-                }
-            }
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str());
+
+    let Some(ti) = v.get("tool_input") else {
+        // No tool_input at all — only a bare tool_name is degenerate.
+        return match tool_name {
+            Some(name) => HookInput::UnknownTool {
+                tool_name: name.to_string(),
+                tool_input: serde_json::Value::Null,
+            },
             None => HookInput::MalformedMissingField,
         };
+    };
+
+    // tool_input must be a non-empty object.
+    match ti.as_object() {
+        Some(obj) if !obj.is_empty() => {}
+        _ => return HookInput::MalformedMissingField,
     }
 
-    if let Some(ti) = tool_input {
-        if ti.as_object().is_none_or(|obj| obj.is_empty()) {
-            return HookInput::MalformedMissingField;
-        }
-        if let Some(name) = v.get("tool_name").and_then(|t| t.as_str()) {
-            return HookInput::UnknownTool(name.to_string());
-        }
+    // SECURITY: a recognised field with the wrong type is a malformed
+    // payload, not a fall-through to UnknownTool fail-open.
+    if has_routing_field_with_wrong_type(ti) {
         return HookInput::MalformedMissingField;
     }
 
-    if let Some(name) = v.get("tool_name").and_then(|t| t.as_str()) {
-        return HookInput::UnknownTool(name.to_string());
+    match classify_input_shape(ti) {
+        InputShape::ShellCommand(cmd) => HookInput::Command(cmd.to_string()),
+        InputShape::FileOp(path) => HookInput::FileOp {
+            tool: tool_name.unwrap_or("unknown").to_string(),
+            path: path.to_string(),
+        },
+        InputShape::ReadOnlyUrl | InputShape::Unknown => match tool_name {
+            Some(name) => HookInput::UnknownTool {
+                tool_name: name.to_string(),
+                tool_input: ti.clone(),
+            },
+            None => HookInput::MalformedMissingField,
+        },
     }
-
-    HookInput::MalformedMissingField
 }
 
 // ---------------------------------------------------------------------------
@@ -788,9 +992,99 @@ mod tests {
     fn extract_hook_input_unknown_tool() {
         let input = r#"{"tool_name":"FutureTool","tool_input":{"query":"something"}}"#;
         match extract_hook_input(input) {
-            HookInput::UnknownTool(name) => assert_eq!(name, "FutureTool"),
+            HookInput::UnknownTool {
+                tool_name,
+                tool_input,
+            } => {
+                assert_eq!(tool_name, "FutureTool");
+                assert_eq!(
+                    tool_input.get("query").and_then(|v| v.as_str()),
+                    Some("something"),
+                    "tool_input must be carried through verbatim for routing"
+                );
+            }
             other => panic!("expected UnknownTool, got: {other:?}"),
         }
+    }
+
+    // --- PR6 (#182): structure-based routing for unknown tools ---
+
+    #[test]
+    fn extract_hook_input_unknown_tool_with_command_routes_to_command() {
+        let input = r#"{"tool_name":"FuturePlanWriter","tool_input":{"command":"ls -la"}}"#;
+        match extract_hook_input(input) {
+            HookInput::Command(cmd) => assert_eq!(cmd, "ls -la"),
+            other => panic!(
+                "expected Command (structure routing), got: {other:?} — \
+                 PR6 fail-open fix means tool_input.command always routes \
+                 to shell pipeline regardless of tool_name"
+            ),
+        }
+    }
+
+    #[test]
+    fn extract_hook_input_unknown_tool_with_cmd_alias_routes_to_command() {
+        let input = r#"{"tool_name":"FutureExec","tool_input":{"cmd":"echo hi"}}"#;
+        match extract_hook_input(input) {
+            HookInput::Command(cmd) => assert_eq!(cmd, "echo hi"),
+            other => panic!("expected Command via cmd alias, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_hook_input_unknown_tool_with_path_alias_routes_to_file_op() {
+        let input = r#"{"tool_name":"FutureEditor","tool_input":{"path":"/tmp/x"}}"#;
+        match extract_hook_input(input) {
+            HookInput::FileOp { tool, path } => {
+                assert_eq!(tool, "FutureEditor");
+                assert_eq!(path, "/tmp/x");
+            }
+            other => panic!("expected FileOp via path alias, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_hook_input_url_routes_to_unknown_tool_for_read_only() {
+        let input = r#"{"tool_name":"FutureFetch","tool_input":{"url":"https://example.com"}}"#;
+        match extract_hook_input(input) {
+            HookInput::UnknownTool {
+                tool_name,
+                tool_input,
+            } => {
+                assert_eq!(tool_name, "FutureFetch");
+                assert_eq!(classify_input_shape(&tool_input), InputShape::ReadOnlyUrl);
+            }
+            other => panic!(
+                "expected UnknownTool carrying url-shape (router decides allow), got: {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn extract_hook_input_wrong_type_command_fails_closed() {
+        // Attacker payload: command is an integer to dodge string-based
+        // routing. Must NOT fall through to UnknownTool fail-open.
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":42}}"#;
+        match extract_hook_input(input) {
+            HookInput::MalformedMissingField => {}
+            other => panic!(
+                "expected MalformedMissingField (fail-close on type mismatch), got: {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_input_shape_command_priority_over_url() {
+        // Defence: a malicious tool sending both `command` and `url`
+        // must be routed as ShellCommand, not ReadOnlyUrl.
+        let v = serde_json::json!({
+            "command": "rm -rf /",
+            "url": "https://example.com",
+        });
+        assert_eq!(
+            classify_input_shape(&v),
+            InputShape::ShellCommand("rm -rf /")
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -958,9 +958,30 @@ fn install_generates_integrity_baseline() {
 
 /// Run `omamori hook-check --provider claude-code` with given stdin input.
 /// Returns (stdout, stderr, exit_code).
+///
+/// HOME / XDG isolation (PR6 R3 / Codex round 3 P3): the hook-check
+/// path now writes audit events on the unknown-tool fail-open route
+/// (`audit_log_unknown_tool_fail_open`). Without isolation, running
+/// `cargo test --test cli` on a developer machine would append
+/// synthetic `unknown_tool_fail_open` events for fixtures like
+/// `FutureTool2027` to the user's real `~/.local/share/omamori/audit.jsonl`.
+/// We point HOME and the XDG dirs at a per-test temp directory; the
+/// hook-check binary inherits these env vars and resolves both
+/// config and audit paths to the temp dir.
 fn run_hook_check(input: &str) -> (String, String, i32) {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let test_home = std::env::temp_dir().join(format!("omamori-cli-hookcheck-{nanos}"));
+    let _ = std::fs::create_dir_all(&test_home);
+
     let mut child = Command::new(binary())
         .args(["hook-check", "--provider", "claude-code"])
+        .env("HOME", &test_home)
+        .env("XDG_CONFIG_HOME", test_home.join(".config"))
+        .env("XDG_DATA_HOME", test_home.join(".local/share"))
+        .env("XDG_CACHE_HOME", test_home.join(".cache"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -978,6 +999,7 @@ fn run_hook_check(input: &str) -> (String, String, i32) {
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let exit_code = output.status.code().unwrap_or(-1);
+    let _ = std::fs::remove_dir_all(&test_home);
     (stdout, stderr, exit_code)
 }
 

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -87,9 +87,29 @@ fn run_hook_script(hook_path: &Path, shim_dir: &Path, input: &str) -> (String, S
         current_path
     );
 
+    // Isolate HOME / XDG dirs to the temp base so tests cannot read or
+    // append to the developer's real ~/.local/share/omamori or config.
+    // PR6 introduced an audit-log write path
+    // (`audit_log_unknown_tool_fail_open`) that triggers on the
+    // unknown-shape integration case; without HOME isolation that
+    // append lands in the host user's audit log. Codex round 2 P2.
+    //
+    // We derive the test home from the hook script path (each test
+    // gets its own unique base via `setup_hook_env`, and the hook
+    // script lives at `<base>/hooks/...`).
+    let test_home = hook_path
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("hook_path must be at <base>/hooks/<file>")
+        .to_path_buf();
+
     let mut child = Command::new("/bin/sh")
         .arg(hook_path)
         .env("PATH", injected_path)
+        .env("HOME", &test_home)
+        .env("XDG_CONFIG_HOME", test_home.join(".config"))
+        .env("XDG_DATA_HOME", test_home.join(".local/share"))
+        .env("XDG_CACHE_HOME", test_home.join(".cache"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -890,5 +910,29 @@ fn mixed_payload_prefers_tool_input_blocks_dangerous_inner() {
         decision_from_exit(exit),
         Decision::Block,
         "PR6 Codex R1: mixed payload must route through tool_input.command and Block"
+    );
+}
+
+/// PR6 Codex round 2 regression guard (E2E): the symmetric case —
+/// dangerous top-level `command` paired with a benign `tool_input`
+/// non-shell shape (`query`, etc.). MUST Block. The round 1 fix had
+/// folded all `tool_input`-present cases into one dispatch and let
+/// this scenario silently turn into UnknownTool fail-open (Allow).
+/// Pinning E2E ensures a future refactor cannot collapse the priority
+/// chain again.
+#[test]
+fn mixed_payload_top_level_command_blocks_when_tool_input_unknown_shape() {
+    let (base, hook_path, shim_dir) = setup_hook_env("mixed-toplevel");
+    let raw = r#"{
+        "command": "/bin/rm -rf /tmp/x",
+        "tool_name": "FutureSearch",
+        "tool_input": { "query": "what time is it" }
+    }"#;
+    let (_, _, exit) = run_hook_script(&hook_path, &shim_dir, raw);
+    let _ = std::fs::remove_dir_all(&base);
+    assert_eq!(
+        decision_from_exit(exit),
+        Decision::Block,
+        "PR6 Codex R2: top-level command must win over tool_input non-shell shape"
     );
 }

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -869,3 +869,26 @@ fn unknown_tool_wrong_type_command_fails_closed() {
         "PR6: wrong-type routing field must not produce Allow (got {decision:?}, exit={exit})"
     );
 }
+
+/// PR6 Codex round 1 regression guard (E2E): a mixed payload with a
+/// safe top-level `command` and a dangerous `tool_input.command` MUST
+/// be Block. The `tool_input` branch wins; the safe top-level decoy
+/// must not route omamori around the shell pipeline. This pins the
+/// vulnerability Codex flagged through the full installer → wrapper →
+/// hook-check chain, not just the parser unit test.
+#[test]
+fn mixed_payload_prefers_tool_input_blocks_dangerous_inner() {
+    let (base, hook_path, shim_dir) = setup_hook_env("mixed-payload");
+    let raw = r#"{
+        "command": "echo ok",
+        "tool_name": "Bash",
+        "tool_input": { "command": "/bin/rm -rf /tmp/x" }
+    }"#;
+    let (_, _, exit) = run_hook_script(&hook_path, &shim_dir, raw);
+    let _ = std::fs::remove_dir_all(&base);
+    assert_eq!(
+        decision_from_exit(exit),
+        Decision::Block,
+        "PR6 Codex R1: mixed payload must route through tool_input.command and Block"
+    );
+}

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -848,7 +848,20 @@ fn unknown_tool_url_allowed_read_only() {
 
 /// Truly unknown shape (e.g. `query` field): observable fail-open.
 /// Decision is Allow (we preserve user workflow), but stderr must
-/// carry the audit-review hint so the silence is gone.
+/// carry the audit-review hint AND an `unknown_tool_fail_open` event
+/// must land in the audit log with `detection_layer = "shape-routing"`.
+///
+/// The audit-side assertions (added in R7 per proxy R6 P2 finding A-1)
+/// retroactively pin three R5 narrative promises that were previously
+/// guaranteed only by stderr-text checks: (1) `detection_layer` carries
+/// the new `"shape-routing"` value (not the `create_event` default
+/// `"layer1"`), (2) the audit append actually happened (not silently
+/// dropped), (3) `target_count` borrows the count of recognised
+/// top-level keys in `tool_input` (1 here, since `query` is the only
+/// key). Without these assertions, a future commit could wire
+/// `audit_log_unknown_tool_fail_open` to a no-op stub or change the
+/// detection_layer string, and the only signal would be a SIEM
+/// downstream noticing the schema drift weeks later.
 #[test]
 fn unknown_tool_unrecognised_shape_observable_fail_open() {
     let (base, hook_path, shim_dir) = setup_hook_env("unk-shape");
@@ -857,7 +870,8 @@ fn unknown_tool_unrecognised_shape_observable_fail_open() {
         serde_json::json!({ "query": "what time is it" }),
     );
     let (_, stderr, exit) = run_hook_script(&hook_path, &shim_dir, &json);
-    let _ = std::fs::remove_dir_all(&base);
+
+    // --- stderr observability assertions (R5 narrative pin) ---
     assert_eq!(
         decision_from_exit(exit),
         Decision::Allow,
@@ -871,6 +885,55 @@ fn unknown_tool_unrecognised_shape_observable_fail_open() {
         stderr.contains("omamori audit unknown"),
         "PR6: stderr must point users at the review surface, got: {stderr}"
     );
+
+    // --- audit log observability assertions (R7 / proxy R6 A-1) ---
+    // Audit log path: <test_home>/.local/share/omamori/audit.jsonl,
+    // where `test_home == base` per `run_hook_script`'s HOME isolation.
+    let audit_path = base.join(".local/share/omamori/audit.jsonl");
+    assert!(
+        audit_path.exists(),
+        "PR6 R7: unknown_tool_fail_open event must reach the audit log; \
+         audit.jsonl is missing at {audit_path:?}"
+    );
+    let audit_contents = std::fs::read_to_string(&audit_path).expect("read audit.jsonl");
+    let last_line = audit_contents
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .expect("audit.jsonl must contain at least one entry after fail-open");
+    let event: serde_json::Value =
+        serde_json::from_str(last_line).expect("audit.jsonl tail must be valid JSON");
+
+    assert_eq!(
+        event["action"], "unknown_tool_fail_open",
+        "PR6 R7: audit event must carry action=\"unknown_tool_fail_open\" \
+         so SIEM filters and `omamori audit unknown` can isolate these \
+         events; got event={event}"
+    );
+    assert_eq!(
+        event["detection_layer"], "shape-routing",
+        "PR6 R7 (proxy R6 A-1 / P1 fix): audit event must carry \
+         detection_layer=\"shape-routing\" — the create_event default \
+         \"layer1\" is wrong here because no Layer 1 detector ran. \
+         A regression that drops this override silently inflates SIEM \
+         Layer-1-hit aggregations; got event={event}"
+    );
+    assert_eq!(
+        event["result"], "allow",
+        "PR6 R7: audit event must record result=allow (the hook decision \
+         is unchanged from the original fail-open behaviour)"
+    );
+    assert_eq!(
+        event["command"], "FutureSearchTool",
+        "PR6 R7: audit event command field borrows the unrecognised \
+         tool_name (per documented Known Limitation in CHANGELOG)"
+    );
+    assert_eq!(
+        event["target_count"], 1,
+        "PR6 R7: audit event target_count borrows the count of \
+         tool_input top-level keys (1 here: only `query`)"
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
 }
 
 /// SECURITY: type-mismatch on a routing field is a malformed payload,

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -729,3 +729,143 @@ fn layer2_blocks_curl_pipe_sudo_bash() {
         "P1-1 sentinel: curl|sudo bash must Block at the hook layer (#146)"
     );
 }
+
+// =============================================================================
+// PR6 (#182): unknown-tool fail-open fix — structure-based routing tests
+// =============================================================================
+//
+// Pre-PR6, `HookInput::UnknownTool` was a forward-compat fail-open: any
+// `tool_name` Claude Code added or renamed silently bypassed Layer 2.
+// These tests pin the new behavior end-to-end through the installed
+// hook script + shim chain (the same harness used by the cross-OS
+// invariant suite above).
+//
+// Test naming: `unknown_tool_<shape>_routes_to_<destination>`.
+
+fn pretooluse_unknown_with_input(tool_name: &str, tool_input: serde_json::Value) -> String {
+    serde_json::json!({
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+    })
+    .to_string()
+}
+
+/// `tool_name=FuturePlanWriter` (unrecognised) carrying
+/// `tool_input.command="rm -rf /"` MUST be routed to the shell pipeline
+/// and Block. The pre-PR6 implementation would have allowed this — that
+/// is the forward-compat fail-open Codex ② A-2 flagged.
+#[test]
+fn unknown_tool_command_routed_to_bash() {
+    let (base, hook_path, shim_dir) = setup_hook_env("unk-cmd");
+    let json = pretooluse_unknown_with_input(
+        "FuturePlanWriter",
+        serde_json::json!({ "command": "/bin/rm -rf /tmp/x" }),
+    );
+    let (_, _, exit) = run_hook_script(&hook_path, &shim_dir, &json);
+    let _ = std::fs::remove_dir_all(&base);
+    assert_eq!(
+        decision_from_exit(exit),
+        Decision::Block,
+        "PR6: unknown tool with tool_input.command must reach shell pipeline and Block"
+    );
+}
+
+/// Same intent, alias field name (`cmd` instead of `command`). The
+/// classifier must treat them equivalently — otherwise an attacker
+/// could route through `cmd` and skip checks.
+#[test]
+fn unknown_tool_cmd_alias_routed_to_bash() {
+    let (base, hook_path, shim_dir) = setup_hook_env("unk-cmd-alias");
+    let json = pretooluse_unknown_with_input(
+        "FutureExec",
+        serde_json::json!({ "cmd": "/bin/rm -rf /tmp/x" }),
+    );
+    let (_, _, exit) = run_hook_script(&hook_path, &shim_dir, &json);
+    let _ = std::fs::remove_dir_all(&base);
+    assert_eq!(
+        decision_from_exit(exit),
+        Decision::Block,
+        "PR6: tool_input.cmd alias must route to shell pipeline (parity with command)"
+    );
+}
+
+/// File-op shape with a protected path: `tool_input.file_path` pointing
+/// at omamori's own config must be Block, regardless of `tool_name`.
+#[test]
+fn unknown_tool_file_path_protected_blocks() {
+    let (base, hook_path, shim_dir) = setup_hook_env("unk-fileop");
+    let protected = base.join(".local/share/omamori/audit-secret");
+    let json = pretooluse_unknown_with_input(
+        "FutureEditor",
+        serde_json::json!({ "file_path": protected.to_string_lossy() }),
+    );
+    let (_, _, exit) = run_hook_script(&hook_path, &shim_dir, &json);
+    let _ = std::fs::remove_dir_all(&base);
+    assert_eq!(
+        decision_from_exit(exit),
+        Decision::Block,
+        "PR6: unknown tool with file_path on a protected path must Block (FileOp routing)"
+    );
+}
+
+/// `tool_input.url` shape is read-only by contract (WebFetch / WebSearch
+/// class). Must Allow.
+#[test]
+fn unknown_tool_url_allowed_read_only() {
+    let (base, hook_path, shim_dir) = setup_hook_env("unk-url");
+    let json = pretooluse_unknown_with_input(
+        "FutureFetch",
+        serde_json::json!({ "url": "https://example.com" }),
+    );
+    let (_, _, exit) = run_hook_script(&hook_path, &shim_dir, &json);
+    let _ = std::fs::remove_dir_all(&base);
+    assert_eq!(
+        decision_from_exit(exit),
+        Decision::Allow,
+        "PR6: read-only url shape must Allow"
+    );
+}
+
+/// Truly unknown shape (e.g. `query` field): observable fail-open.
+/// Decision is Allow (we preserve user workflow), but stderr must
+/// carry the audit-review hint so the silence is gone.
+#[test]
+fn unknown_tool_unrecognised_shape_observable_fail_open() {
+    let (base, hook_path, shim_dir) = setup_hook_env("unk-shape");
+    let json = pretooluse_unknown_with_input(
+        "FutureSearchTool",
+        serde_json::json!({ "query": "what time is it" }),
+    );
+    let (_, stderr, exit) = run_hook_script(&hook_path, &shim_dir, &json);
+    let _ = std::fs::remove_dir_all(&base);
+    assert_eq!(
+        decision_from_exit(exit),
+        Decision::Allow,
+        "PR6: unknown shape must Allow (observable fail-open keeps workflow alive)"
+    );
+    assert!(
+        stderr.contains("unknown tool 'FutureSearchTool'"),
+        "PR6: stderr must surface the tool name so the fail-open is observable, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("omamori audit unknown"),
+        "PR6: stderr must point users at the review surface, got: {stderr}"
+    );
+}
+
+/// SECURITY: type-mismatch on a routing field is a malformed payload,
+/// NOT a fall-through to fail-open. Tested via integer in `command`.
+#[test]
+fn unknown_tool_wrong_type_command_fails_closed() {
+    let (base, hook_path, shim_dir) = setup_hook_env("unk-wrongtype");
+    // tool_input.command is an integer — MUST not be allowed.
+    let raw = r#"{"tool_name":"FutureBash","tool_input":{"command":42}}"#;
+    let (_, _, exit) = run_hook_script(&hook_path, &shim_dir, raw);
+    let _ = std::fs::remove_dir_all(&base);
+    let decision = decision_from_exit(exit);
+    assert_ne!(
+        decision,
+        Decision::Allow,
+        "PR6: wrong-type routing field must not produce Allow (got {decision:?}, exit={exit})"
+    );
+}


### PR DESCRIPTION
## PR thesis

`HookInput::UnknownTool` の無条件 allow を **`tool_input` field shape による structure-based routing** + **observable fail-open** に置換する。`command`/`cmd` → Bash 経路、`file_path`/`path` → FileOp 経路、`url` → read-only allow、該当なし → audit 記録 + stderr hint しつつ allow（user workflow 止めない）。これにより provider が tool 名を変更/追加した瞬間 Layer 2 が無効化される forward-compat fail-open を closing し、かつ silent でなくする。

## Review history (6 round)

| Round | Reviewer | 主要 finding | Fix commit |
|-------|----------|------|------------|
| R0 | — | 初版 (structure-based routing + observable fail-open) | `feb6f55` |
| R1 | Codex | mixed payload `{"command":"echo ok","tool_input":{"command":"rm -rf /"}}` で top-level `command` が先に評価され危険 inner が素通り。priority 反転 regression | `45c528c` |
| R2 P1 | Codex | mixed payload `{"command":"/bin/rm -rf /tmp/x","tool_input":{"query":"x"}}` で top-level command が UnknownTool fail-open に飲まれる。R1 fix で middle priority loss | `da8c366` |
| R2 P2 | Codex | tests/hook_integration.rs::run_hook_script が HOME isolation せず開発機 audit log に汚染書き込み | `da8c366` |
| R3 P2 | Codex | audit_log_unknown_tool_fail_open silent fail。stderr hint で `audit unknown` 案内するのに append 失敗時に観測経路破綻 | `2d19811` |
| R3 P3 | Codex | tests/cli.rs::run_hook_check が HOME isolation 漏れ (R2 fix の caller 漏れ) | `2d19811` |
| R4 | Codex | 6 分以上 hang、cancel | — |
| R4-proxy | Claude (Codex 代理) | P0 InputShape 網羅 GAP / P1 detection_layer 嘘 / P2×6 / P3×5 | 一部 `d1c3d97` |
| R5 | — | proxy R4 を受けて scope 判断 (case C): 観測経路 narrative honest downgrade + P1 fix + dead dedup 削除。P0 / 残 P2/P3 は a future omamori release で対応 | `d1c3d97` |
| R6-proxy | Claude (second pass) | A-1 [P2] retroactive pin test 不在 / A-2 A-3 [P3] cosmetic narrative / B-1〜B-4 [P3] CI invariant + table format + privacy + clock skew | A-1 → R7、A-2/A-3 → R8、B-1〜B-4 → issue #190 |
| R7 | — | proxy R6 A-1 fix: audit.jsonl tail 読んで 5 field assert 追加 | `a607393` |
| R8 | — | proxy R6 A-2 + A-3 fix: CHANGELOG protection unchanged 1 line + src コメント SECURITY.md SoT 参照化 | `1561fff` |

## Scope decision (R5)

proxy R4 P0 (legitimate Claude Code tool が unknown shape に大量 fall して noise 化) を受けて 4 案検討:

- **A. shape catalogue 拡張**: 思想衝突 (yotta 既却下した embedded allowlist と類縁)
- **B. observability filter palliative**: 半端、release narrative 苦しい
- **C. R0-R3 + P1 fix + narrative honest downgrade** ← **採用**
- **D. PR6 撤退**: 4 commit の psychological sunk cost、攻撃面 closure 自体は機能

判断軸: **「攻撃面 closure (R0-R3) は機能している、proxy P0 は観測経路の UX noise であって攻撃面ではない」**。protection guarantee と observability を分離して評価。

## Release blocker (UX 独立検証 2026-04-23) — 達成判定

- [x] **(a) observable fail-open の観測経路 1 本以上**: 4 本実装 (stderr / audit / `audit unknown` CLI / `doctor` 30-day line)。**Known Limitation を honest に開示** (counts は upper bound on adversarial activity, not lower bound)
- [x] **(b) honest narrative**: README / SECURITY / CHANGELOG 3 箇所更新。R5 で legitimate tool noise / audit schema borrowing / dedup 削除を全部 honest に開示、R8 で CHANGELOG protection unchanged + filter-first ordering 反映
- [x] **(c) 運用 UX チェックリスト**: 既に 2026-04-23 同日対応完了済み

## Out of scope (deferred to a future omamori release)

R5 で defer 判定したもの:
- P0 (InputShape 網羅) — shape catalogue 拡張は別 PR
- proxy R4 P2 group (target_count / command tag hijacking / audit unknown defaults / has_routing_field SoT 化 / verify 連携)
- proxy R4 P3 group (stderr prefix 統一 / target_hash collapse / count under-count narrative / R3 stderr warning AI agent 誤誘導 / dead code arm)
- proxy R6 P3 group → **#190** (CI invariant #10 / audit show table format / SECURITY.md privacy disclosure / clock skew narrative)
- Opt-in `strict-mode` (fail-closed on unrecognised shapes)
- Session-level stderr dedup

milestone は釘付けせず "a future omamori release" と表現。後続 issue: **#190**

## Tests

- **747 tests pass** (lib 612 / integration 17 / cli 101 + cli2 12 / poc 5)
- **新規 unit tests** (in `src/engine/hook.rs::tests`): structure routing × shape × wrong-type × mixed-payload priority chain (~12 tests)
- **新規 integration tests** (in `tests/hook_integration.rs`): structure routing × shape × wrong-type × mixed-payload × **R7 audit JSON retroactive pin (action / detection_layer / result / command / target_count)**
- **clippy clean** (`-D warnings`) / **fmt clean** / **invariants 9/9 pass**

## Adversarial CLI smoke (manually verified post-R8)

```
$ echo '{"tool_name":"FuturePlanWriter","tool_input":{"command":"/bin/rm -rf /tmp/x"}}' | omamori hook-check --provider claude-code
omamori hook: blocked — blocked direct rm path that bypasses PATH shim
exit=2 ✓ (forward-compat fail-open closed)

$ echo '{"command":"/bin/rm -rf /tmp/x","tool_name":"FutureSearch","tool_input":{"query":"x"}}' | omamori hook-check --provider claude-code
omamori hook: blocked — blocked direct rm path that bypasses PATH shim
exit=2 ✓ (R2 mixed payload still blocks)

$ echo '{"tool_name":"FutureSearchTool","tool_input":{"query":"hi"}}' | omamori hook-check --provider claude-code
omamori: unknown tool 'FutureSearchTool' routed as fail-open. Review via 'omamori audit unknown'
exit=0 ✓ (observable fail-open, audit event recorded with detection_layer=shape-routing)

$ echo '{"tool_name":"FutureBash","tool_input":{"command":42}}' | omamori hook-check --provider claude-code
omamori hook: blocked — required fields missing from hook input
exit=2 ✓ (type mismatch fails closed)

$ omamori audit unknown
TIMESTAMP            PROVIDER     COMMAND  ACTION          RESULT   RULE
2026-04-25T...       claude-code  FutureSearchTool unknown_tool_fail_open allow    —

$ omamori doctor
... (issues) ...
  Last 30 days: 3 unknown-tool fail-open(s) detected
  Review: omamori audit unknown
```

## Test plan

- [ ] CI green (macos-latest + ubuntu-latest)
- [ ] yotta 動作確認: `omamori audit unknown` / `omamori doctor` 実機 macOS
- [x] proxy second pass review (R6) — Ship with conditions、A-1 R7 / A-2 A-3 R8 で消化、B-1〜B-4 #190 で defer

🤖 Generated with [Claude Code](https://claude.com/claude-code)