### PR TITLE
docs: README 9-H2 restructure + SECURITY navigation + dogfood EN (PR8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ When AI tools like Claude Code, Codex, or Cursor run shell commands, omamori int
 
 Unlike other guards, omamori defends itself — AI agents cannot disable or bypass its protection ([#22](https://github.com/yottayoshida/omamori/issues/22)).
 
-**macOS only** — Terminal commands are never affected; omamori only activates when it detects an AI tool's environment variable. See [Supported Platforms](#supported-platforms) for CI coverage on Linux.
+**macOS only** — Terminal commands are never affected; omamori only activates when it detects an AI tool's environment variable. See [Tool Compatibility](#tool-compatibility) for supported AI tools and CI coverage.
 
 ![omamori demo](demo.svg)
 
@@ -33,22 +33,7 @@ omamori doctor
 
 That's it. Works with Claude Code Auto mode — no extra config needed.
 
-> Requires omamori >= 0.9.0 for `doctor` and `explain` commands.
-
-> **Cursor users**: After upgrades, re-merge the hook snippet. See [Auto-sync](#how-it-works).
-
-## Supported Platforms
-
-| Layer | macOS | Linux |
-|-------|-------|-------|
-| Runtime (shim + hooks) | Supported | Not supported |
-| CI matrix (contributors) | test + clippy + hook integration | test + clippy + hook integration (v0.9.4+) |
-
-**If you're installing omamori**: macOS only. This is a design decision — shim paths and trash integration are macOS-specific.
-
-**If you're contributing**: CI verifies your PR on both macOS and Ubuntu, so `#[cfg(unix)]` regressions are caught before merge.
-
-Windows is not currently supported (Runtime or CI).
+> Requires omamori >= 0.9.0 for `doctor` and `explain` commands. For Cursor and Codex CLI, see [Tool Compatibility](#tool-compatibility).
 
 ## What It Blocks
 
@@ -71,6 +56,34 @@ Windows is not currently supported (Runtime or CI).
 
 All rules are customizable via TOML config. See [Configuration](#configuration) below.
 
+## Tool Compatibility
+
+### Supported tiers
+
+| Tier | Tools | Coverage |
+|------|-------|----------|
+| **Supported** | Claude Code, Codex CLI, Cursor | E2E tested. Layer 1 + Layer 2. Auto mode compatible. |
+| **Community** | Gemini CLI, Cline, others | Layer 1 only. Not E2E tested. |
+| **Fallback** | Any tool setting `AI_GUARD=1` | Layer 1 only. |
+
+> The demo image above is a Claude Code capture; the same `block` / `log-only` / `trash` behaviour applies on Codex CLI and Cursor when their env vars are detected.
+
+### Tool-specific notes
+
+- **Claude Code**: hooks applied automatically. No action needed.
+- **Codex CLI**: hooks and config auto-configured during install. Auto-sync regenerates wrappers on `brew upgrade`.
+- **Cursor**: after `brew upgrade`, re-merge the hook snippet from `~/.omamori/hooks/cursor-hooks.snippet.json` into `.cursor/hooks.json`.
+
+### Platforms
+
+macOS only at runtime — shim paths and Trash integration are macOS-specific. CI verifies contributors' PRs on **macOS + Ubuntu** (`#[cfg(unix)]` regressions caught before merge). Windows is not supported.
+
+### How omamori handles new / renamed tools
+
+omamori routes by **payload shape** (`tool_input.command` / `cmd` / `file_path` / `path` / `url`), not by tool name. A renamed AI tool carrying a `command` field still reaches the full pipeline; unrecognised shapes still allow but emit `unknown_tool_fail_open` audit events. Review with `omamori audit unknown` or check `omamori doctor`'s 30-day count line.
+
+For the full shape catalogue, scope, known operational noise (legitimate tools like `Glob` / `Task` landing in fail-open), and the strict-mode trade-off, see [SECURITY.md → Hook Coverage](SECURITY.md#hook-coverage-layer-2).
+
 ## How It Works
 
 ```
@@ -87,86 +100,49 @@ Terminal → rm -rf src/
           deleted normally
 ```
 
-**Layer 1 — PATH shim**: Symlinks for `rm`, `git`, `chmod`, `find`, `rsync` point to omamori. Rules apply only when an AI environment variable is detected.
+**Layer 1 — PATH shim**: symlinks for `rm`, `git`, `chmod`, `find`, `rsync` point to omamori. Rules apply only when an AI environment variable is detected.
 
-**Layer 2 — Hooks**: Evaluates commands against the same rules as Layer 1, with three additional capabilities:
-- Recursively unwraps shell wrappers (`sudo env bash -c "..."` → extracts inner command)
-- Blocks pipe-to-shell patterns (`curl URL | bash`, `curl URL | sudo bash`, and other transparent-wrapper variants — see [SECURITY.md](SECURITY.md))
-- Blocks dynamic command generation (`bash -c "$(cmd)"`)
+**Layer 2 — Hooks**: evaluates commands against the same rules as Layer 1, with three additional capabilities:
+- Recursively unwraps shell wrappers (`sudo env bash -c "..."` → extracts inner command).
+- Blocks pipe-to-shell patterns (`curl URL | bash`, `curl URL | sudo bash`, and other transparent-wrapper variants — see [SECURITY.md](SECURITY.md)).
+- Blocks dynamic command generation (`bash -c "$(cmd)"`).
 
 Available for Claude Code, Cursor, and Codex CLI.
 
-**Audit log**: Records every command decision in a tamper-evident log — if an AI agent modifies any entry, the chain breaks and tampering is detected.
-- Tamper-evident JSONL log at `~/.local/share/omamori/audit.jsonl`
-- HMAC-SHA256 signed and hash-chained — tampering breaks the chain and is detected
-- Per-install secret; file paths HMAC-hashed (never stored in plaintext)
-- Set `retention_days` in config to automatically prune old entries — chain integrity is preserved across pruning
-- Logging enabled by default; retention is opt-in via config
+**Audit log**: records every command decision in a tamper-evident log — if an AI agent modifies any entry, the chain breaks and tampering is detected.
+- Tamper-evident JSONL log at `~/.local/share/omamori/audit.jsonl`.
+- HMAC-SHA256 signed and hash-chained — tampering breaks the chain and is detected.
+- Per-install secret; file paths HMAC-hashed (never stored in plaintext).
+- Set `retention_days` in config to automatically prune old entries — chain integrity is preserved across pruning.
+- Logging enabled by default; retention is opt-in via config.
 
 **Self-defense**: AI agents cannot `config disable`, `uninstall`, or edit `config.toml` while detected. Hooks block env var unsetting, config modification, and audit log/secret access via shell commands. This is a key differentiator from other CLI guards — omamori assumes adversarial AI behavior and defends against it.
 
-**Auto mode compatible**: Works seamlessly with Claude Code's [Auto mode](https://claude.com/blog/auto-mode) — safe commands proceed without prompts, dangerous commands are still hard-blocked.
+**Auto mode compatible**: works seamlessly with Claude Code's [Auto mode](https://claude.com/blog/auto-mode) — safe commands proceed without prompts, dangerous commands are still hard-blocked.
 
-**Auto-sync**: After `brew upgrade`, the shim detects version mismatch and auto-regenerates hook files on the next invocation.
+**Auto-sync**: after `brew upgrade`, the shim detects version mismatch and auto-regenerates hook files on the next invocation.
 
-- **Claude Code**: Hooks are applied automatically. No action needed.
-- **Codex CLI**: Hooks and config are auto-configured during install. If you install Codex later, the shim sets up hooks on first invocation. Auto-sync regenerates the wrapper on upgrade.
-- **Cursor**: Run `omamori install --hooks` to regenerate the snippet, then merge `~/.omamori/hooks/cursor-hooks.snippet.json` into your `.cursor/hooks.json`.
+**Core policy**: the 7 built-in rules cannot be disabled via `config.toml` — an AI agent setting `enabled = false` is silently ignored. For legitimate overrides, see `omamori override` in [CLI Reference](#cli-reference).
 
-**Core policy**: The 7 built-in rules cannot be disabled via `config.toml` — an AI agent setting `enabled = false` is silently ignored. For legitimate overrides, see `omamori override` in [CLI Reference](#cli-reference).
-
-**Integrity monitoring** (`omamori status`): Verifies all defense layers are intact — shims, hooks, config, core policy, PATH order. Detects tampering including subtle hook edits where the version comment is preserved but the body is rewritten.
-
-**Sandbox complementarity**: omamori operates at the semantic layer — it understands *what* a command does (Layer 1: shim, Layer 2: hooks). A filesystem sandbox operates at the OS boundary — it restricts *where* processes can read and write. These are complementary: omamori catches `rm -rf src/` before it runs; a sandbox prevents damage if something slips through. For defense in depth, combine omamori with your AI tool's sandbox (Codex CLI sandbox (on by default), Claude Code `/sandbox`, Cursor agent sandbox) or a dedicated tool like [nono](https://github.com/always-further/nono).
+**Integrity monitoring** (`omamori status`): verifies all defense layers are intact — shims, hooks, config, core policy, PATH order. Detects tampering including subtle hook edits where the version comment is preserved but the body is rewritten.
 
 **File protection**: AI Edit/Write operations on omamori's own files (config, hooks, audit log, integrity baseline, Claude Code settings.json) are blocked. See [SECURITY.md](SECURITY.md) for the full protected file list.
 
-For what omamori **does not** catch — by design or by structural limit — see [Structural Limitations](#structural-limitations).
+## Real-world Effect
 
-## Supported Tools
+omamori is dogfooded daily on the developer's own setup. Recent observed cases:
 
-| Tier | Tools | Coverage |
-|------|-------|----------|
-| **Supported** | Claude Code, Codex CLI, Cursor | E2E tested. Layer 1 + Layer 2 (where available). Auto mode compatible. |
-| **Community** | Gemini CLI, Cline, others | Layer 1 only. Not E2E tested. |
-| **Fallback** | Any tool setting `AI_GUARD=1` | Layer 1 only. |
+### 2026-04-23: Codex CLI tried to read `config.toml` during MCP re-auth
 
-### How omamori handles new / renamed tools
+When Codex CLI ran `mcp login notion`, it first attempted `rg` / `sed` against `~/.codex/config.toml` to find the auth setting. omamori hooks blocked both reads ("blocked attempt to edit Codex config"). Codex then tried to use `omamori explain -- ...` as an oracle to probe protection — also blocked by oracle-attack prevention. Codex pivoted to `codex mcp --help` → `codex mcp login notion` and completed OAuth via the browser. No protection bypassed; user-side hint preserved for after-the-fact verification.
 
-AI tools rotate fast: Claude Code adds a tool one week, Cursor renames one the next, a third CLI ships next month. omamori is installed locally and updated by `brew upgrade` on your schedule, so a tool-name allowlist baked into the binary would always be slightly behind reality.
+Full transcript: [`docs/dogfood/2026-04-23-codex-notion-mcp-reauth.md`](docs/dogfood/2026-04-23-codex-notion-mcp-reauth.md).
 
-Instead of recognising tools by name, omamori inspects the **shape** of the `tool_input` payload that the AI agent sends:
+These are honest snapshots of a single developer's environment, not benchmark claims.
 
-| Shape we recognise | Routes to |
-|---|---|
-| `tool_input.command` or `tool_input.cmd` is a string | Full Bash pipeline (meta-patterns, env-tampering, unwrap stack) |
-| `tool_input.file_path` or `tool_input.path` is a string | FileOp / protected-path checks |
-| `tool_input.url` is a string (and no shell/file fields) | Read-only — allowed |
-| Wrong type on any of the above (e.g. `command: 42`) | Fails closed (Block) |
-| None of the above | *Observable fail-open* — see below |
+## Configuration
 
-A tool calling itself `FuturePlanWriter` but carrying a `command` field still reaches the shell pipeline. A renamed Edit tool with `file_path` still reaches the protected-path check. The classifier prioritises shell-shape over file-shape over url-shape, so a payload that mixes `command` and `url` cannot dodge into the read-only branch.
-
-**Observable fail-open** (`tool_input` has no shape we recognise): omamori still allows the call — we won't start blocking unreviewed tools retroactively, that breaks user workflows on every legitimate AI update — but the silence is gone. `stderr` carries a one-line hint per invocation, and an `unknown_tool_fail_open` event is appended to the audit chain. Review them later with:
-
-```bash
-omamori audit unknown
-```
-
-`omamori doctor` also surfaces a "Last 30 days: N unknown-tool fail-opens" line whenever the count is non-zero, so you don't have to remember to look.
-
-#### Scope and limitations
-
-The recognised shape catalogue today (`command`/`cmd`/`file_path`/`path`/`url`) is intentionally narrow. Several legitimate Claude Code tools — for instance `NotebookEdit` (`notebook_path`), `Task` (`subagent_type` / `prompt`), `TodoWrite` (`todos`), `WebSearch` (`query`) — currently land in the unknown branch and emit a fail-open event on every invocation.
-
-Practical implications:
-
-- **The `audit unknown` review surface and `doctor`'s 30-day count are an *upper bound* on adversarial activity, not a lower bound.** They include this legitimate-tool noise. If you see "Last 30 days: 50 unknown-tool fail-opens", most of those are routine `Glob` / `Task` / `TodoWrite` calls, not bypass attempts. Treat the count as a "drift indicator" — a sudden spike or a tool name you don't recognise is worth investigating; a steady non-zero baseline is expected.
-- **The protection guarantee is unchanged**: payloads carrying a recognised dangerous shape (`command`, `cmd`, `file_path`, `path`) still route through the full pipeline regardless of `tool_name`. The noise issue is about observability, not the protection layer.
-
-A future omamori release will offer **opt-in strict-mode** so that users can choose between the current fail-open and a fail-closed posture for unrecognised shapes, plus a wider shape catalogue and dedicated audit columns to separate signal from noise. Until then the trade-off above is the deliberate posture.
-
-## Context-Aware Evaluation
+### Context-aware actions
 
 omamori can adjust actions based on what the command targets:
 
@@ -176,7 +152,7 @@ omamori can adjust actions based on what the command targets:
 | `rm -rf src/` | trash | **block** (protected) |
 | `git reset --hard` (no changes) | stash-then-exec | **log-only** (git-aware) |
 
-**Opt-in**: Add `[context]` to `~/.config/omamori/config.toml`. Built-in lists for regenerable (`target/`, `node_modules/`, etc.) and protected (`src/`, `.git/`, `.env`, etc.) paths activate automatically.
+**Opt-in**: add `[context]` to `~/.config/omamori/config.toml`. Built-in lists for regenerable (`target/`, `node_modules/`, etc.) and protected (`src/`, `.git/`, `.env`, etc.) paths activate automatically.
 
 ```toml
 [context]
@@ -186,11 +162,11 @@ omamori can adjust actions based on what the command targets:
 # protected_paths = ["src/", "lib/", ".git/", ".env", ".ssh/", "secrets/"]
 ```
 
-> **Note**: Specifying `regenerable_paths` or `protected_paths` **replaces** the built-in defaults (not appends). Include the built-in entries you want to keep.
+> **Note**: specifying `regenerable_paths` or `protected_paths` **replaces** the built-in defaults (not appends). Include the built-in entries you want to keep.
 
 Security features: symlink defense via `canonicalize()`, path traversal normalization, NEVER_REGENERABLE hardcoded list, fail-close on errors.
 
-## Configuration
+### Rule configuration
 
 Built-in rules are always inherited. Only write the rules you want to change:
 
@@ -243,7 +219,7 @@ retention_days = 90  # 0 = keep all (default). Minimum 7 days.
 strict = true  # default: false. Hook-only commands (ls, cat, etc.) are not affected.
 ```
 
-**Notes**: Config requires `chmod 600`. Destinations must be absolute paths on the same volume. System directories and symlinks are rejected.
+**Notes**: config requires `chmod 600`. Destinations must be absolute paths on the same volume. System directories and symlinks are rejected.
 
 </details>
 
@@ -276,22 +252,31 @@ omamori cursor-hook                      # Cursor hook handler
 omamori --version                        # Show version
 ```
 
-## Structural Limitations
+## Scope and Limitations
 
-These are inherent to the PATH shim approach and documented honestly:
+### Sandbox complementarity
 
-- **Full-path execution** (`/bin/rm`) bypasses the shim — mitigated by Layer 2 hooks
-- **`sudo`** changes PATH — omamori blocks when it detects elevated execution
-- **Interpreter commands** (`python -c "shutil.rmtree(...)"`) — not detected. [Decided out of scope per #74](https://github.com/yottayoshida/omamori/issues/74): zero real-world incidents in target tools
-- **Obfuscated commands** (base64, variable indirection) — cannot be detected by static analysis
-- **AI self-bypass** — `config disable`/`uninstall` are blocked; direct file editing blocked by hooks (Claude Code only)
+omamori operates at the **semantic layer** — it understands *what* a command does (Layer 1: shim, Layer 2: hooks). A filesystem sandbox operates at the **OS boundary** — it restricts *where* processes can read and write. These are complementary:
 
-For the full security model, bypass corpus, and known limitations, see [SECURITY.md](SECURITY.md).
+- omamori catches `rm -rf src/` before it runs (semantic: "dangerous command").
+- A sandbox prevents damage if something slips through (boundary: "this process cannot write outside `/tmp`").
 
-## Contributing
+For defense in depth, combine omamori with your AI tool's sandbox (Codex CLI sandbox (default-on), Claude Code `/sandbox`, Cursor agent sandbox) or [nono](https://github.com/always-further/nono).
+
+### Structural limitations
+
+These are inherent to the PATH shim approach:
+
+- **Full-path execution** (`/bin/rm`) bypasses the shim — mitigated by Layer 2 hooks.
+- **`sudo`** changes PATH — omamori blocks when it detects elevated execution.
+- **Interpreter commands** (`python -c "shutil.rmtree(...)"`) — not detected. [Decided out of scope per #74](https://github.com/yottayoshida/omamori/issues/74): zero real-world incidents in target tools.
+- **Obfuscated commands** (base64, variable indirection) — cannot be detected by static analysis.
+- **AI self-bypass** — `config disable` / `uninstall` are blocked; direct file editing blocked by hooks (Claude Code only).
+
+For what omamori **does not** catch — by design or by structural limit — and for the full security model and bypass corpus, see [SECURITY.md](SECURITY.md).
+
+## Contributing & License
 
 Bug reports, security disclosures, and PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, the SHA-pin policy, and the local pre-PR gate (`./scripts/pre-pr-check.sh`). Releases are reproducible: `Cargo.lock` is tracked, every CI `cargo` invocation runs with `--locked`, and every GitHub Action `uses:` ref is pinned to a 40-char SHA (Dependabot keeps them current). See [SECURITY.md](SECURITY.md#ai-assisted-contribution-invariants-v093) for the five invariants that govern AI-assisted contributions.
-
-## License
 
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,19 @@
 # SECURITY
 
+## How to read this document
+
+This document covers omamori's security model, threat analysis, and known limitations. Different readers want different things:
+
+| If you are... | Read in this order |
+|---|---|
+| **An operator** evaluating omamori for your team | [Security Model](#security-model) → [What It Protects](#what-it-protects-v090) → [Structural Limits](#structural-limits) → [Hook Coverage (Layer 2)](#hook-coverage-layer-2) → [Safe Defaults](#safe-defaults) |
+| **A security researcher** auditing the design | [Design Invariants](#design-invariants-v090) → [Bypass Corpus Testing](#bypass-corpus-testing-v041) → [Audit Log](#audit-log-v070) → [Integrity Monitoring](#integrity-monitoring-v050) |
+| **A contributor** preparing a PR | [AI-assisted Contribution Invariants](#ai-assisted-contribution-invariants-v093) |
+
+For end-user installation and CLI usage, see [README.md](README.md). For known limitations classified by closure status — closed in v0.9.x / decided out of scope / structural — jump to [Bypass Corpus Testing → Known limitations (KNOWN_LIMIT)](#known-limitations-known_limit).
+
+---
+
 ## Security Model
 
 `omamori` is a PATH-shim safeguard for AI-triggered shell commands. It reduces risk for a narrow set of destructive commands, but it is not a sandbox and it does not claim complete mediation.

--- a/docs/dogfood/2026-04-23-codex-notion-mcp-reauth.md
+++ b/docs/dogfood/2026-04-23-codex-notion-mcp-reauth.md
@@ -1,29 +1,26 @@
-# 2026-04-23 Codex による Notion MCP 再認証で omamori hook が発火した実録
+# 2026-04-23: omamori hook fired during Codex CLI Notion MCP re-authentication
 
-## 概要
+## Summary
 
-Codex CLI で Notion MCP の再認証 (`codex mcp login notion`) を実行した際、
-Codex が事前調査として `~/.codex/config.toml` を読もうとして、omamori hook が
-複数段にわたって阻止した実ログ。v0.9.5 で強化した Codex config 保護と
-oracle attack prevention (wrapper-evasion 対策) が本番で機能することを確認した。
+When Codex CLI ran `mcp login notion` (re-authentication for the Notion MCP server), Codex first attempted to read `~/.codex/config.toml` to locate the auth setting. omamori hooks blocked the reads in cascade. This is a real-world transcript validating that the v0.9.5 Codex config-protection layer and oracle-attack prevention work in production.
 
-## シナリオ
+## Scenario
 
-- ユーザー: yotta
-- AI エージェント: Codex CLI
-- 目的: Notion MCP の OAuth 再認証
-- 環境: omamori v0.9.5 (2026-04-20 release) が有効
+- User: yotta
+- AI agent: Codex CLI
+- Goal: OAuth re-authentication for Notion MCP
+- Environment: omamori v0.9.5 (released 2026-04-20)
 
-## 実ログ抜粋
+## Transcript excerpts
 
-### 1. Codex の調査意図
+### 1. Codex's investigation intent
 
 ```
-Notion MCP の認証設定を確認して、再認証に使うコマンドか設定箇所を特定する。
-まず config.toml と notion 関連の定義を読む。
+Confirm Notion MCP auth setup, then determine the re-auth command or config location.
+First, read config.toml and any notion-related definitions.
 ```
 
-### 2. omamori hook が直接参照を阻止
+### 2. omamori hook blocks direct config read
 
 ```
 PreToolUse hook (blocked)
@@ -35,9 +32,9 @@ feedback: omamori hook: blocked — blocked attempt to edit Codex config
 hint: run `omamori explain -- sed -n '1,220p' /Users/i.yoshida/.codex/config.toml` for details
 ```
 
-`rg` / `sed` による Codex config の直接参照はどちらも `blocked` で停止。
+Both `rg` and `sed` reading the Codex `config.toml` were blocked.
 
-### 3. omamori explain ネストによる bypass 試行も阻止
+### 3. Nested `omamori explain` bypass attempt also blocked
 
 ```
 PreToolUse hook (blocked)
@@ -45,68 +42,67 @@ feedback: omamori hook: blocked — blocked attempt to run explain via AI (oracl
 hint: run `omamori explain -- omamori explain -- sed -n '1,220p' /Users/i.yoshida/.codex/config.toml` for details
 ```
 
-hint として示された `omamori explain -- ...` を Codex がそのまま実行しようとしたが、
-oracle attack prevention が起動してネストを弾いた。
+The hint omamori emitted included an `omamori explain -- ...` invocation. Codex tried to execute the hint as-is, but oracle-attack prevention rejected the nested form.
 
-### 4. Codex が別経路へ転換
+### 4. Codex pivots to a different path
 
 ```
-設定読取は保護されているので、Codex CLI 側の再認証導線を探す。
-codex のヘルプから Notion/MCP の認証サブコマンドを確認する。
+Config reads are protected, so look up the Codex CLI re-auth flow.
+Check Codex's help for the Notion / MCP auth subcommand.
 ```
 
-その後、`codex mcp --help` → `codex mcp list` → `codex mcp login notion` で
-OAuth フローを起動し、ブラウザ認可で再認証完了。
+Codex then ran `codex mcp --help` → `codex mcp list` → `codex mcp login notion` to start the OAuth flow, completing re-authentication via the browser.
 
-## 観察ポイント
+## Observations
 
-### 狙い通りに動いた箇所
+### Behaviours that worked as designed
 
-| 挙動 | 評価 |
-|------|------|
-| `rg` による config.toml 参照をブロック | OK |
-| `sed` による config.toml 参照をブロック | OK |
-| `omamori explain -- omamori explain -- ...` のネストをブロック | OK (oracle attack prevention) |
-| hint を出して yotta 本人が後追い検証できる経路を残した | OK |
+| Behaviour | Outcome |
+|---|---|
+| `rg` reading `config.toml` | Blocked |
+| `sed` reading `config.toml` | Blocked |
+| `omamori explain -- omamori explain -- ...` nesting | Blocked (oracle-attack prevention) |
+| Hint emitted so the user can verify after the fact | Preserved |
 
-### v0.9.5 の wrapper-evasion 対策との関連
+### Relation to v0.9.5 closures
 
-v0.9.5 Phase 6-A で Codex が 8 ラウンドかけて unwrap.rs を攻めた結果、
-`bash -s ARG` / `|&` / option-value flags / `command -v/-V` introspection 等の
-bypass 経路を全て塞いだ。今回のログは、そのあとで別の AI が実運用で
-config 読取を試みたら、すべて検知側が先に反応する状態になっていることを
-裏付けている。
+This case validates the v0.9.5 hardening shipped in PR [#170](https://github.com/yottayoshida/omamori/pull/170):
 
-### 設計意図の確認
+- Pipe-to-shell with transparent wrappers is closed: `curl URL | env bash`, `curl URL | sudo bash`, and 7 wrapper variants (`sudo`, `env`, `nice`, `timeout`, `nohup`, `exec`, `command`) including chained, absolute-path, stdin-flag, and option-value forms.
+- File-protection hooks block direct reads of `config.toml`, audit logs, hook scripts, and integrity baselines from AI-issued commands.
+- Oracle-attack prevention blocks AI-issued `omamori explain` so the policy engine cannot be used as a probe.
 
-- 「AI から Codex config を読ませない」 → **達成**
-- 「別 AI が omamori explain を oracle として使うのを防ぐ」 → **達成**
-- 「yotta 本人の後追いデバッグ経路は残す (hint)」 → **達成**
+The 2026-04-23 transcript captures *another* AI in real-world operation hitting the protection layer first (config read blocked, explain-as-oracle blocked) without finding any of the closed bypass paths.
 
-## 補足: omamori 起因ではない周辺ノイズ
+### Design intent confirmed
 
-同じ transcript に以下のエラーも混在していたが、これは omamori 由来ではなく
-Codex 側の hook 設定問題として分離整理した。
+- "AI cannot read Codex config" → **achieved**
+- "Other AI cannot use omamori explain as an oracle" → **achieved**
+- "User-side after-the-fact verification path is preserved (hint)" → **achieved**
+
+## Note: peripheral noise not caused by omamori
+
+The same transcript also contained these errors, which are not from omamori but from the Codex hook configuration:
 
 ```
 UserPromptSubmit hook (failed) error: hook exited with code 127
 PreToolUse hook (failed) error: PreToolUse hook returned unsupported permissionDecision:allow
 ```
 
-- exit 127 = command not found (Codex の hook 定義内で参照されている別コマンドが PATH 解決失敗)
-- `permissionDecision:allow` = Codex hook API が受け付けない値 (Claude Code の hook API と仕様差)
+- exit 127 = command not found (a different command referenced inside Codex's hook definitions failed PATH resolution).
+- `permissionDecision:allow` = the Codex hook API does not accept this value (it is a Claude Code hook API value; the two have a spec-level difference).
 
-## 引用用途
+## Citation use cases
 
-この実録は今後以下の用途で引用可能:
+This transcript can be cited in:
 
-- omamori README の「実運用での効果」セクション
-- v1.0 に向けた dogfooding 証跡
-- ブログ記事「他 AI に自分の設定を覗かせない」の素材
-- 外部レビュー・監査時の挙動エビデンス
+- The omamori README "Real-world Effect" section.
+- v1.0 dogfooding evidence.
+- A blog post such as "Preventing other AIs from peeking at your config".
+- External review / audit evidence.
 
-## 関連
+## Related
 
-- v0.9.5 plan: `investigation/` 配下の Codex Phase 6-A ログ
-- SECURITY.md: wrapper-evasion 対策
-- unwrap.rs: bash wrapper 攻撃面の網羅実装
+- v0.9.5 plan: Codex Phase 6-A logs under `investigation/`.
+- `SECURITY.md`: wrapper-evasion section.
+- `src/unwrap.rs`: bash-wrapper attack-surface coverage.


### PR DESCRIPTION
## Summary

PR8 of 3 v0.9.6 release-prep PRs:
- **PR7 (merged `66e6351`)**: doc narrative integrity + philosophy flip + Known Limitations 3-way split.
- **PR8 (this)**: README 9-H2 restructure + SECURITY navigation block + dogfood doc full English translation + narrative-gluing fix.
- **PR9 (next)**: release ceremony — `Cargo.toml` version bump, `Cargo.lock` update, CHANGELOG `[Unreleased]` → `[0.9.6]` rename, summary header.

Doc-only PR; no code, test, or behavior changes.

ux-designer Round 2 produced the 9-H2 outline, persona-based First Run UX simulations (3 personas: Rails dev / frontend dev / security evaluator), and per-issue concrete edit proposals. This PR implements the Round 2 design.

## Changes

### README restructure (I-101 + I-102 + I-103 + I-104 + I-106)

13 H2 → 9 H2 to fit within Miller's Law 7±2 upper bound. New section order:

1. **Quick Start** — Cursor exception note removed (I-104), redirected to Tool Compatibility.
2. **What It Blocks** — unchanged.
3. **Tool Compatibility** *(new merged section)* — Tier table + Tool-specific notes + Platforms + payload-shape routing summary. Adds a one-line note that the demo image is a Claude Code capture but the same behaviour applies on Codex CLI / Cursor (multi-tool framing patch).
4. **How It Works** — Sandbox complementarity paragraph moved out to Scope and Limitations; File protection paragraph absorbed.
5. **Real-world Effect** *(new)* — single dogfood case for 2026-04-23 Codex MCP re-auth, 5 lines, framed as honest snapshot rather than benchmark claim (I-106).
6. **Configuration** — Context-Aware Evaluation + Configuration merged.
7. **CLI Reference** — unchanged.
8. **Scope and Limitations** *(new merged section)* — Sandbox complementarity + Structural Limitations merged (I-103). The PR7-S4 entry-point sentence "For what omamori does not catch — by design or by structural limit" now lives at the end of this section.
9. **Contributing & License** — merged into one H2.

### SECURITY.md navigation block (I-105)

"How to read this document" added at the top with three reading orders:

- **Operator**: Security Model → What It Protects → Structural Limits → Hook Coverage → Safe Defaults.
- **Security researcher**: Design Invariants → Bypass Corpus Testing → Audit Log → Integrity Monitoring.
- **Contributor**: AI-assisted Contribution Invariants.

All anchor targets cross-checked against actual H2 IDs in the file.

### dogfood doc full English translation + narrative-gluing fix (PR7 proxy R4 P3-1 + P3-2)

`docs/dogfood/2026-04-23-codex-notion-mcp-reauth.md`:
- Translated to English per `rules/git.md` 言語規約 (English default for OSS surface including `docs/`).
- "Relation to v0.9.5 closures" section rewritten from a vague "8 rounds attacked unwrap.rs" narrative into three concrete closure bullets (transparent-wrapper pipe-to-shell, file-protection hooks, oracle-attack prevention), so the connection between the v0.9.5 closures and the 2026-04-23 file-protection block is explicit rather than rhetorical.

## Out of scope

- `Cargo.toml` version bump and CHANGELOG `[Unreleased]` → `[0.9.6]` rename → PR9.
- SECURITY.md L113-124 (Structural Limits) and L186-211 (Scope: unknown / new tools) redundancy cleanup → v0.9.7+ (ux-designer Round 1 findings I-201 to I-204).
- Audit-chain CHAIN_VERSION cross-reference, PR5 wrapper-count semantic tightening → defensible-leave (PR7 proxy R4 P2 findings).
- Path sanitization in dogfood doc absolute home path → PR9 / v0.9.7+ (PR7 Out of scope).
- Full `demo.svg` multi-tool redesign → covered with a one-line note in this PR (Tool Compatibility section); SVG re-author is a separate issue.

## File diff summary

| File | Lines (before → after) | Net |
|---|---|---|
| `README.md` | 297 → 282 | −15 |
| `SECURITY.md` | 580 → 611 | +31 (navigation block) |
| `docs/dogfood/2026-04-23-codex-notion-mcp-reauth.md` | 113 → 108 | −5 (English translation + narrative tightening) |

## Test plan

Doc-only PR; no runtime behavior changes. Verification listed for completeness:

- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `./scripts/check-invariants.sh`