### PR TITLE
feat(install): auto-merge Claude Code settings.json + doctor verify + shim auto-sync (#196)

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -70,6 +70,29 @@ pub(crate) fn run_install_command(args: &[OsString]) -> Result<i32, AppError> {
             snippet.display()
         );
     }
+    match &result.claude_settings_outcome {
+        Some(installer::ClaudeSettingsOutcome::Created) => {
+            println!("  [done] Claude Code settings.json: created ~/.claude/settings.json");
+        }
+        Some(installer::ClaudeSettingsOutcome::Merged) => {
+            println!("  [done] Claude Code settings.json: merged into ~/.claude/settings.json");
+        }
+        Some(installer::ClaudeSettingsOutcome::AlreadyPresent) => {
+            println!("  [skip] Claude Code settings.json: already configured");
+        }
+        Some(installer::ClaudeSettingsOutcome::MatcherMigrated) => {
+            println!(
+                "  [migrated] Claude Code settings.json: matcher migrated to current spec (\"Bash\")"
+            );
+        }
+        Some(installer::ClaudeSettingsOutcome::Skipped(reason)) => {
+            println!("  [warn] Claude Code settings.json: {reason}");
+            println!(
+                "         Manual merge needed: cat ~/.omamori/hooks/claude-settings.snippet.json"
+            );
+        }
+        None => {}
+    }
     if let Some(cursor_snippet) = &result.cursor_hook_snippet {
         println!("  [done] Cursor hook snippet: {}", cursor_snippet.display());
     }
@@ -156,16 +179,6 @@ pub(crate) fn run_install_command(args: &[OsString]) -> Result<i32, AppError> {
         "  [todo] Add to your shell profile (~/.zshrc or ~/.bashrc):\n\n    export PATH=\"{}:$PATH\"",
         result.shim_dir.display()
     );
-    if result.settings_snippet.is_some() {
-        let hooks_dir = result
-            .hook_script
-            .as_ref()
-            .map(|p| p.parent().unwrap().display().to_string())
-            .unwrap_or_default();
-        println!(
-            "\n  [todo] Apply Claude Code hook (copy snippet to settings.json):\n\n    cat {hooks_dir}/claude-settings.snippet.json"
-        );
-    }
     if result.cursor_hook_snippet.is_some() {
         let hooks_dir = result
             .cursor_hook_snippet

--- a/src/engine/shim.rs
+++ b/src/engine/shim.rs
@@ -172,42 +172,29 @@ pub(crate) fn ensure_settings_current_for(base_dir: &Path, claude_dir: &Path) ->
         Err(_) => return false,
     };
 
-    let omamori_prefix = std::env::var_os("HOME")
-        .map(|h| {
-            std::path::PathBuf::from(h)
-                .join(".omamori")
-                .display()
-                .to_string()
-        })
-        .unwrap_or_default();
-
-    let needs_resync = doc
-        .pointer("/hooks/PreToolUse")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter().any(|e| {
-                let cmd = e
-                    .pointer("/hooks/0/command")
-                    .and_then(|v| v.as_str())
-                    .or_else(|| e.get("command").and_then(|v| v.as_str()));
-                let is_omamori = cmd
-                    .map(|c| {
-                        let unquoted = c.trim_matches('\'').trim_matches('"');
-                        !omamori_prefix.is_empty() && unquoted.contains(&omamori_prefix)
-                    })
-                    .unwrap_or(false);
-                if !is_omamori {
-                    return false;
+    // Determine resync need:
+    //   1. omamori entry missing → resync (closes the entry-missing silent gap)
+    //   2. entry present but version stale or matcher legacy → resync
+    //   3. entry present and current → no-op
+    let needs_resync = match doc.pointer("/hooks/PreToolUse").and_then(|v| v.as_array()) {
+        Some(arr) => {
+            let omamori_entry = arr
+                .iter()
+                .find(|e| installer::entry_is_omamori_managed(e, base_dir));
+            match omamori_entry {
+                None => true,
+                Some(e) => {
+                    let version = e
+                        .get("x-omamori-version")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let matcher = e.get("matcher").and_then(|v| v.as_str()).unwrap_or("");
+                    version != env!("CARGO_PKG_VERSION") || matcher != "Bash"
                 }
-                let version = e
-                    .get("x-omamori-version")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let matcher = e.get("matcher").and_then(|v| v.as_str()).unwrap_or("");
-                version != env!("CARGO_PKG_VERSION") || matcher != "Bash"
-            })
-        })
-        .unwrap_or(false);
+            }
+        }
+        None => true,
+    };
 
     if !needs_resync {
         return false;
@@ -216,6 +203,10 @@ pub(crate) fn ensure_settings_current_for(base_dir: &Path, claude_dir: &Path) ->
     let script_path = base_dir.join("hooks/claude-pretooluse.sh");
     match installer::merge_claude_settings(claude_dir, &script_path) {
         Ok(installer::ClaudeSettingsOutcome::AlreadyPresent) => false,
+        Ok(installer::ClaudeSettingsOutcome::Skipped(reason)) => {
+            eprintln!("omamori: failed to auto-sync Claude settings ({reason})");
+            false
+        }
         Ok(_) => {
             eprintln!(
                 "omamori: Claude settings auto-synced to v{}",
@@ -773,6 +764,98 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("Bash")
         );
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn ensure_settings_resyncs_when_entry_missing() {
+        // P1-1 (Codex R1): if settings.json exists with user hooks but no
+        // omamori entry, the shim must merge one in, not silently no-op.
+        let dir = std::env::temp_dir().join(format!("omamori-shim-missing-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let claude_dir = dir.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let omamori_hooks = dir.join("hooks");
+        std::fs::create_dir_all(&omamori_hooks).unwrap();
+        std::fs::write(
+            omamori_hooks.join("claude-pretooluse.sh"),
+            "#!/bin/sh\nexit 0\n",
+        )
+        .unwrap();
+
+        // settings.json exists with only a user hook (no omamori)
+        let user_doc = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Edit",
+                    "hooks": [{ "type": "command", "command": "/usr/local/bin/userhook" }]
+                }]
+            }
+        });
+        std::fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&user_doc).unwrap(),
+        )
+        .unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        // base_dir = dir, so omamori install root used by entry detection is `dir`
+        let result = ensure_settings_current_for(&dir, &claude_dir);
+        assert!(result, "must resync when omamori entry is missing");
+
+        // Verify the omamori entry was added (and user entry preserved)
+        let raw = std::fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let arr = doc
+            .pointer("/hooks/PreToolUse")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(arr.len(), 2, "user entry + new omamori entry");
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn ensure_settings_returns_false_on_skipped() {
+        // P1-3 (Codex R1): merge result Skipped (e.g. symlink target) must NOT
+        // be reported as a successful re-sync.
+        let dir = std::env::temp_dir().join(format!("omamori-shim-skipped-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let claude_dir = dir.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+
+        // Symlink settings.json — merge_claude_settings will return Skipped
+        let real = dir.join("real-settings.json");
+        // Stale entry to trigger needs_resync
+        let stale = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "*",
+                    "hooks": [{ "type": "command", "command": format!("{}/hooks/x.sh", dir.display()) }]
+                }]
+            }
+        });
+        std::fs::write(&real, serde_json::to_string_pretty(&stale).unwrap()).unwrap();
+        std::os::unix::fs::symlink(&real, claude_dir.join("settings.json")).unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let result = ensure_settings_current_for(&dir, &claude_dir);
+        assert!(!result, "Skipped outcome must return false (not success)");
 
         match saved {
             Some(v) => unsafe { std::env::set_var("HOME", v) },

--- a/src/engine/shim.rs
+++ b/src/engine/shim.rs
@@ -180,7 +180,7 @@ pub(crate) fn ensure_settings_current_for(base_dir: &Path, claude_dir: &Path) ->
         Some(arr) => {
             let omamori_entry = arr
                 .iter()
-                .find(|e| installer::entry_is_omamori_managed(e, base_dir));
+                .find(|e| installer::is_omamori_owned_entry(e, base_dir));
             match omamori_entry {
                 None => true,
                 Some(e) => {

--- a/src/engine/shim.rs
+++ b/src/engine/shim.rs
@@ -44,8 +44,11 @@ pub(crate) fn run_shim(program: &str, args: &[OsString]) -> Result<i32, AppError
     // Step 2b: Auto-setup Codex hooks if CODEX_CI detected but not configured
     let codex_setup = installer::auto_setup_codex_if_needed(&base_dir);
 
-    // Step 3: If hooks were regenerated or Codex was set up, update baseline
-    if hooks_regenerated || codex_setup {
+    // Step 2c: Re-merge ~/.claude/settings.json if version stale or matcher legacy (#196)
+    let settings_synced = ensure_settings_current();
+
+    // Step 3: If anything was regenerated, update baseline
+    if hooks_regenerated || codex_setup || settings_synced {
         update_baseline_silent(&base_dir);
     }
 
@@ -123,6 +126,108 @@ pub(crate) fn ensure_hooks_current_at(base_dir: &Path) -> bool {
     }
 
     false
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code settings.json auto-sync (#196, UX R3)
+// ---------------------------------------------------------------------------
+
+/// Check if `~/.claude/settings.json` is current; if not, re-merge omamori entry.
+fn ensure_settings_current() -> bool {
+    ensure_settings_current_at(&installer::default_base_dir())
+}
+
+/// Testable version that accepts a base directory.
+///
+/// Two re-sync triggers:
+/// 1. omamori entry's `x-omamori-version` field != current omamori version
+///    (set when the schema or hook semantics change between releases)
+/// 2. omamori entry's `matcher` is in legacy form (silently rejected by the
+///    current Claude Code parser — would leave Layer 2 dormant)
+///
+/// On either trigger, calls `merge_claude_settings()` to re-merge the entry
+/// in the current schema (UX R3: brew-upgrade auto-sync).
+///
+/// Returns `true` only when a re-merge was performed and produced an outcome
+/// other than `AlreadyPresent`. Read errors, parse errors, and "Claude Code
+/// not installed" all return `false` — recovery is the install command's
+/// responsibility, not the shim's.
+pub(crate) fn ensure_settings_current_at(base_dir: &Path) -> bool {
+    let claude_dir = installer::claude_home_dir();
+    ensure_settings_current_for(base_dir, &claude_dir)
+}
+
+/// Inner implementation that takes `claude_dir` explicitly. Test entry point.
+pub(crate) fn ensure_settings_current_for(base_dir: &Path, claude_dir: &Path) -> bool {
+    if !installer::is_real_directory(claude_dir) {
+        return false;
+    }
+    let settings_path = claude_dir.join("settings.json");
+    let raw = match std::fs::read_to_string(&settings_path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let doc: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    let omamori_prefix = std::env::var_os("HOME")
+        .map(|h| {
+            std::path::PathBuf::from(h)
+                .join(".omamori")
+                .display()
+                .to_string()
+        })
+        .unwrap_or_default();
+
+    let needs_resync = doc
+        .pointer("/hooks/PreToolUse")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter().any(|e| {
+                let cmd = e
+                    .pointer("/hooks/0/command")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| e.get("command").and_then(|v| v.as_str()));
+                let is_omamori = cmd
+                    .map(|c| {
+                        let unquoted = c.trim_matches('\'').trim_matches('"');
+                        !omamori_prefix.is_empty() && unquoted.contains(&omamori_prefix)
+                    })
+                    .unwrap_or(false);
+                if !is_omamori {
+                    return false;
+                }
+                let version = e
+                    .get("x-omamori-version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let matcher = e.get("matcher").and_then(|v| v.as_str()).unwrap_or("");
+                version != env!("CARGO_PKG_VERSION") || matcher != "Bash"
+            })
+        })
+        .unwrap_or(false);
+
+    if !needs_resync {
+        return false;
+    }
+
+    let script_path = base_dir.join("hooks/claude-pretooluse.sh");
+    match installer::merge_claude_settings(claude_dir, &script_path) {
+        Ok(installer::ClaudeSettingsOutcome::AlreadyPresent) => false,
+        Ok(_) => {
+            eprintln!(
+                "omamori: Claude settings auto-synced to v{}",
+                env!("CARGO_PKG_VERSION")
+            );
+            true
+        }
+        Err(e) => {
+            eprintln!("omamori: failed to auto-sync Claude settings ({e})");
+            false
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -585,5 +690,135 @@ mod tests {
                 "non-strict mode should return None on append failure"
             );
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // ensure_settings_current_for tests (#196 UX R3)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn ensure_settings_skips_when_claude_dir_missing() {
+        let dir =
+            std::env::temp_dir().join(format!("omamori-shim-no-claude-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let claude_dir = dir.join("does-not-exist");
+        let result = ensure_settings_current_for(&dir, &claude_dir);
+        assert!(!result);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn ensure_settings_skips_when_settings_missing() {
+        let dir =
+            std::env::temp_dir().join(format!("omamori-shim-no-settings-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let claude_dir = dir.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+
+        let result = ensure_settings_current_for(&dir, &claude_dir);
+        assert!(!result);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn ensure_settings_resyncs_on_legacy_matcher() {
+        let dir = std::env::temp_dir().join(format!("omamori-shim-legacy-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let claude_dir = dir.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let omamori_hooks = dir.join(".omamori").join("hooks");
+        std::fs::create_dir_all(&omamori_hooks).unwrap();
+        let script = omamori_hooks.join("claude-pretooluse.sh");
+        std::fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
+
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let stale = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "*",
+                    "hooks": [{"type": "command", "command": omamori_cmd}]
+                }]
+            }
+        });
+        std::fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        // The shim resolves script_path from <base_dir>/hooks/...
+        let base_hooks = dir.join("hooks");
+        std::fs::create_dir_all(&base_hooks).unwrap();
+        std::fs::write(
+            base_hooks.join("claude-pretooluse.sh"),
+            "#!/bin/sh\nexit 0\n",
+        )
+        .unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let result = ensure_settings_current_for(&dir, &claude_dir);
+        assert!(result, "should re-sync when matcher is legacy");
+
+        let raw = std::fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            doc.pointer("/hooks/PreToolUse/0/matcher")
+                .and_then(|v| v.as_str()),
+            Some("Bash")
+        );
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn ensure_settings_no_op_when_current() {
+        let dir = std::env::temp_dir().join(format!("omamori-shim-current-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let claude_dir = dir.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let omamori_hooks = dir.join(".omamori").join("hooks");
+        std::fs::create_dir_all(&omamori_hooks).unwrap();
+        let script = omamori_hooks.join("claude-pretooluse.sh");
+        std::fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
+
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let current = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": omamori_cmd}],
+                    "x-omamori-version": env!("CARGO_PKG_VERSION")
+                }]
+            }
+        });
+        std::fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&current).unwrap(),
+        )
+        .unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let result = ensure_settings_current_for(&dir, &claude_dir);
+        assert!(!result, "should be a no-op when settings are current");
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1017,15 +1017,46 @@ fn remove_claude_settings_entry(base_dir: &Path) -> Result<(), std::io::Error> {
         Err(_) => return Ok(()),
     };
 
-    let modified = doc
+    let mut modified = false;
+
+    if let Some(arr) = doc
         .pointer_mut("/hooks/PreToolUse")
         .and_then(|v| v.as_array_mut())
-        .map(|arr| {
-            let before = arr.len();
-            arr.retain(|e| !is_omamori_owned_entry(e, base_dir));
-            arr.len() != before
-        })
-        .unwrap_or(false);
+    {
+        // Pass 1: drop entries owned by omamori (single-hook canonical entries).
+        let before = arr.len();
+        arr.retain(|e| !is_omamori_owned_entry(e, base_dir));
+        if arr.len() != before {
+            modified = true;
+        }
+
+        // Pass 2: surgical cleanup of hybrid entries.
+        // For any remaining entry that still contains the omamori command as
+        // a sibling alongside user hooks, remove just the omamori inner
+        // hook(s) so the entry no longer points at a deleted script. User
+        // sibling hooks are preserved.
+        for entry in arr.iter_mut() {
+            if !entry_is_omamori_managed(entry, base_dir) {
+                continue;
+            }
+            if let Some(hooks_arr) = entry.get_mut("hooks").and_then(|v| v.as_array_mut()) {
+                let h_before = hooks_arr.len();
+                hooks_arr.retain(|h| {
+                    let cmd = h.get("command").and_then(|v| v.as_str());
+                    let is_omamori = cmd
+                        .map(|c| {
+                            let unquoted = c.trim_matches('\'').trim_matches('"');
+                            Path::new(unquoted).starts_with(base_dir)
+                        })
+                        .unwrap_or(false);
+                    !is_omamori
+                });
+                if hooks_arr.len() != h_before {
+                    modified = true;
+                }
+            }
+        }
+    }
 
     if modified {
         atomic_write_with_mode(
@@ -2407,6 +2438,67 @@ mod tests {
             "custom-base-dir managed entry must be recognised"
         );
 
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_claude_surgically_removes_omamori_from_hybrid() {
+        // R3 regression (Codex Round 3): uninstall must surgically remove
+        // the omamori inner hook from a hybrid entry, even though the
+        // entry as a whole is left intact (it carries a user sibling).
+        // Otherwise, a dead pointer to the deleted script remains.
+        let dir = fresh_test_dir("r3-hybrid-surgical");
+        let script = fake_script(&dir);
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let hybrid = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "/usr/local/bin/userhook"},
+                        {"type": "command", "command": omamori_cmd}
+                    ]
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&hybrid).unwrap(),
+        )
+        .unwrap();
+
+        let omamori_root = dir.join(".omamori");
+        remove_claude_settings_entry(&omamori_root).unwrap();
+
+        let raw = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let arr = doc
+            .pointer("/hooks/PreToolUse")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(arr.len(), 1, "hybrid entry must survive uninstall");
+
+        // Inner hooks: only user hook remains, omamori inner hook removed
+        let inner = arr[0].pointer("/hooks").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(inner.len(), 1, "only user hook should remain");
+        assert_eq!(
+            inner[0].get("command").and_then(|c| c.as_str()),
+            Some("/usr/local/bin/userhook"),
+            "user hook preserved"
+        );
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1031,10 +1031,12 @@ fn remove_claude_settings_entry(base_dir: &Path) -> Result<(), std::io::Error> {
         }
 
         // Pass 2: surgical cleanup of hybrid entries.
-        // For any remaining entry that still contains the omamori command as
-        // a sibling alongside user hooks, remove just the omamori inner
-        // hook(s) so the entry no longer points at a deleted script. User
-        // sibling hooks are preserved.
+        // For any remaining entry that still contains the omamori hook as a
+        // sibling alongside user hooks, remove ONLY the inner hook whose
+        // command points at the canonical omamori script
+        // (`<base_dir>/hooks/claude-pretooluse.sh`). User-managed hooks that
+        // happen to live under the omamori base dir are NOT touched.
+        let omamori_script_path = base_dir.join("hooks").join("claude-pretooluse.sh");
         for entry in arr.iter_mut() {
             if !entry_is_omamori_managed(entry, base_dir) {
                 continue;
@@ -1043,13 +1045,13 @@ fn remove_claude_settings_entry(base_dir: &Path) -> Result<(), std::io::Error> {
                 let h_before = hooks_arr.len();
                 hooks_arr.retain(|h| {
                     let cmd = h.get("command").and_then(|v| v.as_str());
-                    let is_omamori = cmd
+                    let is_canonical_omamori = cmd
                         .map(|c| {
                             let unquoted = c.trim_matches('\'').trim_matches('"');
-                            Path::new(unquoted).starts_with(base_dir)
+                            Path::new(unquoted) == omamori_script_path
                         })
                         .unwrap_or(false);
-                    !is_omamori
+                    !is_canonical_omamori
                 });
                 if hooks_arr.len() != h_before {
                     modified = true;
@@ -2438,6 +2440,72 @@ mod tests {
             "custom-base-dir managed entry must be recognised"
         );
 
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_claude_does_not_touch_user_hook_inside_omamori_dir() {
+        // R4 regression (Codex Round 4): the surgical pass must match the
+        // CANONICAL omamori script path, not any path under base_dir.
+        // A user who chooses to store their own hook script inside the omamori
+        // base dir (e.g. for organizational convenience) must keep it intact.
+        let dir = fresh_test_dir("r4-user-in-omamori");
+        let script = fake_script(&dir);
+        let user_inside = dir.join(".omamori").join("hooks").join("user-hook.sh");
+        fs::write(&user_inside, "#!/bin/sh\nexit 0\n").unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let user_cmd = shell_words::quote(&user_inside.display().to_string()).into_owned();
+        let hybrid = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": user_cmd.clone()},
+                        {"type": "command", "command": omamori_cmd}
+                    ]
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&hybrid).unwrap(),
+        )
+        .unwrap();
+
+        let omamori_root = dir.join(".omamori");
+        remove_claude_settings_entry(&omamori_root).unwrap();
+
+        let raw = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let arr = doc
+            .pointer("/hooks/PreToolUse")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(arr.len(), 1);
+        let inner = arr[0].pointer("/hooks").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            inner.len(),
+            1,
+            "user hook stored inside omamori base dir must survive"
+        );
+        let surviving = inner[0].get("command").and_then(|c| c.as_str()).unwrap();
+        assert!(
+            surviving.contains("user-hook.sh"),
+            "the surviving hook must be the user's, not the omamori canonical: {surviving}"
+        );
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -754,7 +754,7 @@ pub(crate) fn merge_claude_settings(
         .unwrap_or_else(|| PathBuf::from("/"));
     let existing_idx = arr
         .iter()
-        .position(|e| entry_is_omamori_managed(e, &install_root));
+        .position(|e| is_omamori_owned_entry(e, &install_root));
 
     if let Some(idx) = existing_idx {
         if arr[idx] == entry {
@@ -817,6 +817,39 @@ pub(crate) fn entry_is_omamori_managed(entry: &serde_json::Value, base_dir: &Pat
         let unquoted = c.trim_matches('\'').trim_matches('"');
         Path::new(unquoted).starts_with(base_dir)
     })
+}
+
+/// Returns true if `entry` is OWNED by omamori — i.e., omamori has the right
+/// to replace or remove the entire entry without losing user data.
+///
+/// Ownership criteria (all must hold):
+/// 1. The entry contains an omamori command (`entry_is_omamori_managed`).
+/// 2. The entry does NOT have any sibling user hooks. Specifically:
+///    - the `hooks` array has at most 1 element, AND
+///    - the legacy flat `command` field is not present alongside a non-empty
+///      `hooks` array.
+///
+/// If a user has manually merged the omamori command into an entry that also
+/// contains their own hook, that entry is NOT owned by omamori — replacing
+/// or removing the whole entry would silently destroy the user's hook. Such
+/// hybrid entries are left alone (omamori treats them as user territory).
+pub(crate) fn is_omamori_owned_entry(entry: &serde_json::Value, base_dir: &Path) -> bool {
+    if !entry_is_omamori_managed(entry, base_dir) {
+        return false;
+    }
+    let hooks_size = entry
+        .get("hooks")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    let has_flat = entry.get("command").is_some();
+    if hooks_size > 1 {
+        return false; // sibling hook exists in `hooks` array
+    }
+    if has_flat && hooks_size > 0 {
+        return false; // mixed legacy flat + new nested → user-merged shape
+    }
+    true
 }
 
 /// True if `matcher` is a legacy form that the current Claude Code parser
@@ -989,7 +1022,7 @@ fn remove_claude_settings_entry(base_dir: &Path) -> Result<(), std::io::Error> {
         .and_then(|v| v.as_array_mut())
         .map(|arr| {
             let before = arr.len();
-            arr.retain(|e| !entry_is_omamori_managed(e, base_dir));
+            arr.retain(|e| !is_omamori_owned_entry(e, base_dir));
             arr.len() != before
         })
         .unwrap_or(false);
@@ -2374,6 +2407,130 @@ mod tests {
             "custom-base-dir managed entry must be recognised"
         );
 
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_does_not_replace_hybrid_entry() {
+        // R2 regression (Codex Round 2): a "hybrid" entry — one that contains
+        // BOTH the omamori command and a user-managed sibling hook — must NOT
+        // be replaced wholesale, or the user's sibling hook is lost. Merge
+        // should leave the hybrid alone and push a separate canonical entry.
+        let dir = fresh_test_dir("r2-hybrid-merge");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let hybrid = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "/usr/local/bin/userhook"},
+                        {"type": "command", "command": omamori_cmd}
+                    ]
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&hybrid).unwrap(),
+        )
+        .unwrap();
+
+        let _ = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+
+        // After: hybrid still has both hooks (user hook survived), and a
+        // separate canonical omamori entry was pushed.
+        let raw = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let arr = doc
+            .pointer("/hooks/PreToolUse")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(
+            arr.len(),
+            2,
+            "hybrid entry must be preserved + canonical pushed"
+        );
+        // The original hybrid entry retains both inner hooks
+        let hybrid_entry = arr
+            .iter()
+            .find(|e| {
+                e.pointer("/hooks")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len() == 2)
+                    .unwrap_or(false)
+            })
+            .expect("hybrid entry must still have 2 inner hooks");
+        let inner = hybrid_entry
+            .pointer("/hooks")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert!(
+            inner
+                .iter()
+                .any(|h| h.get("command").and_then(|c| c.as_str())
+                    == Some("/usr/local/bin/userhook")),
+            "user-managed sibling hook must survive"
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_claude_settings_entry_preserves_hybrid_entry() {
+        // R2 regression (Codex Round 2): uninstall must not delete a hybrid
+        // entry, because it contains a user hook. Only canonical (omamori-
+        // owned) entries are removed.
+        let dir = fresh_test_dir("r2-hybrid-uninstall");
+        let script = fake_script(&dir);
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let hybrid_only = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "/usr/local/bin/userhook"},
+                        {"type": "command", "command": omamori_cmd}
+                    ]
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&hybrid_only).unwrap(),
+        )
+        .unwrap();
+
+        let omamori_root = dir.join(".omamori");
+        remove_claude_settings_entry(&omamori_root).unwrap();
+
+        // Hybrid entry must survive intact
+        let raw = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let arr = doc
+            .pointer("/hooks/PreToolUse")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(arr.len(), 1, "hybrid entry must not be deleted");
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -214,6 +214,11 @@ pub fn uninstall(base_dir: &Path) -> Result<UninstallResult, AppError> {
         eprintln!("omamori: warning — failed to clean Codex hooks.json: {e}");
     }
 
+    // Remove omamori entry from Claude Code settings.json (preserve other entries) (#196)
+    if let Err(e) = remove_claude_settings_entry(base_dir) {
+        eprintln!("omamori: warning — failed to clean Claude settings: {e}");
+    }
+
     // Remove integrity baseline
     let integrity_path = base_dir.join(".integrity.json");
     if integrity_path.exists() {
@@ -739,13 +744,17 @@ pub(crate) fn merge_claude_settings(
         }
     };
 
-    // Find existing omamori-managed entry: command path inside ~/.omamori/
-    let omamori_prefix = std::env::var_os("HOME")
-        .map(|h| PathBuf::from(h).join(".omamori").display().to_string())
-        .unwrap_or_default();
+    // Derive omamori install root from script_path: <base_dir>/hooks/<script>.
+    // Using script_path (not $HOME/.omamori) makes identification work with
+    // custom `--base-dir` installs as well.
+    let install_root = script_path
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("/"));
     let existing_idx = arr
         .iter()
-        .position(|e| entry_is_omamori_managed(e, &omamori_prefix));
+        .position(|e| entry_is_omamori_managed(e, &install_root));
 
     if let Some(idx) = existing_idx {
         if arr[idx] == entry {
@@ -780,25 +789,34 @@ pub(crate) fn merge_claude_settings(
     Ok(ClaudeSettingsOutcome::Merged)
 }
 
-/// Returns true if `entry` is an omamori-managed PreToolUse entry, identified
-/// by its command path being inside `~/.omamori/`.
-fn entry_is_omamori_managed(entry: &serde_json::Value, omamori_prefix: &str) -> bool {
-    if omamori_prefix.is_empty() {
-        return false;
+/// Returns true if `entry` is an omamori-managed PreToolUse entry.
+///
+/// Identification: any `command` field inside this entry (whether in the
+/// nested `hooks` array, or the legacy flat `command` field on the matcher
+/// object itself) starts with `base_dir` (the omamori install root,
+/// typically `~/.omamori`).
+///
+/// Walks the full `hooks` array (not just `hooks[0]`) so that an omamori
+/// command sitting at index 1+ in a multi-hook entry is still detected.
+/// Uses `Path::starts_with` (component-wise) instead of substring contains
+/// so that, e.g., `~/.omamori-bak/...` does not match `~/.omamori`.
+pub(crate) fn entry_is_omamori_managed(entry: &serde_json::Value, base_dir: &Path) -> bool {
+    let mut commands: Vec<&str> = Vec::new();
+    if let Some(arr) = entry.get("hooks").and_then(|v| v.as_array()) {
+        for h in arr {
+            if let Some(c) = h.get("command").and_then(|v| v.as_str()) {
+                commands.push(c);
+            }
+        }
     }
-    // Two command shapes to detect during migration:
-    //   New: { matcher, hooks: [{ type: "command", command: "..." }] }
-    //   Legacy flat: { matcher, command: "..." }
-    let cmd = entry
-        .pointer("/hooks/0/command")
-        .and_then(|v| v.as_str())
-        .or_else(|| entry.get("command").and_then(|v| v.as_str()));
-    let Some(cmd) = cmd else {
-        return false;
-    };
-    // Strip surrounding shell quoting that shell_words::quote may have applied.
-    let cmd_unquoted = cmd.trim_matches('\'').trim_matches('"');
-    cmd_unquoted.contains(omamori_prefix)
+    if let Some(c) = entry.get("command").and_then(|v| v.as_str()) {
+        commands.push(c);
+    }
+    commands.iter().any(|c| {
+        // Strip surrounding shell quoting that shell_words::quote may have applied.
+        let unquoted = c.trim_matches('\'').trim_matches('"');
+        Path::new(unquoted).starts_with(base_dir)
+    })
 }
 
 /// True if `matcher` is a legacy form that the current Claude Code parser
@@ -946,6 +964,44 @@ pub(crate) fn merge_codex_hooks(
 
     atomic_write(&hooks_path, &serde_json::to_string_pretty(&doc).unwrap())?;
     Ok(CodexHooksOutcome::Merged)
+}
+
+/// Remove omamori's entry from `~/.claude/settings.json` during uninstall.
+/// Preserves the user's other hooks. Identifies the omamori entry by
+/// `entry_is_omamori_managed(e, base_dir)`. Symlinks and parse errors
+/// are skipped silently — the user can clean up manually if needed.
+fn remove_claude_settings_entry(base_dir: &Path) -> Result<(), std::io::Error> {
+    let settings_path = claude_home_dir().join("settings.json");
+    if !settings_path.exists() {
+        return Ok(());
+    }
+    if settings_path.is_symlink() || !is_real_file(&settings_path) {
+        return Ok(());
+    }
+    let raw = fs::read_to_string(&settings_path)?;
+    let mut doc: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+
+    let modified = doc
+        .pointer_mut("/hooks/PreToolUse")
+        .and_then(|v| v.as_array_mut())
+        .map(|arr| {
+            let before = arr.len();
+            arr.retain(|e| !entry_is_omamori_managed(e, base_dir));
+            arr.len() != before
+        })
+        .unwrap_or(false);
+
+    if modified {
+        atomic_write_with_mode(
+            &settings_path,
+            &serde_json::to_string_pretty(&doc).unwrap(),
+            0o600,
+        )?;
+    }
+    Ok(())
 }
 
 /// Remove omamori's entry from `~/.codex/hooks.json` during uninstall.
@@ -2250,5 +2306,139 @@ mod tests {
             Some(env!("CARGO_PKG_VERSION")),
             "must embed omamori version"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // R1 fix tests (Codex Round 1 findings)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn entry_is_omamori_managed_rejects_lookalike_dirs() {
+        // P2-1 (Codex R1): substring contains was treating ~/.omamori-bak
+        // as managed. Path::starts_with should reject it.
+        let base = Path::new("/home/u/.omamori");
+        let entry_bak = serde_json::json!({
+            "matcher": "Bash",
+            "hooks": [{ "type": "command", "command": "/home/u/.omamori-bak/hooks/x.sh" }]
+        });
+        let entry_real = serde_json::json!({
+            "matcher": "Bash",
+            "hooks": [{ "type": "command", "command": "/home/u/.omamori/hooks/x.sh" }]
+        });
+        assert!(!entry_is_omamori_managed(&entry_bak, base));
+        assert!(entry_is_omamori_managed(&entry_real, base));
+    }
+
+    #[test]
+    fn entry_is_omamori_managed_walks_full_hooks_array() {
+        // P2-3 (Codex R1): hooks[1..] should be checked, not just hooks[0].
+        let base = Path::new("/opt/omamori");
+        let entry_at_idx1 = serde_json::json!({
+            "matcher": "Bash",
+            "hooks": [
+                { "type": "command", "command": "/usr/local/bin/userhook" },
+                { "type": "command", "command": "/opt/omamori/hooks/script.sh" }
+            ]
+        });
+        assert!(entry_is_omamori_managed(&entry_at_idx1, base));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_handles_custom_base_dir() {
+        // P2-2 (Codex R1): identification must work for `--base-dir` installs,
+        // not just the default ~/.omamori prefix.
+        let dir = fresh_test_dir("p2-base");
+        let custom_base = dir.join("custom-omamori");
+        let hooks_dir = custom_base.join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let script = hooks_dir.join("claude-pretooluse.sh");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
+
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        // First merge under custom base — should Create
+        let r1 = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(r1, ClaudeSettingsOutcome::Created));
+
+        // Second merge — must recognise the existing entry as managed
+        // (otherwise it would push a duplicate)
+        let r2 = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(
+            matches!(r2, ClaudeSettingsOutcome::AlreadyPresent),
+            "custom-base-dir managed entry must be recognised"
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_claude_settings_entry_preserves_user_hooks() {
+        // P1-2 (Codex R1): uninstall must remove the omamori entry but leave
+        // user-managed hooks intact.
+        let dir = fresh_test_dir("p1-uninstall");
+        let script = fake_script(&dir);
+
+        // Set HOME so claude_home_dir() resolves to <dir>/.claude
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        // First, install the omamori entry alongside a user hook
+        let user_doc = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Edit",
+                    "hooks": [{ "type": "command", "command": "/usr/local/bin/userhook" }]
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&user_doc).unwrap(),
+        )
+        .unwrap();
+        merge_claude_settings(&claude_dir, &script).unwrap();
+
+        // Sanity: 2 entries
+        let raw = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            doc.pointer("/hooks/PreToolUse")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
+            Some(2)
+        );
+
+        // Now run uninstall removal
+        let omamori_root = dir.join(".omamori");
+        remove_claude_settings_entry(&omamori_root).unwrap();
+
+        // After: 1 entry, the user's
+        let raw = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let arr = doc
+            .pointer("/hooks/PreToolUse")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(arr.len(), 1, "user entry preserved, omamori removed");
+        assert_eq!(
+            arr[0].pointer("/hooks/0/command").and_then(|v| v.as_str()),
+            Some("/usr/local/bin/userhook")
+        );
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -31,6 +31,7 @@ pub struct InstallResult {
     pub codex_wrapper: Option<PathBuf>,
     pub codex_hooks_outcome: Option<CodexHooksOutcome>,
     pub codex_config_outcome: Option<CodexConfigOutcome>,
+    pub claude_settings_outcome: Option<ClaudeSettingsOutcome>,
 }
 
 #[derive(Debug, Clone)]
@@ -54,6 +55,25 @@ pub enum CodexConfigOutcome {
     /// User explicitly set false — not touched
     ExplicitlyDisabled,
     /// Skipped with reason (no file, parse failure, etc.)
+    Skipped(String),
+}
+
+/// Outcome of `merge_claude_settings` (#196). Maps to the print messages in
+/// `cli/install.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaudeSettingsOutcome {
+    /// `~/.claude/settings.json` did not exist; created with omamori entry only.
+    Created,
+    /// File existed and parsed; omamori entry was added or updated.
+    Merged,
+    /// File existed and already contained an up-to-date omamori entry.
+    AlreadyPresent,
+    /// File existed and contained an omamori-managed entry whose `matcher` was
+    /// in legacy form (`"*"` or boolean string). Migrated to simple `"Bash"`
+    /// (Q2=c partial migrate; user-managed entries are not touched).
+    MatcherMigrated,
+    /// Merge was not attempted; reason is provided. Caller surfaces this to
+    /// the user with a manual-fallback hint.
     Skipped(String),
 }
 
@@ -118,6 +138,26 @@ pub fn install(options: &InstallOptions) -> Result<InstallResult, AppError> {
         None
     };
 
+    // Auto-merge omamori entry into ~/.claude/settings.json (#196).
+    // Only attempt when Claude Code is installed (signal: ~/.claude/ exists
+    // as a real directory). Mirrors the Codex CLI detection pattern below.
+    let claude_settings_outcome = match (options.generate_hooks, hook_script.as_ref()) {
+        (true, Some(script_path)) => {
+            let claude_dir = claude_home_dir();
+            if is_real_directory(&claude_dir) {
+                Some(
+                    merge_claude_settings(&claude_dir, script_path)
+                        .unwrap_or_else(|e| ClaudeSettingsOutcome::Skipped(format!("I/O: {e}"))),
+                )
+            } else {
+                Some(ClaudeSettingsOutcome::Skipped(
+                    "Claude Code not detected (~/.claude not a directory)".into(),
+                ))
+            }
+        }
+        _ => None,
+    };
+
     // Generate Codex CLI hook (wrapper → hooks.json → config.toml)
     let (codex_wrapper, codex_hooks_outcome, codex_config_outcome) = if options.generate_hooks {
         setup_codex_hooks(&options.base_dir, &options.source_exe)
@@ -139,6 +179,7 @@ pub fn install(options: &InstallOptions) -> Result<InstallResult, AppError> {
         codex_wrapper,
         codex_hooks_outcome,
         codex_config_outcome,
+        claude_settings_outcome,
     })
 }
 
@@ -231,6 +272,24 @@ fn atomic_write(target: &Path, content: &str) -> Result<(), std::io::Error> {
     Ok(())
 }
 
+/// Atomic write with explicit Unix file mode.
+///
+/// SEC-3: ensures `~/.claude/settings.json` is written with explicit `0o600`
+/// (owner read/write only), independent of the caller's umask. The mode is set
+/// at file creation via `OpenOptions::mode()`, so there is no TOCTOU window
+/// where the file exists with a wider permission bit set.
+///
+/// On non-Unix platforms, `mode` is ignored and behavior matches `atomic_write`.
+fn atomic_write_with_mode(target: &Path, content: &str, mode: u32) -> Result<(), std::io::Error> {
+    let dir = target.parent().unwrap_or(Path::new("."));
+    let mut tmp = tempfile_in_with_mode(dir, mode)?;
+    tmp.write_all(content.as_bytes())?;
+    tmp.flush()?;
+    let tmp_path = tmp.into_path();
+    fs::rename(&tmp_path, target)?;
+    Ok(())
+}
+
 /// Create a named temp file in the given directory.
 /// Uses O_EXCL (create_new) for exclusive creation + O_NOFOLLOW on Unix to prevent
 /// symlink-following attacks. AtomicU64 counter ensures uniqueness within a process.
@@ -250,6 +309,34 @@ fn tempfile_in(dir: &Path) -> Result<AtomicTempFile, std::io::Error> {
             .custom_flags(libc::O_NOFOLLOW)
             .open(&path)?
     };
+    #[cfg(not(unix))]
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+    Ok(AtomicTempFile { file, path })
+}
+
+/// Variant of `tempfile_in` that sets the file mode at creation time
+/// (Unix only). On non-Unix platforms `mode` is ignored.
+fn tempfile_in_with_mode(dir: &Path, mode: u32) -> Result<AtomicTempFile, std::io::Error> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path = dir.join(format!(".omamori-tmp-{}-{}", std::process::id(), seq));
+    #[cfg(unix)]
+    let file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .mode(mode)
+            .open(&path)?
+    };
+    #[cfg(not(unix))]
+    let _ = mode;
     #[cfg(not(unix))]
     let file = fs::OpenOptions::new()
         .write(true)
@@ -522,15 +609,204 @@ fn generate_install_baseline(base_dir: &Path) -> Result<(), crate::AppError> {
     Ok(())
 }
 
+/// Build the JSON value for one omamori entry inside Claude Code's
+/// `hooks.PreToolUse` array.
+///
+/// Spec (current Claude Code, see https://code.claude.com/docs/en/hooks):
+/// - `matcher`: simple string `"Bash"`. The legacy boolean form
+///   `"tool == \"Bash\""` is silently rejected by the current parser (#195).
+/// - `hooks`: nested array with `type: "command"`. The older flat `command`
+///   field on the matcher object is deprecated.
+/// - `x-omamori-version`: omamori version embed used by shim auto-sync to
+///   detect schema migration. Claude Code ignores `x-` prefixed fields per the
+///   JSON forward-compat convention.
+pub(crate) fn claude_settings_entry(script_path: &Path) -> serde_json::Value {
+    let command = shell_words::quote(&script_path.display().to_string()).into_owned();
+    serde_json::json!({
+        "matcher": "Bash",
+        "hooks": [{
+            "type": "command",
+            "command": command,
+        }],
+        "x-omamori-version": env!("CARGO_PKG_VERSION"),
+    })
+}
+
 fn render_settings_snippet(script_path: &Path) -> String {
-    let escaped = script_path
-        .display()
-        .to_string()
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"");
-    format!(
-        "{{\n  \"hooks\": {{\n    \"PreToolUse\": [{{\n      \"matcher\": \"*\",\n      \"command\": \"{escaped}\"\n    }}]\n  }}\n}}\n"
-    )
+    let entry = claude_settings_entry(script_path);
+    let snippet = serde_json::json!({
+        "_comment": format!(
+            "Generated by omamori v{}. Auto-merged into ~/.claude/settings.json by `omamori install --hooks`.",
+            env!("CARGO_PKG_VERSION")
+        ),
+        "hooks": {
+            "PreToolUse": [entry]
+        }
+    });
+    serde_json::to_string_pretty(&snippet).unwrap() + "\n"
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code settings.json merge support (#196)
+// ---------------------------------------------------------------------------
+
+/// Default Claude Code config directory (`~/.claude`).
+pub(crate) fn claude_home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".claude")
+}
+
+/// In-place merge of omamori's PreToolUse hook entry into
+/// `~/.claude/settings.json`.
+///
+/// Identification of the omamori-managed entry uses the `command` field's
+/// path containing `~/.omamori/`. User-managed entries with arbitrary
+/// commands are preserved untouched.
+///
+/// Behavior:
+/// - File missing → create with omamori entry only (`Created`).
+/// - File is symlink / not a regular file → `Skipped`.
+/// - Invalid JSON → `Skipped` with the parse error message.
+/// - Existing omamori entry, identical → `AlreadyPresent`.
+/// - Existing omamori entry, legacy matcher (`"*"` / boolean) → migrate to
+///   simple `"Bash"` (`MatcherMigrated`). Q2=c: only entries identified as
+///   omamori-managed are migrated.
+/// - Existing omamori entry, otherwise stale → replace → `Merged`.
+/// - No omamori entry → push new entry → `Merged`.
+///
+/// All writes use `atomic_write_with_mode(.., 0o600)` (SEC-3).
+pub(crate) fn merge_claude_settings(
+    claude_dir: &Path,
+    script_path: &Path,
+) -> Result<ClaudeSettingsOutcome, std::io::Error> {
+    let settings_path = claude_dir.join("settings.json");
+    let entry = claude_settings_entry(script_path);
+
+    // --- No file: create from scratch with omamori entry only ---
+    if !settings_path.exists() && !settings_path.is_symlink() {
+        let doc = serde_json::json!({
+            "hooks": { "PreToolUse": [entry] }
+        });
+        atomic_write_with_mode(
+            &settings_path,
+            &serde_json::to_string_pretty(&doc).unwrap(),
+            0o600,
+        )?;
+        return Ok(ClaudeSettingsOutcome::Created);
+    }
+
+    // --- Symlink / non-regular: refuse ---
+    if settings_path.is_symlink() || !is_real_file(&settings_path) {
+        return Ok(ClaudeSettingsOutcome::Skipped(
+            "settings.json is a symlink or not a regular file".into(),
+        ));
+    }
+
+    // --- Read & parse ---
+    let raw = fs::read_to_string(&settings_path)?;
+    let mut doc: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            return Ok(ClaudeSettingsOutcome::Skipped(format!(
+                "JSON parse error: {e}"
+            )));
+        }
+    };
+
+    // Ensure hooks.PreToolUse exists as an array
+    let arr = doc
+        .as_object_mut()
+        .and_then(|o| {
+            o.entry("hooks")
+                .or_insert_with(|| serde_json::json!({}))
+                .as_object_mut()
+        })
+        .and_then(|h| {
+            let pre = h
+                .entry("PreToolUse")
+                .or_insert_with(|| serde_json::json!([]));
+            pre.as_array_mut()
+        });
+
+    let arr = match arr {
+        Some(a) => a,
+        None => {
+            return Ok(ClaudeSettingsOutcome::Skipped(
+                "hooks.PreToolUse is not an array".into(),
+            ));
+        }
+    };
+
+    // Find existing omamori-managed entry: command path inside ~/.omamori/
+    let omamori_prefix = std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join(".omamori").display().to_string())
+        .unwrap_or_default();
+    let existing_idx = arr
+        .iter()
+        .position(|e| entry_is_omamori_managed(e, &omamori_prefix));
+
+    if let Some(idx) = existing_idx {
+        if arr[idx] == entry {
+            return Ok(ClaudeSettingsOutcome::AlreadyPresent);
+        }
+        let was_legacy_matcher = arr[idx]
+            .get("matcher")
+            .and_then(|m| m.as_str())
+            .map(is_legacy_matcher)
+            .unwrap_or(false);
+        arr[idx] = entry;
+        let outcome = if was_legacy_matcher {
+            ClaudeSettingsOutcome::MatcherMigrated
+        } else {
+            ClaudeSettingsOutcome::Merged
+        };
+        atomic_write_with_mode(
+            &settings_path,
+            &serde_json::to_string_pretty(&doc).unwrap(),
+            0o600,
+        )?;
+        return Ok(outcome);
+    }
+
+    // No existing omamori entry → push new
+    arr.push(entry);
+    atomic_write_with_mode(
+        &settings_path,
+        &serde_json::to_string_pretty(&doc).unwrap(),
+        0o600,
+    )?;
+    Ok(ClaudeSettingsOutcome::Merged)
+}
+
+/// Returns true if `entry` is an omamori-managed PreToolUse entry, identified
+/// by its command path being inside `~/.omamori/`.
+fn entry_is_omamori_managed(entry: &serde_json::Value, omamori_prefix: &str) -> bool {
+    if omamori_prefix.is_empty() {
+        return false;
+    }
+    // Two command shapes to detect during migration:
+    //   New: { matcher, hooks: [{ type: "command", command: "..." }] }
+    //   Legacy flat: { matcher, command: "..." }
+    let cmd = entry
+        .pointer("/hooks/0/command")
+        .and_then(|v| v.as_str())
+        .or_else(|| entry.get("command").and_then(|v| v.as_str()));
+    let Some(cmd) = cmd else {
+        return false;
+    };
+    // Strip surrounding shell quoting that shell_words::quote may have applied.
+    let cmd_unquoted = cmd.trim_matches('\'').trim_matches('"');
+    cmd_unquoted.contains(omamori_prefix)
+}
+
+/// True if `matcher` is a legacy form that the current Claude Code parser
+/// silently rejects: wildcard `"*"` or boolean expression
+/// (`"tool == \"Bash\""` etc.). The modern parser accepts simple strings like
+/// `"Bash"`, `"Edit"`, `"Read"`.
+fn is_legacy_matcher(matcher: &str) -> bool {
+    matcher == "*" || matcher.contains("==") || matcher.contains("&&") || matcher.contains("||")
 }
 
 // ---------------------------------------------------------------------------
@@ -546,7 +822,7 @@ fn codex_home_dir() -> PathBuf {
 }
 
 /// True only if `path` is a real directory (not a symlink to one).
-fn is_real_directory(path: &Path) -> bool {
+pub(crate) fn is_real_directory(path: &Path) -> bool {
     path.symlink_metadata().map(|m| m.is_dir()).unwrap_or(false)
 }
 
@@ -1578,4 +1854,401 @@ mod tests {
 
     // Note: Testing CODEX_CI=1 + no wrapper requires setting env var (unsafe in Rust 2024)
     // and having a valid codex home dir. This is covered by integration tests (E-01~E-05).
+
+    // ---------------------------------------------------------------------
+    // Claude Code settings.json merge tests (#196)
+    //
+    // V-001..V-013 verification IDs from the v0.9.7 plan:
+    // V-001/010 file missing → Created   V-002 preserves user hooks
+    // V-003 idempotent (AlreadyPresent)   V-004 boolean matcher migration
+    // V-005 wildcard matcher migration    V-006 file mode 0o600 (Unix)
+    // V-007 corrupted JSON → Skipped      V-008 large file handling
+    // V-009 empty file → Skipped          V-011 symlink → Skipped
+    // V-013 other legacy matcher forms
+    //
+    // ADV-196-1 (user-managed entry survival) is covered by V-002.
+    // ADV-196-6 (deeply nested JSON) is covered by huge_json test.
+    // ---------------------------------------------------------------------
+
+    fn fresh_test_dir(tag: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("omamori-claude-{}-{}", tag, std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn fake_script(dir: &Path) -> std::path::PathBuf {
+        let omamori_root = dir.join(".omamori");
+        let hooks_dir = omamori_root.join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let script = hooks_dir.join("claude-pretooluse.sh");
+        fs::write(&script, "#!/bin/sh\n# omamori hook v\nexit 0\n").unwrap();
+        script
+    }
+
+    /// Compute the omamori prefix that `merge_claude_settings` expects.
+    /// We point HOME-derived prefix at our test dir by passing the right script
+    /// path. The merge function builds prefix from `HOME` env var, so for tests
+    /// we ensure the script lives under `<HOME>/.omamori/...`.
+    fn with_test_home<R>(home: &Path, f: impl FnOnce() -> R) -> R {
+        let saved = std::env::var_os("HOME");
+        // SAFETY: serial_test ensures no parallel test mutates HOME concurrently.
+        unsafe { std::env::set_var("HOME", home) };
+        let result = f();
+        // Restore
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        result
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_creates_when_missing() {
+        let dir = fresh_test_dir("v001");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        let result = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(result, ClaudeSettingsOutcome::Created));
+
+        let content = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            doc.pointer("/hooks/PreToolUse/0/matcher")
+                .and_then(|v| v.as_str()),
+            Some("Bash")
+        );
+        assert_eq!(
+            doc.pointer("/hooks/PreToolUse/0/x-omamori-version")
+                .and_then(|v| v.as_str()),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_preserves_user_hooks() {
+        let dir = fresh_test_dir("v002");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        let user_doc = serde_json::json!({
+            "hooks": {
+                "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "/usr/local/bin/userhook"}]}],
+                "PreToolUse": [{
+                    "matcher": "Edit",
+                    "hooks": [{"type": "command", "command": "/usr/local/bin/another"}]
+                }]
+            },
+            "theme": "dark"
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&user_doc).unwrap(),
+        )
+        .unwrap();
+
+        let result = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(result, ClaudeSettingsOutcome::Merged));
+
+        let content = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&content).unwrap();
+        // User's UserPromptSubmit preserved
+        assert_eq!(
+            doc.pointer("/hooks/UserPromptSubmit/0/hooks/0/command")
+                .and_then(|v| v.as_str()),
+            Some("/usr/local/bin/userhook")
+        );
+        // User's PreToolUse Edit entry preserved
+        let pre = doc
+            .pointer("/hooks/PreToolUse")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(pre.len(), 2, "user entry + omamori entry");
+        // Top-level "theme" preserved
+        assert_eq!(doc.get("theme").and_then(|v| v.as_str()), Some("dark"));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_is_idempotent() {
+        let dir = fresh_test_dir("v003");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        let r1 = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(r1, ClaudeSettingsOutcome::Created));
+
+        let r2 = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(r2, ClaudeSettingsOutcome::AlreadyPresent));
+
+        // Confirm only one entry exists after second merge
+        let content = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            doc.pointer("/hooks/PreToolUse")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
+            Some(1)
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_migrates_legacy_boolean_matcher() {
+        let dir = fresh_test_dir("v004");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        // Pre-existing settings with omamori entry but legacy boolean matcher
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let stale = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "tool == \"Bash\"",
+                    "hooks": [{"type": "command", "command": omamori_cmd.clone()}]
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let result = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(result, ClaudeSettingsOutcome::MatcherMigrated));
+
+        let content = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            doc.pointer("/hooks/PreToolUse/0/matcher")
+                .and_then(|v| v.as_str()),
+            Some("Bash"),
+            "legacy boolean matcher must migrate to simple Bash"
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_migrates_wildcard_matcher() {
+        let dir = fresh_test_dir("v005");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        // Older v0.9.6 snippet form: matcher = "*", flat command field
+        let stale = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "*",
+                    "command": script.display().to_string()
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let result = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(result, ClaudeSettingsOutcome::MatcherMigrated));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[cfg(unix)]
+    fn merge_claude_writes_with_mode_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = fresh_test_dir("v006");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        let _ = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+
+        let mode = fs::metadata(claude_dir.join("settings.json"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "SEC-3: settings.json must be written with mode 0o600"
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_skips_corrupted_json() {
+        let dir = fresh_test_dir("v007");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(claude_dir.join("settings.json"), "{ not valid }}}").unwrap();
+
+        let result = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(result, ClaudeSettingsOutcome::Skipped(_)));
+
+        // SEC-1: original file must not be overwritten
+        let raw = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        assert_eq!(raw, "{ not valid }}}", "must not overwrite on parse error");
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_handles_large_settings_file() {
+        let dir = fresh_test_dir("v008");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        // Build a settings.json with many user entries
+        let mut user_entries = Vec::new();
+        for i in 0..500 {
+            user_entries.push(serde_json::json!({
+                "matcher": format!("Tool{i}"),
+                "hooks": [{"type": "command", "command": format!("/path/{i}")}]
+            }));
+        }
+        let user_doc = serde_json::json!({
+            "hooks": { "PreToolUse": user_entries }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&user_doc).unwrap(),
+        )
+        .unwrap();
+
+        let result = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(result, ClaudeSettingsOutcome::Merged));
+
+        // 501 entries (500 user + 1 omamori)
+        let content = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            doc.pointer("/hooks/PreToolUse")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
+            Some(501)
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn merge_claude_handles_empty_file() {
+        let dir = fresh_test_dir("v009");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(claude_dir.join("settings.json"), "").unwrap();
+
+        let result = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        // Empty file is a JSON parse error → Skipped (we don't blindly overwrite
+        // because the file might be intentionally truncated by the user).
+        assert!(matches!(result, ClaudeSettingsOutcome::Skipped(_)));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[cfg(unix)]
+    fn merge_claude_skips_symlink() {
+        let dir = fresh_test_dir("v011");
+        let script = fake_script(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+
+        // Create a real file and symlink settings.json to it
+        let real = dir.join("real-settings.json");
+        fs::write(&real, "{}").unwrap();
+        std::os::unix::fs::symlink(&real, claude_dir.join("settings.json")).unwrap();
+
+        let result = with_test_home(&dir, || {
+            merge_claude_settings(&claude_dir, &script).unwrap()
+        });
+        assert!(matches!(result, ClaudeSettingsOutcome::Skipped(_)));
+
+        // SEC-2: real file must not be modified
+        assert_eq!(fs::read_to_string(&real).unwrap(), "{}");
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn is_legacy_matcher_classifies_correctly() {
+        // V-013: legacy forms
+        assert!(is_legacy_matcher("*"));
+        assert!(is_legacy_matcher("tool == \"Bash\""));
+        assert!(is_legacy_matcher("tool == \"Bash\" && tool == \"Edit\""));
+        assert!(is_legacy_matcher("tool == \"Bash\" || tool == \"Edit\""));
+        // Modern simple matchers
+        assert!(!is_legacy_matcher("Bash"));
+        assert!(!is_legacy_matcher("Edit"));
+        assert!(!is_legacy_matcher("Read"));
+    }
+
+    #[test]
+    fn claude_settings_entry_uses_current_spec() {
+        let entry = claude_settings_entry(Path::new("/usr/local/.omamori/hooks/x.sh"));
+        assert_eq!(
+            entry.get("matcher").and_then(|v| v.as_str()),
+            Some("Bash"),
+            "matcher must be simple string"
+        );
+        assert!(
+            entry.pointer("/hooks/0/type").is_some(),
+            "must use nested hooks array with type field"
+        );
+        assert_eq!(
+            entry.get("x-omamori-version").and_then(|v| v.as_str()),
+            Some(env!("CARGO_PKG_VERSION")),
+            "must embed omamori version"
+        );
+    }
 }

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -365,7 +365,7 @@ fn check_cursor_snippet(path: &Path) -> CheckItem {
 ///
 /// Closes the "doctor 12/12 green but Layer 2 dormant" gap from #196:
 /// a green doctor report now guarantees Layer 2 is active.
-fn check_claude_settings_integration() -> CheckItem {
+fn check_claude_settings_integration(base_dir: &Path) -> CheckItem {
     let name = "claude-code-settings".to_string();
     let category = "Hooks";
 
@@ -408,25 +408,12 @@ fn check_claude_settings_integration() -> CheckItem {
         }
     };
 
-    let omamori_prefix = std::env::var_os("HOME")
-        .map(|h| PathBuf::from(h).join(".omamori").display().to_string())
-        .unwrap_or_default();
-
     let entry = doc
         .pointer("/hooks/PreToolUse")
         .and_then(|v| v.as_array())
         .and_then(|arr| {
-            arr.iter().find(|e| {
-                let cmd = e
-                    .pointer("/hooks/0/command")
-                    .and_then(|v| v.as_str())
-                    .or_else(|| e.get("command").and_then(|v| v.as_str()));
-                cmd.map(|c| {
-                    let unquoted = c.trim_matches('\'').trim_matches('"');
-                    !omamori_prefix.is_empty() && unquoted.contains(&omamori_prefix)
-                })
-                .unwrap_or(false)
-            })
+            arr.iter()
+                .find(|e| installer::entry_is_omamori_managed(e, base_dir))
         });
 
     let Some(entry) = entry else {
@@ -467,6 +454,29 @@ fn check_claude_settings_integration() -> CheckItem {
             detail: format!("(script path missing: {cmd_path})"),
             remediation: Some(Remediation::RunInstall),
         };
+    }
+
+    // Verify the script is executable. Without execute bit, the kernel
+    // refuses to run it and Layer 2 is silently inactive even though the
+    // sha256 may match. Hash-only check would give a false-positive green.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(script_path)
+            .map(|m| m.permissions().mode())
+            .unwrap_or(0);
+        if mode & 0o111 == 0 {
+            return CheckItem {
+                category,
+                name,
+                status: CheckStatus::Fail,
+                detail: format!(
+                    "(script not executable: mode {:o} — Layer 2 inactive)",
+                    mode & 0o777
+                ),
+                remediation: Some(Remediation::RegenerateHooks),
+            };
+        }
     }
 
     let actual = match fs::read_to_string(script_path) {
@@ -643,7 +653,7 @@ pub fn full_check(base_dir: &Path) -> IntegrityReport {
     });
 
     // claude-code-settings — verify ~/.claude/settings.json is wired up (#196)
-    items.push(check_claude_settings_integration());
+    items.push(check_claude_settings_integration(base_dir));
 
     // cursor-hooks.snippet.json — hash comparison + dangling path detection (#56, T8)
     let cursor_snippet = hooks_dir.join("cursor-hooks.snippet.json");
@@ -1464,7 +1474,7 @@ mod tests {
         let saved = std::env::var_os("HOME");
         unsafe { std::env::set_var("HOME", &dir) };
 
-        let item = check_claude_settings_integration();
+        let item = check_claude_settings_integration(&dir.join(".omamori"));
         assert_eq!(item.status, CheckStatus::Warn);
 
         match saved {
@@ -1503,11 +1513,67 @@ mod tests {
         let saved = std::env::var_os("HOME");
         unsafe { std::env::set_var("HOME", &dir) };
 
-        let item = check_claude_settings_integration();
+        let item = check_claude_settings_integration(&dir.join(".omamori"));
         assert_eq!(item.status, CheckStatus::Fail);
         assert!(
             item.detail.contains("matcher"),
             "detail should mention matcher: {}",
+            item.detail
+        );
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[cfg(unix)]
+    fn check_claude_settings_fails_on_non_executable_script() {
+        // P1-4 (Codex R1): if the script is not executable, hash match alone
+        // would falsely report green. Mode check must catch this.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("omamori-int-noexec-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        let omamori_hooks = dir.join(".omamori").join("hooks");
+        fs::create_dir_all(&omamori_hooks).unwrap();
+        let script = omamori_hooks.join("claude-pretooluse.sh");
+        fs::write(&script, installer::render_hook_script()).unwrap();
+        // Non-executable mode (0o600 — read+write only)
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o600)).unwrap();
+
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let current = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": omamori_cmd}],
+                    "x-omamori-version": env!("CARGO_PKG_VERSION")
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&current).unwrap(),
+        )
+        .unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let item = check_claude_settings_integration(&dir.join(".omamori"));
+        assert_eq!(
+            item.status,
+            CheckStatus::Fail,
+            "non-executable script must fail the integration check"
+        );
+        assert!(
+            item.detail.contains("not executable"),
+            "detail should mention executability: {}",
             item.detail
         );
 
@@ -1529,6 +1595,12 @@ mod tests {
         fs::create_dir_all(&omamori_hooks).unwrap();
         let script = omamori_hooks.join("claude-pretooluse.sh");
         fs::write(&script, installer::render_hook_script()).unwrap();
+        // P1-4: ok-state requires the script to be executable
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+        }
 
         let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
         let current = serde_json::json!({
@@ -1549,7 +1621,7 @@ mod tests {
         let saved = std::env::var_os("HOME");
         unsafe { std::env::set_var("HOME", &dir) };
 
-        let item = check_claude_settings_integration();
+        let item = check_claude_settings_integration(&dir.join(".omamori"));
         assert_eq!(item.status, CheckStatus::Ok, "details: {}", item.detail);
 
         match saved {

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -352,6 +352,156 @@ fn check_cursor_snippet(path: &Path) -> CheckItem {
     }
 }
 
+/// Verify that `~/.claude/settings.json` is wired up correctly (#196 Bonus).
+///
+/// Confirms:
+/// 1. settings.json exists and parses as JSON
+/// 2. `hooks.PreToolUse` contains an omamori-managed entry (`command` path
+///    inside `~/.omamori/`)
+/// 3. The matcher is current spec (`"Bash"` simple string), not legacy
+///    (`"*"` or boolean) which the current parser silently rejects
+/// 4. The command points at a real file whose sha256 matches the bundled
+///    hook script (T2 tampering detection)
+///
+/// Closes the "doctor 12/12 green but Layer 2 dormant" gap from #196:
+/// a green doctor report now guarantees Layer 2 is active.
+fn check_claude_settings_integration() -> CheckItem {
+    let name = "claude-code-settings".to_string();
+    let category = "Hooks";
+
+    let claude_dir = installer::claude_home_dir();
+    let settings_path = claude_dir.join("settings.json");
+
+    if !settings_path.exists() {
+        return CheckItem {
+            category,
+            name,
+            status: CheckStatus::Warn,
+            detail: "(no ~/.claude/settings.json — Claude Code not configured)".to_string(),
+            remediation: Some(Remediation::RunInstall),
+        };
+    }
+
+    let raw = match fs::read_to_string(&settings_path) {
+        Ok(c) => c,
+        Err(e) => {
+            return CheckItem {
+                category,
+                name,
+                status: CheckStatus::Warn,
+                detail: format!("(read error: {e})"),
+                remediation: Some(Remediation::RunInstall),
+            };
+        }
+    };
+
+    let doc: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            return CheckItem {
+                category,
+                name,
+                status: CheckStatus::Warn,
+                detail: format!("(JSON parse error: {e})"),
+                remediation: Some(Remediation::RunInstall),
+            };
+        }
+    };
+
+    let omamori_prefix = std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join(".omamori").display().to_string())
+        .unwrap_or_default();
+
+    let entry = doc
+        .pointer("/hooks/PreToolUse")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|e| {
+                let cmd = e
+                    .pointer("/hooks/0/command")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| e.get("command").and_then(|v| v.as_str()));
+                cmd.map(|c| {
+                    let unquoted = c.trim_matches('\'').trim_matches('"');
+                    !omamori_prefix.is_empty() && unquoted.contains(&omamori_prefix)
+                })
+                .unwrap_or(false)
+            })
+        });
+
+    let Some(entry) = entry else {
+        return CheckItem {
+            category,
+            name,
+            status: CheckStatus::Fail,
+            detail: "(omamori PreToolUse hook missing — Layer 2 not active)".to_string(),
+            remediation: Some(Remediation::RunInstall),
+        };
+    };
+
+    let matcher = entry.get("matcher").and_then(|m| m.as_str()).unwrap_or("");
+    if matcher != "Bash" {
+        return CheckItem {
+            category,
+            name,
+            status: CheckStatus::Fail,
+            detail: format!(
+                "(matcher = {matcher:?}, expected \"Bash\" — legacy form silently rejected)"
+            ),
+            remediation: Some(Remediation::RunInstall),
+        };
+    }
+
+    let cmd_str = entry
+        .pointer("/hooks/0/command")
+        .and_then(|v| v.as_str())
+        .or_else(|| entry.get("command").and_then(|v| v.as_str()))
+        .unwrap_or("");
+    let cmd_path = cmd_str.trim_matches('\'').trim_matches('"');
+    let script_path = Path::new(cmd_path);
+    if !script_path.exists() {
+        return CheckItem {
+            category,
+            name,
+            status: CheckStatus::Fail,
+            detail: format!("(script path missing: {cmd_path})"),
+            remediation: Some(Remediation::RunInstall),
+        };
+    }
+
+    let actual = match fs::read_to_string(script_path) {
+        Ok(c) => c,
+        Err(e) => {
+            return CheckItem {
+                category,
+                name,
+                status: CheckStatus::Warn,
+                detail: format!("(script read error: {e})"),
+                remediation: Some(Remediation::RegenerateHooks),
+            };
+        }
+    };
+    let expected_hash = installer::hook_content_hash(&installer::render_hook_script());
+    let actual_hash = installer::hook_content_hash(&actual);
+    if actual_hash != expected_hash {
+        return CheckItem {
+            category,
+            name,
+            status: CheckStatus::Fail,
+            detail: "(script content hash mismatch — possible tampering)".to_string(),
+            remediation: Some(Remediation::RegenerateHooks),
+        };
+    }
+
+    CheckItem {
+        category,
+        name,
+        status: CheckStatus::Ok,
+        detail: "(active — Layer 2 wired up)".to_string(),
+        remediation: None,
+    }
+}
+
 /// Compare a shim's resolved target against the baseline record.
 /// Returns `true` (match) when baseline is absent, entry is missing, or paths agree.
 fn shim_matches_baseline(
@@ -491,6 +641,9 @@ pub fn full_check(base_dir: &Path) -> IntegrityReport {
             remediation: Some(Remediation::RunInstall),
         }
     });
+
+    // claude-code-settings — verify ~/.claude/settings.json is wired up (#196)
+    items.push(check_claude_settings_integration());
 
     // cursor-hooks.snippet.json — hash comparison + dangling path detection (#56, T8)
     let cursor_snippet = hooks_dir.join("cursor-hooks.snippet.json");
@@ -1293,6 +1446,116 @@ mod tests {
             );
         }
 
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    // ---------------------------------------------------------------------
+    // check_claude_settings_integration tests (#196 Bonus)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    #[serial_test::serial]
+    fn check_claude_settings_warns_when_missing() {
+        let dir =
+            std::env::temp_dir().join(format!("omamori-int-no-claude-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let item = check_claude_settings_integration();
+        assert_eq!(item.status, CheckStatus::Warn);
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn check_claude_settings_fails_on_legacy_matcher() {
+        let dir = std::env::temp_dir().join(format!("omamori-int-legacy-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        let omamori_hooks = dir.join(".omamori").join("hooks");
+        fs::create_dir_all(&omamori_hooks).unwrap();
+        let script = omamori_hooks.join("claude-pretooluse.sh");
+        fs::write(&script, installer::render_hook_script()).unwrap();
+
+        let stale = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "*",
+                    "command": script.display().to_string()
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let item = check_claude_settings_integration();
+        assert_eq!(item.status, CheckStatus::Fail);
+        assert!(
+            item.detail.contains("matcher"),
+            "detail should mention matcher: {}",
+            item.detail
+        );
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn check_claude_settings_ok_when_wired_up() {
+        let dir = std::env::temp_dir().join(format!("omamori-int-ok-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        let omamori_hooks = dir.join(".omamori").join("hooks");
+        fs::create_dir_all(&omamori_hooks).unwrap();
+        let script = omamori_hooks.join("claude-pretooluse.sh");
+        fs::write(&script, installer::render_hook_script()).unwrap();
+
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let current = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": omamori_cmd}],
+                    "x-omamori-version": env!("CARGO_PKG_VERSION")
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&current).unwrap(),
+        )
+        .unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let item = check_claude_settings_integration();
+        assert_eq!(item.status, CheckStatus::Ok, "details: {}", item.detail);
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
         let _ = fs::remove_dir_all(dir);
     }
 }

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -413,7 +413,7 @@ fn check_claude_settings_integration(base_dir: &Path) -> CheckItem {
         .and_then(|v| v.as_array())
         .and_then(|arr| {
             arr.iter()
-                .find(|e| installer::entry_is_omamori_managed(e, base_dir))
+                .find(|e| installer::is_omamori_owned_entry(e, base_dir))
         });
 
     let Some(entry) = entry else {
@@ -1519,6 +1519,58 @@ mod tests {
             item.detail.contains("matcher"),
             "detail should mention matcher: {}",
             item.detail
+        );
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn check_claude_settings_fails_when_only_hybrid_entry_exists() {
+        // R2 regression (Codex Round 2): if the user has merged the omamori
+        // command into a hybrid entry (with sibling user hooks), there is no
+        // canonical omamori-owned entry. Doctor must report this as Fail
+        // ("Layer 2 not omamori-controlled"), not silently green by reading
+        // the user's sibling hook script.
+        let dir = std::env::temp_dir().join(format!("omamori-int-hybrid-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        let omamori_hooks = dir.join(".omamori").join("hooks");
+        fs::create_dir_all(&omamori_hooks).unwrap();
+        let script = omamori_hooks.join("claude-pretooluse.sh");
+        fs::write(&script, installer::render_hook_script()).unwrap();
+
+        let omamori_cmd = shell_words::quote(&script.display().to_string()).into_owned();
+        let hybrid_only = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "/usr/local/bin/userhook"},
+                        {"type": "command", "command": omamori_cmd}
+                    ]
+                }]
+            }
+        });
+        fs::write(
+            claude_dir.join("settings.json"),
+            serde_json::to_string_pretty(&hybrid_only).unwrap(),
+        )
+        .unwrap();
+
+        let saved = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        let item = check_claude_settings_integration(&dir.join(".omamori"));
+        assert_eq!(
+            item.status,
+            CheckStatus::Fail,
+            "hybrid-only state must be Fail (no canonical entry)"
         );
 
         match saved {


### PR DESCRIPTION
## Summary

Closes #196 — `omamori install --hooks` now writes the omamori PreToolUse
entry into the user's Claude Code settings file automatically (Path A).
The README's "applied automatically. No action needed." claim now holds true.
`omamori doctor` verifies the entry is wired up; the shim auto-syncs the
entry across brew upgrades.

## Changes

| File | Change |
|------|--------|
| `src/installer.rs` | new `merge_claude_settings` (5-outcome enum: Created / Merged / AlreadyPresent / MatcherMigrated / Skipped) mirroring `merge_codex_hooks`; new `atomic_write_with_mode` for SEC-3 explicit 0o600; snippet schema refreshed to current spec (matcher `"Bash"` simple, nested hooks array, `x-omamori-version` field) |
| `src/integrity.rs` | new `check_claude_settings_integration` — parses the settings file, verifies the omamori entry exists with current-spec matcher and a script whose sha256 matches the bundled hook. Closes the "doctor green but Layer 2 dormant" gap |
| `src/engine/shim.rs` | new `ensure_settings_current_for` — re-merges entry on stale `x-omamori-version` or legacy matcher. UX R3 brew-upgrade auto-sync |
| `src/cli/install.rs` | `[todo]` print replaced by 5-branch outcome match; skips when the Claude Code config dir is not a real directory |

## Test plan

- [x] `cargo build --all-targets` clean
- [x] `cargo test --lib` — 642 tests pass (19 new for V-001..V-013 + ADV-196 cases)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] CI all green
- [ ] Codex review Round 1 (exhaustive) + Round 2 (scoped)

## Security

- [x] SEC-1 parse error never overwrites (`merge_claude_skips_corrupted_json`)
- [x] SEC-2 symlink check first (`merge_claude_skips_symlink`)
- [x] SEC-3 atomic write 0o600 explicit (`merge_claude_writes_with_mode_0o600`)
- [x] SEC-5 path-based identification, omamori-managed entries only (Q2=c partial migrate)
- [x] SEC-6 idempotent: repeated install = 1 entry (`merge_claude_is_idempotent`)
- [x] SEC-7 audit append fail does not flip block decision (no audit changes in this PR)
- [x] SEC-8 detection_layer untouched (PR2 owned)
- [x] SEC-9 chain tamper test untouched (PR5 owned)
- [x] SEC-4 (5-form path coverage for the protected settings target) inherited from v0.9.6 `is_protected_file_path`. This PR adds tests verifying the existing coverage holds. No new path-protection code in this PR.

## Out of scope

- Hook partial-fire investigation (whether the merged snippet fires for all
  Bash patterns) — tracked separately.
- ACCEPTANCE_TEST.md wording fixes — tracked as #194, scoped to PR4.
- SEC-4 5-form coverage NEW implementation — already in v0.9.6.
