### PR TITLE
test+ci: v0.9.7 PR5 — close #187 (test-strengthening cluster)

### DIFF
--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -111,6 +111,25 @@ else
         echo "FAIL [invariant #6e]: $hi must not gate tests on target_os"
         hi_fail=1
     fi
+    # #6f (PR #187 item 3): pin existence of the floor test itself. PR4 (#146
+    # scope 4) introduced `corpus_includes_meta_pattern_coverage` to encode
+    # the "silent pattern drop must fail the suite" guarantee, but the floor
+    # function is itself subject to silent drop — a contributor who deletes
+    # the function body passes CI quietly. Pin the function name here so
+    # physical removal fails CI before reaching review.
+    if ! grep -qF 'fn corpus_includes_meta_pattern_coverage' "$hi"; then
+        echo "FAIL [invariant #6f]: PR #146 scope 4 floor test 'fn corpus_includes_meta_pattern_coverage' must be retained — it pins the silent-drop guarantee and is itself subject to silent drop"
+        hi_fail=1
+    fi
+    # #6g (PR #187 item 3): pin the global meta-pattern floor at >= 18.
+    # The exact range allows the head count to drift to 23 (PR #187 added
+    # 2 DI-9 entries for total 23) without re-flagging this invariant on
+    # every legitimate corpus growth. Floor below 18 means tactical drift
+    # has eaten the safety margin and this should fail CI.
+    if ! grep -qE 'meta_pattern_count >= *(18|19|20|21|22|23)' "$hi"; then
+        echo "FAIL [invariant #6g]: meta-pattern global floor 'meta_pattern_count >= 18..23' must be present"
+        hi_fail=1
+    fi
 fi
 if [ "$hi_fail" -eq 0 ]; then
     echo "#6 OK: hook integration suite has required structure"

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -130,6 +130,21 @@ else
         echo "FAIL [invariant #6g]: meta-pattern global floor 'meta_pattern_count >= 18..23' must be present"
         hi_fail=1
     fi
+    # #6h (PR #187 Codex R1 P1): pin the per-category floor map itself.
+    # #6f and #6g pin only the global floor; without #6h, a future commit
+    # could delete `META_PATTERN_CATEGORY_FLOORS` and its iteration, leaving
+    # the global ≥18 floor as the only guard. That re-opens the
+    # category-selective drop attack PR #187 item 1 was designed to close.
+    # Pin both the const declaration and the iteration site so neither half
+    # of the per-category guard can be silently removed.
+    if ! grep -qF 'const META_PATTERN_CATEGORY_FLOORS' "$hi"; then
+        echo "FAIL [invariant #6h]: PR #187 item 1 per-category floor map 'const META_PATTERN_CATEGORY_FLOORS' must be retained"
+        hi_fail=1
+    fi
+    if ! grep -qF 'for (prefix, floor) in META_PATTERN_CATEGORY_FLOORS' "$hi"; then
+        echo "FAIL [invariant #6h]: per-category floor iteration 'for (prefix, floor) in META_PATTERN_CATEGORY_FLOORS' must be retained"
+        hi_fail=1
+    fi
 fi
 if [ "$hi_fail" -eq 0 ]; then
     echo "#6 OK: hook integration suite has required structure"

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -705,6 +705,19 @@ mod tests {
              this is the reorder tamper signal"
         );
 
+        // End-to-end detector check (Codex Round 1 P0): the underlying signal
+        // is necessary but not sufficient — `verify_chain` is what the omamori
+        // CLI actually invokes to surface tamper, so a future regression in
+        // `verify_chain`'s prev_hash-linkage check would silently flip every
+        // chain_tamper_* test back to passing without detection. Pin both
+        // layers (raw signal + detector E2E).
+        let verify_result = verify::verify_chain(&verify_config(&dir))
+            .expect("verify_chain must run on a non-symlink test dir");
+        assert!(
+            verify_result.broken_at.is_some(),
+            "verify_chain must report broken_at = Some(_) after on-disk reorder; got None"
+        );
+
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -750,6 +763,16 @@ mod tests {
             events[0]["entry_hash"].as_str().unwrap(),
             "after middle-deletion, prev_hash points to a vanished hash — \
              this is the deletion tamper signal"
+        );
+
+        // End-to-end detector check (Codex Round 1 P0): see
+        // `chain_tamper_reorder_detected` for the rationale on pinning
+        // `verify_chain` in addition to the raw on-disk signal.
+        let verify_result = verify::verify_chain(&verify_config(&dir))
+            .expect("verify_chain must run on a non-symlink test dir");
+        assert!(
+            verify_result.broken_at.is_some(),
+            "verify_chain must report broken_at = Some(_) after middle-deletion; got None"
         );
 
         let _ = fs::remove_dir_all(&dir);
@@ -808,6 +831,16 @@ mod tests {
             recomputed_seq0, GOLDEN_ENTRY_HASHES[0],
             "recomputed entry_hash over tampered (prev_hash-rewritten) genesis payload \
              diverges from golden — this is the genesis-rewrite tamper signal"
+        );
+
+        // End-to-end detector check (Codex Round 1 P0): see
+        // `chain_tamper_reorder_detected` for the rationale on pinning
+        // `verify_chain` in addition to the raw on-disk signal.
+        let verify_result = verify::verify_chain(&verify_config(&dir))
+            .expect("verify_chain must run on a non-symlink test dir");
+        assert!(
+            verify_result.broken_at.is_some(),
+            "verify_chain must report broken_at = Some(_) after genesis-rewrite; got None"
         );
 
         let _ = fs::remove_dir_all(&dir);

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -654,6 +654,165 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
+    /// PR #187 item 4 / PR #186 proxy R4 P3-5 deferred.
+    ///
+    /// Tamper class: physical reorder of two adjacent on-disk events. Each
+    /// event still carries its original (unchanged) entry_hash, but the
+    /// hash-chain linkage between adjacent on-disk entries breaks because
+    /// each `prev_hash` references the predecessor of its *original*
+    /// position, not the predecessor at its new physical position.
+    #[test]
+    fn chain_tamper_reorder_detected() {
+        let dir = test_dir("chain-tamper-reorder");
+        let logger = test_logger(&dir);
+
+        for i in 0..3 {
+            logger.append(make_event(&format!("cmd{i}"))).unwrap();
+        }
+
+        let content = fs::read_to_string(&logger.path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3);
+        // Swap on-disk positions of seq=1 and seq=2 lines.
+        let reordered = format!("{}\n{}\n{}\n", lines[0], lines[2], lines[1]);
+        fs::write(&logger.path, reordered).unwrap();
+
+        let events = read_events(&logger.path);
+        assert_eq!(events.len(), 3);
+
+        // After reorder:
+        //   on-disk position 0 = original seq=0 (entry_hash = GOLDEN[0])
+        //   on-disk position 1 = original seq=2 (entry_hash = GOLDEN[2])
+        //   on-disk position 2 = original seq=1 (entry_hash = GOLDEN[1])
+        // Detection: position-1's recorded prev_hash references GOLDEN[1]
+        // (its original predecessor seq=1's hash), but its on-disk
+        // predecessor is position-0 whose entry_hash is GOLDEN[0]. The
+        // adjacent-pair linkage breaks.
+        assert_eq!(
+            events[1]["entry_hash"].as_str().unwrap(),
+            GOLDEN_ENTRY_HASHES[2],
+            "reordered position 1 carries original seq=2's entry_hash (unchanged by reorder)"
+        );
+        assert_eq!(
+            events[1]["prev_hash"].as_str().unwrap(),
+            GOLDEN_ENTRY_HASHES[1],
+            "position 1's prev_hash still references its original predecessor (seq=1)"
+        );
+        assert_ne!(
+            events[1]["prev_hash"].as_str().unwrap(),
+            events[0]["entry_hash"].as_str().unwrap(),
+            "after reorder, prev_hash linkage between adjacent on-disk entries breaks — \
+             this is the reorder tamper signal"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// PR #187 item 4 / PR #186 proxy R4 P3-5 deferred.
+    ///
+    /// Tamper class: physical deletion of a middle event (seq=1). After
+    /// deletion, the surviving seq=2 entry sits at on-disk position 1
+    /// but its `prev_hash` still references the deleted seq=1's hash.
+    /// The on-disk predecessor (seq=0) carries a different entry_hash,
+    /// so the chain breaks at the deletion point.
+    #[test]
+    fn chain_tamper_middle_deletion_detected() {
+        let dir = test_dir("chain-tamper-middle-deletion");
+        let logger = test_logger(&dir);
+
+        for i in 0..3 {
+            logger.append(make_event(&format!("cmd{i}"))).unwrap();
+        }
+
+        let content = fs::read_to_string(&logger.path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3);
+        // Drop the middle line (original seq=1).
+        let truncated = format!("{}\n{}\n", lines[0], lines[2]);
+        fs::write(&logger.path, truncated).unwrap();
+
+        let events = read_events(&logger.path);
+        assert_eq!(events.len(), 2);
+
+        // Surviving on-disk position 1 = original seq=2.
+        assert_eq!(
+            events[1]["entry_hash"].as_str().unwrap(),
+            GOLDEN_ENTRY_HASHES[2],
+            "surviving position 1 carries original seq=2's entry_hash"
+        );
+        assert_eq!(
+            events[1]["prev_hash"].as_str().unwrap(),
+            GOLDEN_ENTRY_HASHES[1],
+            "surviving position 1 still references the deleted seq=1's hash"
+        );
+        assert_ne!(
+            events[1]["prev_hash"].as_str().unwrap(),
+            events[0]["entry_hash"].as_str().unwrap(),
+            "after middle-deletion, prev_hash points to a vanished hash — \
+             this is the deletion tamper signal"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// PR #187 item 4 / PR #186 proxy R4 P3-5 deferred.
+    ///
+    /// Tamper class: overwrite `prev_hash` on the genesis event (seq=0).
+    /// Without the HMAC secret an attacker cannot forge a valid prev_hash
+    /// — genesis is HMAC(secret, "omamori-genesis-v1"). Any overwrite
+    /// produces a value != GOLDEN_GENESIS. The recorded entry_hash on
+    /// seq=0 stays at GOLDEN[0] (attacker only flipped prev_hash bytes),
+    /// but recomputing the entry_hash over the post-tamper payload now
+    /// diverges from GOLDEN[0]. Both signals fire.
+    #[test]
+    fn chain_tamper_genesis_rewrite_detected() {
+        let dir = test_dir("chain-tamper-genesis-rewrite");
+        let logger = test_logger(&dir);
+
+        for i in 0..3 {
+            logger.append(make_event(&format!("cmd{i}"))).unwrap();
+        }
+
+        let forged = "0000000000000000000000000000000000000000000000000000000000000000";
+        let content = fs::read_to_string(&logger.path).unwrap();
+        let tampered = content.replacen(GOLDEN_GENESIS, forged, 1);
+        fs::write(&logger.path, tampered).unwrap();
+
+        let events = read_events(&logger.path);
+        assert_eq!(events.len(), 3);
+
+        // Signal 1: genesis prev_hash diverges from golden.
+        assert_ne!(
+            events[0]["prev_hash"].as_str().unwrap(),
+            GOLDEN_GENESIS,
+            "genesis-rewrite must surface as prev_hash divergence from golden genesis"
+        );
+        assert_eq!(
+            events[0]["prev_hash"].as_str().unwrap(),
+            forged,
+            "tampered prev_hash value is observable as the rewritten content"
+        );
+
+        // Signal 2: recorded entry_hash stays at golden (only prev_hash bytes
+        // were touched), but recomputing entry_hash over the post-tamper
+        // payload diverges from golden — same end-to-end signal as
+        // chain_tamper_detected above, applied to the genesis event.
+        assert_eq!(
+            events[0]["entry_hash"].as_str().unwrap(),
+            GOLDEN_ENTRY_HASHES[0],
+            "attacker only flipped prev_hash bytes; entry_hash byte sequence unchanged"
+        );
+        let parsed_seq0: AuditEvent = serde_json::from_value(events[0].clone()).unwrap();
+        let recomputed_seq0 = compute_entry_hash(Some(&TEST_SECRET), &parsed_seq0);
+        assert_ne!(
+            recomputed_seq0, GOLDEN_ENTRY_HASHES[0],
+            "recomputed entry_hash over tampered (prev_hash-rewritten) genesis payload \
+             diverges from golden — this is the genesis-rewrite tamper signal"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
     // --- create_event ---
 
     #[test]

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -504,7 +504,9 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
     ),
     // 15b-DI9. DI-9 behavioral pins for `omamori doctor --fix` and
     //          `omamori explain` `blocked_string_patterns()` entries
-    //          (declared at `src/installer.rs:425-432`). Inherited gap
+    //          (declared inside `blocked_string_patterns()` in
+    //          `src/installer.rs`; line numbers omitted because they drift).
+    //          Inherited gap
     //          from the deleted `meta_patterns_cover_config_modification`
     //          unit test — neither PR4 nor the rest of HOOK_DECISION_CASES
     //          carried behavioral coverage for these two patterns. PR4's

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -502,6 +502,25 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Block,
         "meta-pattern-override-block",
     ),
+    // 15b-DI9. DI-9 behavioral pins for `omamori doctor --fix` and
+    //          `omamori explain` `blocked_string_patterns()` entries
+    //          (declared at `src/installer.rs:425-432`). Inherited gap
+    //          from the deleted `meta_patterns_cover_config_modification`
+    //          unit test — neither PR4 nor the rest of HOOK_DECISION_CASES
+    //          carried behavioral coverage for these two patterns. PR4's
+    //          thesis applies universally: every `blocked_string_patterns()`
+    //          entry should have at least one behavioral fixture somewhere.
+    //          PR #187 item 2 / PR #186 R5 P3 B3.
+    (
+        "omamori doctor --fix",
+        Decision::Block,
+        "meta-pattern-doctor-fix-block",
+    ),
+    (
+        "omamori explain some-rule",
+        Decision::Block,
+        "meta-pattern-explain-block",
+    ),
     // 15c. Codex CLI hook / config protection (#66 T2/T3).
     (
         "echo payload > ~/.codex/hooks.json",
@@ -571,6 +590,32 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
     ),
 ];
 
+/// Per-category minimum floors for `meta-pattern-*` HOOK_DECISION_CASES
+/// entries. Catches category-selective drop that the global ≥18 floor in
+/// `corpus_includes_meta_pattern_coverage` misses (e.g. deleting all 8
+/// `15a` rm boundary fixtures and adding 8 new fixtures elsewhere keeps
+/// the total ≥ 18 but silently drops rm coverage). Sum is 23 — the full
+/// HEAD count including the PR #187 DI-9 additions.
+///
+/// Each prefix anchors with a trailing `-` to prevent accidental
+/// sub-prefix matching: `meta-pattern-bin-rm-` does NOT match
+/// `meta-pattern-bin-rmdir-` because the next char after `rm` is `-` vs
+/// `d`. PR #187 item 1 / PR #186 R5 P3 B2.
+const META_PATTERN_CATEGORY_FLOORS: &[(&str, usize)] = &[
+    ("meta-pattern-bin-rm-", 4),        // 15a (bin side, 4 boundary types)
+    ("meta-pattern-usr-bin-rm-", 4),    // 15a (usr/bin side, 4 boundary types)
+    ("meta-pattern-config-", 2),        // 15b (config disable / enable)
+    ("meta-pattern-init-force-", 1),    // 15b
+    ("meta-pattern-uninstall-", 1),     // 15b
+    ("meta-pattern-override-", 1),      // 15b
+    ("meta-pattern-doctor-fix-", 1),    // 15b-DI9 (PR #187 item 2)
+    ("meta-pattern-explain-", 1),       // 15b-DI9 (PR #187 item 2)
+    ("meta-pattern-codex-", 5),         // 15c (4 keywords) + 15c-iso standalone
+    ("meta-pattern-rmdir-", 1),         // 15d FP guard
+    ("meta-pattern-bin-rmdir-", 1),     // 15d FP guard
+    ("meta-pattern-usr-bin-rmdir-", 1), // 15d FP guard
+];
+
 /// Cross-OS invariant: the same bash input must yield the same Decision on
 /// every supported OS. Runs the entire corpus in one temp env to keep install
 /// cost at one-per-test.
@@ -627,18 +672,36 @@ fn corpus_includes_meta_pattern_coverage() {
     //   - codex_protection:   4 original keywords                   = 4 fixtures
     //                         + 1 isolation fixture for codex_hooks = 5 fixtures
     //   - do_not_false_positive_on_rmdir: bare + 2 direct paths     = 3 fixtures
-    // → 8 + 5 + 5 + 3 = 21 behavioral fixtures in HEAD (4 of 5 categories
-    // map 1:1 from the deleted unit tests; codex_protection gained +1 from
-    // the R4 isolation requirement). Floor set to 18 to allow minor tactical
-    // reshuffles (up to 3-fixture drift) without drift, while still catching
-    // an accidental category-level deletion. PR #186 R5 proxy corrected the
-    // prior 20/18 arithmetic to 21/18.
+    // → 8 + 5 + 5 + 3 = 21 behavioral fixtures from PR #146 scope 4.
+    // PR #187 item 2 added 2 DI-9 fixtures (doctor --fix, explain) for a
+    // HEAD total of 23. Floor stays at 18 to allow tactical drift while
+    // still catching wholesale category-level deletion. Per-category
+    // selective drop (e.g. deleting all 15a rm-boundary fixtures and
+    // adding 8 unrelated new ones) is caught by `META_PATTERN_CATEGORY_FLOORS`
+    // below. PR #186 R5 proxy corrected the prior 20/18 arithmetic.
     assert!(
         meta_pattern_count >= 18,
         "meta-pattern corpus (#146 scope 4) must have ≥18 entries; got {meta_pattern_count}. \
          If you are intentionally removing entries, verify the attack/FP surfaces still \
          have isolated behavioral coverage and update this floor."
     );
+
+    // Per-category floor map: catches category-selective drop that the
+    // global ≥18 floor would miss (the same total can be hit by deleting
+    // an entire category and replacing it with unrelated new fixtures).
+    // PR #187 item 1 / PR #186 R5 P3 B2.
+    for (prefix, floor) in META_PATTERN_CATEGORY_FLOORS {
+        let count = HOOK_DECISION_CASES
+            .iter()
+            .filter(|(_, _, cat)| cat.starts_with(prefix))
+            .count();
+        assert!(
+            count >= *floor,
+            "meta-pattern category '{prefix}*' must have ≥{floor} entries; got {count}. \
+             Category-selective deletion would silently drop this surface coverage even \
+             when the global ≥18 floor still passes."
+        );
+    }
 }
 
 /// Pin the Block exit code contract at exactly 2. The `cross_os_invariant`


### PR DESCRIPTION
## Summary

Closes #187. Test-strengthening cluster — four P3 findings deferred from PR #186 (PR4 of v0.9.6) review. None are bugs; all four extend the meta-level "silent drop must fail the suite" thesis that PR #186 established.

## PR thesis

> v0.9.7 PR5 strengthens test-suite guarantees without touching runtime behaviour. Four items: (1) per-category floor map catches category-selective drop that the global ≥18 floor misses; (2) DI-9 behavioral pins close inherited gap (`omamori doctor --fix` / `omamori explain` had no behavioral fixture); (3) `scripts/check-invariants.sh` `#6f` / `#6g` / `#6h` pin the floor test, the floor range, AND the per-category guard itself against silent removal; (4) three additional chain tamper class tests (reorder / middle-deletion / genesis-rewrite) all pinned against the same `GOLDEN_ENTRY_HASHES` / `GOLDEN_GENESIS` golden vectors, plus end-to-end `verify_chain` detector pin.

## Changes

| Item | Surface | Change |
|------|---------|--------|
| 1 | `tests/hook_integration.rs` | New `META_PATTERN_CATEGORY_FLOORS` const (12 prefixes / sum 23). `corpus_includes_meta_pattern_coverage` iterates the floor map after the global ≥18 assert. Each prefix anchors with trailing `-` to prevent sub-prefix collision. Defense-in-depth: global allows tactical drift, per-category catches selective drop. |
| 2 | `tests/hook_integration.rs` | Two `HOOK_DECISION_CASES` entries (`omamori doctor --fix` / `omamori explain some-rule`) inserted in new `15b-DI9` sub-section. These are the only `blocked_string_patterns()` entries lacking behavioral coverage; PR4's thesis applies universally. |
| 3 | `scripts/check-invariants.sh` | Three new sub-invariants inside `#6` aggregate: `#6f` (greps `fn corpus_includes_meta_pattern_coverage` against silent removal), `#6g` (greps `meta_pattern_count >= (18..23)` for floor range), `#6h` (Round 1 P1: pins `const META_PATTERN_CATEGORY_FLOORS` + `for (prefix, floor) in META_PATTERN_CATEGORY_FLOORS` so the per-category guard itself cannot be silently removed). |
| 4 | `src/audit/mod.rs` | Three new tests: `chain_tamper_reorder_detected`, `chain_tamper_middle_deletion_detected`, `chain_tamper_genesis_rewrite_detected`. Each pins the raw on-disk signal (golden hash divergence) AND calls `verify::verify_chain(&verify_config(&dir))` asserting `broken_at.is_some()` — Round 1 P0 fix to pin both the underlying signal AND the actual detector path the omamori CLI uses. |

## Out of scope

Per the v0.9.7 plan (`~/.claude/plans/foamy-squishing-map.md`):

- **#176 ObfuscatedExpansion** — security feature, separate scope
- **env detector layer rebuild** — structural; out of v0.9.7
- **#177 / #175** — semver-breaking, reserved for v0.10.0
- **PR6 (release prep doc cluster — added 2026-04-29)** — CHANGELOG + Cargo.toml v0.9.6→v0.9.7 + README/SECURITY.md final sweep, lands as the next PR

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo test --locked --quiet` — **802 passed / 0 failed / 1 ignored** (PR4 baseline 802 + 3 new chain tamper tests, but 3 of the 5 lib-test-result lines aggregate so the lib total is 658 = 655 + 3)
- [x] `cargo test --locked --quiet chain_tamper` — 4 passed (1 existing + 3 new, each with verify_chain end-to-end assertion)
- [x] `cargo test --locked --quiet corpus_includes_meta_pattern` — 1 passed (per-category iteration green over 12 prefixes)
- [x] `cargo clippy --locked --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-invariants.sh` — `#6 OK` aggregate (#6a-#6h all green; new #6f/#6g/#6h silent on success per existing #6 pattern)

## Codex review

| Round | Verdict | Findings | Disposition |
|-------|---------|----------|-------------|
| **Round 1** | Block | 3 (1 P0 + 1 P1 + 1 P2) | All Bug-fact after independent file:line verify (zero vacuous). Combined Phase 6-A code review + Phase 6-B test adversarial review in a single round (test-only PR, axes overlap heavily). Fixes applied in `0264dbd`. |
| **Round 2** | **Approve** | 3/3 verified ✅, 0 regressions, 0 issue proposals | Natural stop per `/develop` Phase 6-A Step 4 (R3 approve = stop, R2 approve is even better — same as PR4). |

Round 1 finding summary:

- **F1 (P0)** — three new `chain_tamper_*` tests pinned the underlying on-disk signal but never invoked `verify_chain`, the actual detector. False-confidence risk: a future regression in `verify_chain`'s prev_hash linkage check would silently flip these tests to passing. Fix: each test now also calls `verify::verify_chain(&verify_config(&dir))` and asserts `broken_at.is_some()`. Both layers pinned.
- **F2 (P1)** — `#6f` / `#6g` pinned only the global floor (function existence + numeric range). `META_PATTERN_CATEGORY_FLOORS` const + iteration (the actual per-category guard introduced in item 1) was not pinned. Fix: added `#6h` with two sub-checks (const + iteration site).
- **F3 (P2)** — DI-9 comment cited `src/installer.rs:425-432`, but actual line is 469 (`fn blocked_string_patterns`). Comment was copied verbatim from issue #187 body where the line numbers had drifted. Fix: replaced literal range with function-name reference + explicit "line numbers omitted because they drift" note.

## Operational note

Several Bash commands during this PR's authoring hit the omamori Layer 2 meta-pattern false-positive documented in PR #207's SECURITY.md "Known Operational Caveats" section — specifically, `grep -n '"omamori doctor --fix"|"omamori explain"' src/installer.rs` was DI-9-blocked because the search pattern itself contains the trigger strings. Workaround per the Caveats section: split contiguous strings or grep on adjacent function names. Live confirmation that the documented workarounds work in practice; no change to the protection.

## Commits (4)

| # | SHA | Type | Summary |
|---|-----|------|---------|
| 1 | `bbed759` | test(hook) | per-category floor map + DI-9 behavioral pins (items 1+2) |
| 2 | `0b29aca` | ci(invariants) | #6f / #6g floor existence + range (item 3 — partial; #6h added in commit 4) |
| 3 | `391742a` | test(audit) | 3 chain tamper class tests (item 4 — Round 1 added verify_chain assertions to all 3 in commit 4) |
| 4 | `0264dbd` | test+ci(round1) | Codex Round 1 corrections (F1 verify_chain, F2 #6h, F3 comment line refs) |

## Plan reference

- Plan file: `~/.claude/plans/foamy-squishing-map.md`
- Phase status: PR1 ✅ / PR2 ✅ / PR3 ✅ / PR4 ✅ / **PR5 (this) ready for review** / PR6 (release prep, runtime-added) next.
- Plan rule "test-strengthening cluster, last-land for minimal test conflict with other PRs" — observed; no test conflicts with merged PR1-PR4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
