### PR TITLE
docs(release): v0.9.7 final prep — date alignment + #210 caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
-## [0.9.7] - 2026-04-29
+## [0.9.7] - 2026-04-30
 
 **Summary**: HMAC tamper-evident audit chain moat completion + `install --hooks` automation. Three structural closures tightened against silent gaps the v0.9.6 ship surfaced: (1) Layer 2 hook deny verdicts (`BlockMeta` / `BlockRule` / `BlockStructural`) now append to the HMAC audit chain — the marketed tamper-evident moat covered Layer 1 (PATH shim) end-to-end but had a structural gap at Layer 2 ([#181](https://github.com/yottayoshida/omamori/issues/181)); (2) `omamori install --hooks` automatically merges into `~/.claude/settings.json` instead of printing a `[todo]` snippet, with omamori-managed legacy-matcher entries auto-migrated and user-managed entries preserved verbatim ([#196](https://github.com/yottayoshida/omamori/issues/196)); (3) `omamori doctor` parses settings.json and verifies the omamori-managed entry's matcher syntax + script_path SHA-256, so doctor green now structurally implies Layer 2 active. Plus shim auto-sync extension (`ensure_settings_current()` parallels `ensure_hooks_current()`) so brew upgrade does not leave stale config behind, doc / test polish (#190, #194, #187), and a new SECURITY.md `## Known Operational Caveats` section documenting the meta-pattern false-positive surface that omamori's own development surfaces (commit messages, grep arguments, AI-review prompts that quote protected paths).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -628,6 +628,28 @@ These blocks are correct under the v0.9.7 design: the meta-pattern cannot tell *
 
 This is a known trade-off, not a bug. Loosening the meta-pattern toward syntactic precision (e.g. tokenizing every Bash command before substring matching) would weaken the protection against obfuscated access to `audit-secret` / `.integrity.json` and is therefore not on the roadmap. The trade-off is documented here so operators reading omamori's own commit history understand that an occasional false-positive block during development is *evidence the layer is working*, not a regression to investigate.
 
+### Test-suite pollution of contributor `~/.claude/settings.json` (v0.9.7)
+
+Running `cargo test` against omamori's own test suite on a machine that has Claude Code installed (i.e. a real `~/.claude/` directory exists) can leave dead entries in `~/.claude/settings.json` under `hooks.PreToolUse`. Affected entries point at temporary install paths under `$TMPDIR/omamori-install-*/hooks/claude-pretooluse.sh` that no longer exist after the test run cleans up. Bash tool invocations in Claude Code subsequently emit non-blocking errors per dead entry on every command. Filed as [#210](https://github.com/yottayoshida/omamori/issues/210) (closed not planned).
+
+**Scope**: contributors only. Production install paths (`brew install omamori`, `cargo install omamori`, manual `omamori install --hooks`) all use the canonical `base_dir = ~/.omamori`, so registered command paths are permanent across runs and dedup works correctly. The accumulation is gated behind running `cargo test` on a machine with a real `~/.claude/` directory.
+
+**Cause** (for contributors who want to understand the mechanism): seven test sites invoke `omamori install --hooks --base-dir /tmp/...` (six as a subprocess, one in-process) without overriding `HOME`. The child process's `merge_claude_settings` resolves `claude_home_dir()` from the developer's real `$HOME` and writes the test-only base_dir path into the developer's real `~/.claude/settings.json`. After test cleanup removes the base_dir, the entry's `command` path becomes a broken reference. Each test run adds another entry because the dedup logic in `is_omamori_owned_entry` keys on the current install_root and cannot recognize prior runs' base_dirs as owned.
+
+**Manual cleanup** (sufficient for current contributor population — the maintainer):
+
+```bash
+cp ~/.claude/settings.json ~/.claude/settings.json.bak.$(date +%Y%m%d_%H%M%S)
+jq '.hooks.PreToolUse |= map(select(.hooks[0].command | test("omamori-install-") | not))' \
+  ~/.claude/settings.json > /tmp/settings.cleaned.json && \
+  jq . /tmp/settings.cleaned.json > /dev/null && \
+  mv /tmp/settings.cleaned.json ~/.claude/settings.json
+```
+
+This filter assumes the live entry's command path does not contain `omamori-install-` (i.e. is `~/.omamori/hooks/...` or similar canonical path).
+
+**Why no automatic fix**: a full automated cleanup would require ~500 lines (test HOME isolation across 7 sites + dedup logic strengthening + warning UX + CI lint to prevent regression) for an issue with zero impact on production users and a one-line manual cleanup for contributors. The cost/value did not justify implementation in v0.9.7. If the contributor population grows or a related issue surfaces (e.g. [#206](https://github.com/yottayoshida/omamori/issues/206) OpenClaw hook coexistence touches the same identification logic), this can be reopened. See [#210 close comment](https://github.com/yottayoshida/omamori/issues/210#issuecomment-4350136214) for the full investigation log.
+
 ## AI-assisted Contribution Invariants (v0.9.3+)
 
 omamori is developed with AI coding assistants (Claude Code / Codex). That


### PR DESCRIPTION
## Summary

Release-eve documentation alignment for v0.9.7. Two small changes:

1. CHANGELOG `[0.9.7]` date 2026-04-29 → 2026-04-30 to match the actual tag day. PR6 (#209) wrote 2026-04-29 anticipating same-day release; the release ceremony slid one day.

2. SECURITY.md "Known Operational Caveats" gains a new subsection: **Test-suite pollution of contributor `~/.claude/<config>` (v0.9.7)** — documents [#210](https://github.com/yottayoshida/omamori/issues/210) (closed not planned). Covers scope (contributors only, zero production user impact), cause (7 test sites invoke install without HOME override), manual cleanup (one `jq` invocation), and the cost/value rationale for not automating the fix in v0.9.7. Cross-links the [#210 close comment](https://github.com/yottayoshida/omamori/issues/210#issuecomment-4350136214) and [#206](https://github.com/yottayoshida/omamori/issues/206) (OpenClaw hook coexistence) as the trigger that would justify reopening.

## Test plan

- [x] CHANGELOG and SECURITY.md render correctly in GitHub preview
- [x] No code or test changes — CI smoke run only
- [ ] CI green
- [ ] Squash-merge after CI

After merge: v0.9.7 release ceremony (tag, GitHub release, cargo publish, brew tap PR).
