### PR TITLE
feat(doctor): restructure display as 4-section trust dashboard (#220)

### DIFF
--- a/src/cli/checks_display.rs
+++ b/src/cli/checks_display.rs
@@ -131,7 +131,11 @@ mod tests {
         let groups = group_by_section(&items);
         assert!(groups[0].1.is_empty(), "Layer1 should be empty");
         assert!(groups[1].1.is_empty(), "Layer2 should be empty");
-        assert_eq!(groups[2].1.len(), 2, "both unknowns should land in Integrity");
+        assert_eq!(
+            groups[2].1.len(),
+            2,
+            "both unknowns should land in Integrity"
+        );
     }
 
     #[test]

--- a/src/cli/checks_display.rs
+++ b/src/cli/checks_display.rs
@@ -1,0 +1,116 @@
+//! Shared display utilities for doctor/status check output.
+//!
+//! Maps integrity `CheckItem.category` strings to doctor's 4-section model.
+//! Status retains its own legacy formatter (v0.10.0 compat).
+
+use crate::integrity::CheckItem;
+
+/// Doctor's 4-section model (Layer 1 / Layer 2 / Integrity / Risk signals).
+/// Risk signals come from `audit::report`, not from integrity checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DoctorSection {
+    Layer1,
+    Layer2,
+    Integrity,
+}
+
+impl DoctorSection {
+    pub fn heading(self) -> &'static str {
+        match self {
+            Self::Layer1 => "[Layer 1] PATH shims",
+            Self::Layer2 => "[Layer 2] Hook defense",
+            Self::Integrity => "[Integrity] Config & baseline",
+        }
+    }
+}
+
+/// Deterministic mapping from CheckItem.category to DoctorSection.
+///
+/// Categories are fixed strings from integrity.rs:
+/// Shims, Hooks, Config, Core Policy, PATH, Baseline
+pub fn map_category_to_section(category: &str) -> DoctorSection {
+    match category {
+        "Shims" | "PATH" => DoctorSection::Layer1,
+        "Hooks" => DoctorSection::Layer2,
+        "Config" | "Core Policy" | "Baseline" => DoctorSection::Integrity,
+        _ => DoctorSection::Integrity,
+    }
+}
+
+/// Group CheckItems by DoctorSection, preserving order within each group.
+pub fn group_by_section(items: &[CheckItem]) -> [(DoctorSection, Vec<&CheckItem>); 3] {
+    let mut layer1 = Vec::new();
+    let mut layer2 = Vec::new();
+    let mut integrity = Vec::new();
+
+    for item in items {
+        match map_category_to_section(item.category) {
+            DoctorSection::Layer1 => layer1.push(item),
+            DoctorSection::Layer2 => layer2.push(item),
+            DoctorSection::Integrity => integrity.push(item),
+        }
+    }
+
+    [
+        (DoctorSection::Layer1, layer1),
+        (DoctorSection::Layer2, layer2),
+        (DoctorSection::Integrity, integrity),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integrity::{CheckItem, CheckStatus};
+
+    #[test]
+    fn test_category_mapping() {
+        assert_eq!(map_category_to_section("Shims"), DoctorSection::Layer1);
+        assert_eq!(map_category_to_section("PATH"), DoctorSection::Layer1);
+        assert_eq!(map_category_to_section("Hooks"), DoctorSection::Layer2);
+        assert_eq!(map_category_to_section("Config"), DoctorSection::Integrity);
+        assert_eq!(
+            map_category_to_section("Core Policy"),
+            DoctorSection::Integrity
+        );
+        assert_eq!(
+            map_category_to_section("Baseline"),
+            DoctorSection::Integrity
+        );
+        assert_eq!(map_category_to_section("Unknown"), DoctorSection::Integrity);
+    }
+
+    #[test]
+    fn test_group_by_section() {
+        let items = vec![
+            CheckItem {
+                category: "Shims",
+                name: "rm".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+            CheckItem {
+                category: "Hooks",
+                name: "hook1".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+            CheckItem {
+                category: "Config",
+                name: "cfg".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+        ];
+        let groups = group_by_section(&items);
+        assert_eq!(groups[0].0, DoctorSection::Layer1);
+        assert_eq!(groups[0].1.len(), 1);
+        assert_eq!(groups[1].0, DoctorSection::Layer2);
+        assert_eq!(groups[1].1.len(), 1);
+        assert_eq!(groups[2].0, DoctorSection::Integrity);
+        assert_eq!(groups[2].1.len(), 1);
+    }
+}

--- a/src/cli/checks_display.rs
+++ b/src/cli/checks_display.rs
@@ -81,6 +81,60 @@ mod tests {
     }
 
     #[test]
+    fn test_group_by_section_preserves_order() {
+        let items = vec![
+            CheckItem {
+                category: "Shims",
+                name: "cp".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+            CheckItem {
+                category: "Shims",
+                name: "rm".to_string(),
+                status: CheckStatus::Fail,
+                detail: "missing".to_string(),
+                remediation: None,
+            },
+            CheckItem {
+                category: "Shims",
+                name: "mv".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+        ];
+        let groups = group_by_section(&items);
+        let names: Vec<&str> = groups[0].1.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(names, vec!["cp", "rm", "mv"]);
+    }
+
+    #[test]
+    fn test_unknown_categories_land_in_integrity() {
+        let items = vec![
+            CheckItem {
+                category: "FutureCategory",
+                name: "a".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+            CheckItem {
+                category: "",
+                name: "b".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+        ];
+        let groups = group_by_section(&items);
+        assert!(groups[0].1.is_empty(), "Layer1 should be empty");
+        assert!(groups[1].1.is_empty(), "Layer2 should be empty");
+        assert_eq!(groups[2].1.len(), 2, "both unknowns should land in Integrity");
+    }
+
+    #[test]
     fn test_group_by_section() {
         let items = vec![
             CheckItem {

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -809,6 +809,53 @@ mod tests {
     }
 
     #[test]
+    fn json_summary_protection_status_warn_only() {
+        let items = vec![CheckItem {
+            category: "PATH",
+            name: "shim order".to_string(),
+            status: CheckStatus::Warn,
+            detail: "after /usr/bin".to_string(),
+            remediation: Some(Remediation::ManualOnly("fix PATH".to_string())),
+        }];
+        let output = build_json_output(&items, false);
+        assert_eq!(output["summary"]["protection_status"], "warn");
+    }
+
+    #[test]
+    fn json_summary_protection_status_all_ok() {
+        let items = vec![
+            CheckItem {
+                category: "Shims",
+                name: "rm".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+            CheckItem {
+                category: "Hooks",
+                name: "hook".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+        ];
+        let output = build_json_output(&items, false);
+        assert_eq!(output["summary"]["protection_status"], "ok");
+    }
+
+    #[test]
+    fn remediation_hint_ai_env_suppresses_chmod() {
+        let generic = "fix: run omamori doctor --fix directly in your terminal (not via AI)";
+        assert_eq!(
+            remediation_hint(
+                &Remediation::ChmodConfig(PathBuf::from("/etc/omamori/config.toml")),
+                true
+            ),
+            generic
+        );
+    }
+
+    #[test]
     fn json_output_has_summary_and_items() {
         let items = vec![
             CheckItem {

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -8,10 +8,13 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use crate::AppError;
+use crate::audit::report::{ChainStatus, aggregate_report};
 use crate::engine::guard::guard_ai_config_modification;
 use crate::installer;
 use crate::integrity::{self, CheckItem, CheckStatus, Remediation};
 use crate::util::usage_text;
+
+use super::checks_display::group_by_section;
 
 // ---------------------------------------------------------------------------
 // Public entry point
@@ -84,90 +87,129 @@ pub(crate) fn run_doctor_command(args: &[OsString]) -> Result<i32, AppError> {
 // ---------------------------------------------------------------------------
 
 fn run_diagnose(items: &[CheckItem], verbose: bool) -> Result<i32, AppError> {
+    let has_fail = items.iter().any(|i| i.status == CheckStatus::Fail);
+    let has_warn = items.iter().any(|i| i.status == CheckStatus::Warn);
+
+    // Top-line: Protection status
+    let status_word = if has_fail {
+        "FAIL"
+    } else if has_warn {
+        "WARN"
+    } else {
+        "OK"
+    };
+    println!("Protection status: {status_word}");
+    println!();
+
+    let sections = group_by_section(items);
+    let ai_env = is_ai_environment();
+
+    for (section, section_items) in &sections {
+        let pass = section_items
+            .iter()
+            .filter(|i| i.status == CheckStatus::Ok)
+            .count();
+        let total = section_items.len();
+        let all_ok = pass == total;
+
+        if all_ok {
+            println!("  {} {pass}/{total}", section.heading());
+        } else {
+            println!("  {} {pass}/{total}", section.heading());
+            for item in section_items {
+                if item.status == CheckStatus::Ok {
+                    if verbose {
+                        println!(
+                            "    {:<6} {} {}",
+                            item.status.label(),
+                            item.name,
+                            item.detail
+                        );
+                    }
+                    continue;
+                }
+                println!(
+                    "    {:<6} {} {}",
+                    item.status.label(),
+                    item.name,
+                    item.detail
+                );
+                if let Some(ref rem) = item.remediation {
+                    println!("           {}", remediation_hint(rem, ai_env));
+                }
+            }
+        }
+    }
+
+    // Section 4: Recent risk signals (from audit aggregation)
+    print_risk_signals_section();
+
+    println!();
+
     let problems: Vec<_> = items
         .iter()
         .filter(|i| i.status != CheckStatus::Ok)
         .collect();
-
-    if problems.is_empty() {
-        // Healthy: 3-line summary
-        let total = items.len();
-        let ok_count = items.iter().filter(|i| i.status == CheckStatus::Ok).count();
-        println!("omamori: all healthy");
-        println!("  {ok_count}/{total} checks passed");
-        print_unknown_tool_fail_open_summary();
-        if verbose {
-            println!();
-            print_all_items(items);
-        } else {
-            println!("  run `omamori doctor --verbose` for full details");
-        }
-        return Ok(0);
-    }
-
-    // Unhealthy: show problems only
-    println!("omamori doctor: {} issue(s) found\n", problems.len());
-
-    for item in &problems {
-        let label = item.status.label();
-        println!(
-            "  {:<6} [{}] {} {}",
-            label, item.category, item.name, item.detail
-        );
-        if let Some(ref rem) = item.remediation {
-            println!("         {}", remediation_hint(rem));
+    if !problems.is_empty() {
+        let has_fixable = problems.iter().any(|i| {
+            i.remediation
+                .as_ref()
+                .is_some_and(|r| !matches!(r, Remediation::ManualOnly(_)))
+        });
+        if has_fixable {
+            println!("  run `omamori doctor --fix` to auto-repair");
         }
     }
 
-    println!();
-    print_unknown_tool_fail_open_summary();
-    let has_fixable = problems.iter().any(|i| {
-        i.remediation
-            .as_ref()
-            .is_some_and(|r| !matches!(r, Remediation::ManualOnly(_)))
-    });
-    if has_fixable {
-        println!("  run `omamori doctor --fix` to auto-repair");
-    }
-
-    if verbose {
+    if verbose && !items.is_empty() {
         println!();
         println!("All checks:");
         print_all_items(items);
+    } else if problems.is_empty() {
+        println!("  run `omamori doctor --verbose` for full details");
     }
 
-    // exit code: 1 if any Fail, 2 if only Warn
-    if problems.iter().any(|i| i.status == CheckStatus::Fail) {
+    if has_fail {
         Ok(1)
-    } else {
+    } else if has_warn {
         Ok(2)
+    } else {
+        Ok(0)
     }
 }
 
-/// PR6 (#182): print a summary of `unknown_tool_fail_open` events from
-/// the last 30 days. Skipped when zero so doctor stays quiet on healthy
-/// installs (per UX release blocker: zero must not generate noise).
+/// Section 4: Recent risk signals from audit aggregation (last 30 days).
 ///
-/// Best-effort: any error loading config / reading the audit log makes
-/// this a silent no-op rather than failing doctor.
-///
-/// Clock-skew assumption (#190 B-4, v0.9.7+): the cutoff is computed as
-/// `OffsetDateTime::now_utc() - Duration::days(30)` and applied as a `>=`
-/// filter on `event.timestamp` (see [`crate::audit::count_unknown_tool_fail_opens_within`]).
-/// Significant NTP rewinds or other clock anomalies move the cutoff window
-/// and silently shrink or zero the count. The surfaced number is a drift
-/// indicator, not a forensic counter; SECURITY.md `## Scope: unknown / new
-/// tools (v0.9.6+)` carries the user-facing version of this caveat (full
-/// heading quoted to make a future rename a hard build/lint signal rather
-/// than a silent partial-substring miss).
-fn print_unknown_tool_fail_open_summary() {
+/// Uses `aggregate_report` from PR 1 to surface blocks and unknown-tool
+/// fail-opens. Zero counts are suppressed (healthy install = quiet).
+/// Best-effort: config/audit read failures → silent no-op.
+fn print_risk_signals_section() {
     let Ok(load_result) = crate::config::load_config(None) else {
         return;
     };
-    let count = crate::audit::count_unknown_tool_fail_opens_within(&load_result.config.audit, 30);
-    if count > 0 {
-        println!("  Last 30 days: {count} unknown-tool fail-open(s) detected");
-        println!("  Review: omamori audit unknown");
+    let report = aggregate_report(&load_result.config.audit, 30);
+
+    let has_blocks = report.total_blocks > 0;
+    let has_unknown = report.unknown_tool_fail_opens > 0;
+    let chain_broken = matches!(report.chain_status, ChainStatus::Broken { .. });
+
+    if !has_blocks && !has_unknown && !chain_broken {
+        println!("  [Risk signals] Last 30 days: quiet");
+        return;
+    }
+
+    println!("  [Risk signals] Last 30 days");
+    if has_blocks {
+        println!("    {} block(s)", report.total_blocks);
+    }
+    if has_unknown {
+        println!(
+            "    {} unknown-tool fail-open(s) — review: omamori audit unknown",
+            report.unknown_tool_fail_opens
+        );
+    }
+    if let ChainStatus::Broken { .. } = &report.chain_status {
+        println!("    chain: broken — run omamori audit verify");
     }
 }
 
@@ -226,7 +268,7 @@ fn run_fix(items: &[CheckItem], base_dir: &Path, verbose: bool) -> Result<i32, A
 
     // 1. RunInstall (covers shims + hooks + baseline)
     if needs_install {
-        print!("  [install] re-running full install...");
+        print!("  [Layer 1] re-running full install...");
         match run_install_repair(base_dir) {
             Ok(()) => {
                 println!(" [fixed]");
@@ -241,7 +283,7 @@ fn run_fix(items: &[CheckItem], base_dir: &Path, verbose: bool) -> Result<i32, A
 
     // 2. RegenerateHooks (only if install wasn't needed)
     if needs_regen_hooks {
-        print!("  [hooks] regenerating hook scripts...");
+        print!("  [Layer 2] regenerating hook scripts...");
         match installer::regenerate_hooks(base_dir) {
             Ok(()) => {
                 println!(" [fixed]");
@@ -256,7 +298,7 @@ fn run_fix(items: &[CheckItem], base_dir: &Path, verbose: bool) -> Result<i32, A
 
     // 3. ChmodConfig
     for path in &chmod_targets {
-        print!("  [config] chmod 600 {}...", path.display());
+        print!("  [Integrity] chmod 600 {}...", path.display());
         match chmod_600(path) {
             Ok(()) => {
                 println!(" [fixed]");
@@ -271,7 +313,7 @@ fn run_fix(items: &[CheckItem], base_dir: &Path, verbose: bool) -> Result<i32, A
 
     // 4. RegenerateBaseline (LAST per DI-10)
     if needs_regen_baseline {
-        print!("  [baseline] regenerating integrity baseline...");
+        print!("  [Integrity] regenerating integrity baseline...");
         match regen_baseline(base_dir) {
             Ok(()) => {
                 println!(" [fixed]");
@@ -416,34 +458,43 @@ fn chmod_600(_path: &Path) -> Result<(), AppError> {
 // Display helpers
 // ---------------------------------------------------------------------------
 
-fn remediation_hint(rem: &Remediation) -> String {
-    match rem {
-        Remediation::RunInstall => "fix: run `omamori install`".to_string(),
-        Remediation::RegenerateHooks => "fix: run `omamori install --hooks`".to_string(),
-        Remediation::RegenerateBaseline => {
-            "fix: run `omamori install` to update baseline".to_string()
+/// SEC-R5: in AI environments, suppress literal commands to prevent
+/// AI agents from learning repair invocations as attack surface.
+fn remediation_hint(rem: &Remediation, ai_env: bool) -> String {
+    if ai_env {
+        match rem {
+            Remediation::ManualOnly(hint) => format!("manual: {hint}"),
+            _ => "fix: run omamori doctor --fix directly in your terminal (not via AI)".to_string(),
         }
-        Remediation::ChmodConfig(path) => format!("fix: run `chmod 600 {}`", path.display()),
-        Remediation::ManualOnly(hint) => format!("manual: {hint}"),
+    } else {
+        match rem {
+            Remediation::RunInstall => "fix: run `omamori install`".to_string(),
+            Remediation::RegenerateHooks => "fix: run `omamori install --hooks`".to_string(),
+            Remediation::RegenerateBaseline => {
+                "fix: run `omamori install` to update baseline".to_string()
+            }
+            Remediation::ChmodConfig(path) => format!("fix: run `chmod 600 {}`", path.display()),
+            Remediation::ManualOnly(hint) => format!("manual: {hint}"),
+        }
     }
 }
 
+/// Lightweight AI environment check reusing the detector infrastructure.
+fn is_ai_environment() -> bool {
+    let detectors = crate::config::default_detectors();
+    let env_pairs: Vec<(String, String)> = std::env::vars().collect();
+    let detection = crate::detector::evaluate_detectors(&detectors, &env_pairs);
+    detection.protected
+}
+
 fn print_all_items(items: &[CheckItem]) {
-    let categories = [
-        "Shims",
-        "Hooks",
-        "Config",
-        "Core Policy",
-        "PATH",
-        "Baseline",
-    ];
-    for cat in &categories {
-        let cat_items: Vec<_> = items.iter().filter(|i| i.category == *cat).collect();
-        if cat_items.is_empty() {
+    let sections = group_by_section(items);
+    for (section, section_items) in &sections {
+        if section_items.is_empty() {
             continue;
         }
-        println!("  {}:", cat);
-        for item in &cat_items {
+        println!("  {}:", section.heading());
+        for item in section_items {
             println!(
                 "    {:<6} {:<36} {}",
                 item.status.label(),
@@ -475,18 +526,42 @@ fn print_json(items: &[CheckItem], fix_mode: bool, _base_dir: &Path) -> Result<i
         })
         .collect();
 
+    let has_fail = items.iter().any(|i| i.status == CheckStatus::Fail);
+    let has_warn = items.iter().any(|i| i.status == CheckStatus::Warn);
+    let protection_status = if has_fail {
+        "fail"
+    } else if has_warn {
+        "warn"
+    } else {
+        "ok"
+    };
+
+    let sections = group_by_section(items);
+    let section_summary = |section_items: &[&CheckItem]| -> serde_json::Value {
+        let pass = section_items
+            .iter()
+            .filter(|i| i.status == CheckStatus::Ok)
+            .count();
+        serde_json::json!({ "pass": pass, "total": section_items.len() })
+    };
+
     let output = serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "mode": if fix_mode { "fix" } else { "diagnose" },
+        "summary": {
+            "protection_status": protection_status,
+            "layer1": section_summary(&sections[0].1),
+            "layer2": section_summary(&sections[1].1),
+            "integrity": section_summary(&sections[2].1),
+        },
         "items": json_items,
     });
 
     println!("{}", serde_json::to_string_pretty(&output).unwrap());
 
-    // exit code based on items
-    if items.iter().any(|i| i.status == CheckStatus::Fail) {
+    if has_fail {
         Ok(1)
-    } else if items.iter().any(|i| i.status == CheckStatus::Warn) {
+    } else if has_warn {
         Ok(2)
     } else {
         Ok(0)
@@ -512,21 +587,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn remediation_hint_formats_correctly() {
+    fn remediation_hint_non_ai() {
         assert_eq!(
-            remediation_hint(&Remediation::RunInstall),
+            remediation_hint(&Remediation::RunInstall, false),
             "fix: run `omamori install`"
         );
         assert_eq!(
-            remediation_hint(&Remediation::RegenerateHooks),
+            remediation_hint(&Remediation::RegenerateHooks, false),
             "fix: run `omamori install --hooks`"
         );
         assert_eq!(
-            remediation_hint(&Remediation::ChmodConfig(PathBuf::from("/tmp/config.toml"))),
+            remediation_hint(
+                &Remediation::ChmodConfig(PathBuf::from("/tmp/config.toml")),
+                false
+            ),
             "fix: run `chmod 600 /tmp/config.toml`"
         );
         assert_eq!(
-            remediation_hint(&Remediation::ManualOnly("do something".to_string())),
+            remediation_hint(&Remediation::ManualOnly("do something".to_string()), false),
+            "manual: do something"
+        );
+    }
+
+    #[test]
+    fn remediation_hint_ai_env_suppresses_literals() {
+        let generic = "fix: run omamori doctor --fix directly in your terminal (not via AI)";
+        assert_eq!(remediation_hint(&Remediation::RunInstall, true), generic);
+        assert_eq!(
+            remediation_hint(&Remediation::RegenerateHooks, true),
+            generic
+        );
+        assert_eq!(
+            remediation_hint(&Remediation::RegenerateBaseline, true),
+            generic
+        );
+        assert_eq!(
+            remediation_hint(&Remediation::ManualOnly("do something".to_string()), true),
             "manual: do something"
         );
     }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -522,7 +522,7 @@ fn print_all_items(items: &[CheckItem]) {
 // JSON output
 // ---------------------------------------------------------------------------
 
-fn print_json(items: &[CheckItem], fix_mode: bool, _base_dir: &Path) -> Result<i32, AppError> {
+fn build_json_output(items: &[CheckItem], fix_mode: bool) -> serde_json::Value {
     let json_items: Vec<serde_json::Value> = items
         .iter()
         .map(|item| {
@@ -558,7 +558,7 @@ fn print_json(items: &[CheckItem], fix_mode: bool, _base_dir: &Path) -> Result<i
         serde_json::json!({ "pass": pass, "total": section_items.len() })
     };
 
-    let output = serde_json::json!({
+    serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "mode": if fix_mode { "fix" } else { "diagnose" },
         "summary": {
@@ -568,13 +568,16 @@ fn print_json(items: &[CheckItem], fix_mode: bool, _base_dir: &Path) -> Result<i
             "integrity": section_summary(&sections[2].1),
         },
         "items": json_items,
-    });
+    })
+}
 
+fn print_json(items: &[CheckItem], fix_mode: bool, _base_dir: &Path) -> Result<i32, AppError> {
+    let output = build_json_output(items, fix_mode);
     println!("{}", serde_json::to_string_pretty(&output).unwrap());
 
-    if has_fail {
+    if items.iter().any(|i| i.status == CheckStatus::Fail) {
         Ok(1)
-    } else if has_warn {
+    } else if items.iter().any(|i| i.status == CheckStatus::Warn) {
         Ok(2)
     } else {
         Ok(0)
@@ -823,40 +826,8 @@ mod tests {
                 remediation: Some(Remediation::RegenerateHooks),
             },
         ];
-        // Capture stdout by parsing the JSON that print_json produces
-        // (print_json writes to stdout, but we can verify structure via
-        // the same construction logic)
-        let sections = super::super::checks_display::group_by_section(&items);
-        let section_summary = |section_items: &[&CheckItem]| -> serde_json::Value {
-            let pass = section_items
-                .iter()
-                .filter(|i| i.status == CheckStatus::Ok)
-                .count();
-            serde_json::json!({ "pass": pass, "total": section_items.len() })
-        };
 
-        let output = serde_json::json!({
-            "version": env!("CARGO_PKG_VERSION"),
-            "mode": "diagnose",
-            "summary": {
-                "protection_status": "fail",
-                "layer1": section_summary(&sections[0].1),
-                "layer2": section_summary(&sections[1].1),
-                "integrity": section_summary(&sections[2].1),
-            },
-            "items": items.iter().map(|item| {
-                let mut obj = serde_json::json!({
-                    "category": item.category,
-                    "name": item.name,
-                    "status": item.status.label(),
-                    "detail": item.detail,
-                });
-                if let Some(ref rem) = item.remediation {
-                    obj["remediation"] = serde_json::json!(remediation_to_str(rem));
-                }
-                obj
-            }).collect::<Vec<_>>(),
-        });
+        let output = build_json_output(&items, false);
 
         // Backward compat: items[] still present with expected shape
         let items_arr = output["items"].as_array().unwrap();
@@ -864,10 +835,11 @@ mod tests {
         assert!(items_arr[0].get("category").is_some());
         assert!(items_arr[0].get("name").is_some());
         assert!(items_arr[0].get("status").is_some());
+        assert_eq!(items_arr[1]["remediation"], "regenerate_hooks");
 
         // Additive: summary block present
         let summary = output.get("summary").unwrap();
-        assert!(summary.get("protection_status").is_some());
+        assert_eq!(summary["protection_status"], "fail");
         assert!(summary.get("layer1").is_some());
         assert!(summary.get("layer2").is_some());
         assert!(summary.get("integrity").is_some());
@@ -877,5 +849,9 @@ mod tests {
         assert_eq!(summary["layer1"]["total"], 1);
         assert_eq!(summary["layer2"]["pass"], 0);
         assert_eq!(summary["layer2"]["total"], 1);
+
+        // Top-level keys: version, mode, summary, items
+        assert!(output.get("version").is_some());
+        assert_eq!(output["mode"], "diagnose");
     }
 }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -112,31 +112,30 @@ fn run_diagnose(items: &[CheckItem], verbose: bool) -> Result<i32, AppError> {
         let total = section_items.len();
         let all_ok = pass == total;
 
+        println!("  {} {pass}/{total}", section.heading());
         if all_ok {
-            println!("  {} {pass}/{total}", section.heading());
-        } else {
-            println!("  {} {pass}/{total}", section.heading());
-            for item in section_items {
-                if item.status == CheckStatus::Ok {
-                    if verbose {
-                        println!(
-                            "    {:<6} {} {}",
-                            item.status.label(),
-                            item.name,
-                            item.detail
-                        );
-                    }
-                    continue;
+            continue;
+        }
+        for item in section_items {
+            if item.status == CheckStatus::Ok {
+                if verbose {
+                    println!(
+                        "    {:<6} {} {}",
+                        item.status.label(),
+                        item.name,
+                        item.detail
+                    );
                 }
-                println!(
-                    "    {:<6} {} {}",
-                    item.status.label(),
-                    item.name,
-                    item.detail
-                );
-                if let Some(ref rem) = item.remediation {
-                    println!("           {}", remediation_hint(rem, ai_env));
-                }
+                continue;
+            }
+            println!(
+                "    {:<6} {} {}",
+                item.status.label(),
+                item.name,
+                item.detail
+            );
+            if let Some(ref rem) = item.remediation {
+                println!("           {}", remediation_hint(rem, ai_env));
             }
         }
     }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -142,7 +142,7 @@ fn run_diagnose(items: &[CheckItem], verbose: bool) -> Result<i32, AppError> {
     }
 
     // Section 4: Recent risk signals (from audit aggregation)
-    print_risk_signals_section();
+    print_risk_signals_section(ai_env);
 
     println!();
 
@@ -156,8 +156,10 @@ fn run_diagnose(items: &[CheckItem], verbose: bool) -> Result<i32, AppError> {
                 .as_ref()
                 .is_some_and(|r| !matches!(r, Remediation::ManualOnly(_)))
         });
-        if has_fixable {
+        if has_fixable && !ai_env {
             println!("  run `omamori doctor --fix` to auto-repair");
+        } else if has_fixable {
+            println!("  issues detected — run doctor --fix directly in your terminal");
         }
     }
 
@@ -181,9 +183,9 @@ fn run_diagnose(items: &[CheckItem], verbose: bool) -> Result<i32, AppError> {
 /// Section 4: Recent risk signals from audit aggregation (last 30 days).
 ///
 /// Uses `aggregate_report` from PR 1 to surface blocks and unknown-tool
-/// fail-opens. Zero counts are suppressed (healthy install = quiet).
+/// fail-opens. All-zero state shows "quiet" indicator.
 /// Best-effort: config/audit read failures → silent no-op.
-fn print_risk_signals_section() {
+fn print_risk_signals_section(ai_env: bool) {
     let Ok(load_result) = crate::config::load_config(None) else {
         return;
     };
@@ -203,13 +205,24 @@ fn print_risk_signals_section() {
         println!("    {} block(s)", report.total_blocks);
     }
     if has_unknown {
-        println!(
-            "    {} unknown-tool fail-open(s) — review: omamori audit unknown",
-            report.unknown_tool_fail_opens
-        );
+        if ai_env {
+            println!(
+                "    {} unknown-tool fail-open(s) detected",
+                report.unknown_tool_fail_opens
+            );
+        } else {
+            println!(
+                "    {} unknown-tool fail-open(s) — review: omamori audit unknown",
+                report.unknown_tool_fail_opens
+            );
+        }
     }
     if let ChainStatus::Broken { .. } = &report.chain_status {
-        println!("    chain: broken — run omamori audit verify");
+        if ai_env {
+            println!("    chain: broken");
+        } else {
+            println!("    chain: broken — run omamori audit verify");
+        }
     }
 }
 
@@ -790,5 +803,79 @@ mod tests {
         assert!(needs_install);
         assert!(!needs_regen_hooks);
         assert!(!needs_regen_baseline);
+    }
+
+    #[test]
+    fn json_output_has_summary_and_items() {
+        let items = vec![
+            CheckItem {
+                category: "Shims",
+                name: "rm".to_string(),
+                status: CheckStatus::Ok,
+                detail: "ok".to_string(),
+                remediation: None,
+            },
+            CheckItem {
+                category: "Hooks",
+                name: "hook".to_string(),
+                status: CheckStatus::Fail,
+                detail: "missing".to_string(),
+                remediation: Some(Remediation::RegenerateHooks),
+            },
+        ];
+        // Capture stdout by parsing the JSON that print_json produces
+        // (print_json writes to stdout, but we can verify structure via
+        // the same construction logic)
+        let sections = super::super::checks_display::group_by_section(&items);
+        let section_summary = |section_items: &[&CheckItem]| -> serde_json::Value {
+            let pass = section_items
+                .iter()
+                .filter(|i| i.status == CheckStatus::Ok)
+                .count();
+            serde_json::json!({ "pass": pass, "total": section_items.len() })
+        };
+
+        let output = serde_json::json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "mode": "diagnose",
+            "summary": {
+                "protection_status": "fail",
+                "layer1": section_summary(&sections[0].1),
+                "layer2": section_summary(&sections[1].1),
+                "integrity": section_summary(&sections[2].1),
+            },
+            "items": items.iter().map(|item| {
+                let mut obj = serde_json::json!({
+                    "category": item.category,
+                    "name": item.name,
+                    "status": item.status.label(),
+                    "detail": item.detail,
+                });
+                if let Some(ref rem) = item.remediation {
+                    obj["remediation"] = serde_json::json!(remediation_to_str(rem));
+                }
+                obj
+            }).collect::<Vec<_>>(),
+        });
+
+        // Backward compat: items[] still present with expected shape
+        let items_arr = output["items"].as_array().unwrap();
+        assert_eq!(items_arr.len(), 2);
+        assert!(items_arr[0].get("category").is_some());
+        assert!(items_arr[0].get("name").is_some());
+        assert!(items_arr[0].get("status").is_some());
+
+        // Additive: summary block present
+        let summary = output.get("summary").unwrap();
+        assert!(summary.get("protection_status").is_some());
+        assert!(summary.get("layer1").is_some());
+        assert!(summary.get("layer2").is_some());
+        assert!(summary.get("integrity").is_some());
+
+        // Section counts correct
+        assert_eq!(summary["layer1"]["pass"], 1);
+        assert_eq!(summary["layer1"]["total"], 1);
+        assert_eq!(summary["layer2"]["pass"], 0);
+        assert_eq!(summary["layer2"]["total"], 1);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@
 //! - `config_cmd`: `omamori config/override/init` + config mutation
 
 pub(crate) mod audit_cmd;
+pub(crate) mod checks_display;
 pub(crate) mod config_cmd;
 pub(crate) mod doctor;
 pub(crate) mod explain;


### PR DESCRIPTION
## Summary
- Restructure `omamori doctor` output from flat 13-check list to 4-section trust dashboard: Layer 1 (PATH shims), Layer 2 (Hook defense), Integrity (Config & baseline), Risk signals (audit aggregation)
- Top-line `Protection status: OK/WARN/FAIL` as first output line for quick triage
- SEC-R5: AI environment detection suppresses literal commands in remediation hints

## Changes
- [x] New `src/cli/checks_display.rs`: `DoctorSection` enum + `group_by_section()` mapping
- [x] `run_diagnose()`: 4-section hierarchical display with pass/total counts per section
- [x] `--fix` labels: `[install]`→`[Layer 1]`, `[hooks]`→`[Layer 2]`, `[config]`/`[baseline]`→`[Integrity]`
- [x] `--json`: additive `summary` block (protection_status + per-section pass/total), existing `items[]` untouched
- [x] `print_risk_signals_section()`: replaces `print_unknown_tool_fail_open_summary()`, uses `aggregate_report` from PR 1
- [x] `remediation_hint()`: AI env → generic "run directly in terminal" message; non-AI → existing literal commands
- [x] `is_ai_environment()`: reuses `evaluate_detectors` + `default_detectors()`

## Behavioral invariants
- `--fix` repair logic (DI-7/9/10) unchanged — only display labels changed
- `--json` `items[]` array backward-compatible (additive `summary` only)
- Exit codes unchanged: 0 (healthy), 1 (fail), 2 (warn-only)
- `status` subcommand untouched (compat preserved)

## Testing
- [x] `remediation_hint_non_ai`: existing literal format preserved
- [x] `remediation_hint_ai_env_suppresses_literals`: generic message for all auto-fixable types
- [x] `checks_display::test_category_mapping`: all 7 categories mapped correctly
- [x] `checks_display::test_group_by_section`: items grouped into correct sections
- [x] All 682+ existing tests pass
- [x] clippy clean, fmt clean

## Security
- SEC-R5: AI env literal command suppression
- SEC-R6: no `blocked_string_patterns` literals in `println!` output

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)