### PR TITLE
feat(report): add omamori report subcommand (#221)

### DIFF
--- a/ACCEPTANCE_TEST.md
+++ b/ACCEPTANCE_TEST.md
@@ -152,10 +152,48 @@ echo "exit=$?"
 
 | # | コマンド | AI-executable assertion | 人間 summary | PASS |
 |---|---------|-------------------------|--------------|------|
-| D-1 | `omamori doctor` | `exit = 0 ∧ stdout ~~ /healthy/` | 健全環境で summary 表示 | [ ] |
+| D-1 | `omamori doctor` | `exit = 0 ∧ stdout ~~ /Protection status: OK/` | 健全環境で trust dashboard 表示 | [ ] |
 | D-2 | `omamori doctor --verbose` | `exit = 0 ∧ stdout 行数 ≥ 10` | 全チェック項目表示 | [ ] |
 | D-3 | 上記 fenced block の D-3 dry-run | `exit = 2 ∧ stderr ~~ /omamori hook:/` | hook-check が block (Layer 1 + Layer 2 両判定経路) | [ ] |
 | D-4 | 上記 fenced block の D-4 dry-run | `exit = 0` | hook-check が allow | [ ] |
+| D-5 | `omamori doctor --json \| jq .summary` | `exit = 0 ∧ summary.protection_status = "ok" ∧ summary に layer1/layer2/integrity` | JSON summary block 存在確認 | [ ] |
+| D-6 | `omamori doctor --json \| jq '.items[0].category'` | category field が文字列 | JSON items[] backward compat | [ ] |
+| D-7 | `omamori doctor` 出力に `[Layer 1]` `[Layer 2]` `[Integrity]` セクション | `stdout ~~ /\[Layer 1\]/` | 4-section trust dashboard 構造 | [ ] |
+
+## Report (Rep-*)
+
+```bash
+# Rep-1: default (7d)
+omamori report
+echo "exit=$?"
+
+# Rep-2: explicit duration
+omamori report --last 30d
+echo "exit=$?"
+
+# Rep-3: JSON output
+omamori report --json | jq keys
+echo "exit=$?"
+
+# Rep-4: out-of-range duration
+omamori report --last 91d 2>&1
+echo "exit=$?"
+
+# Rep-5: invalid format
+omamori report --last 7 2>&1
+echo "exit=$?"
+```
+
+| ID | Command | Expected | Rationale | Done |
+|---|---|---|---|---|
+| Rep-1 | `omamori report` | `exit = 0 ∧ stdout ~~ /omamori report/` | default 7d report | [ ] |
+| Rep-2 | `omamori report --last 30d` | `exit = 0 ∧ stdout ~~ /last 30 days/` | explicit duration | [ ] |
+| Rep-3 | `omamori report --json \| jq keys` | `exit = 0 ∧ 7 keys (period_days, actual_window_days, total_blocks, by_layer, by_provider, chain_status, unknown_tool_fail_opens)` | SEC-R2 JSON schema | [ ] |
+| Rep-4 | `omamori report --last 91d` | `exit ≠ 0 ∧ stderr ~~ /out of range/` | SEC-R4 upper bound | [ ] |
+| Rep-5 | `omamori report --last 7` | `exit ≠ 0 ∧ stderr ~~ /invalid duration/` | no-unit rejection | [ ] |
+| Rep-6 | `omamori report --last 1d` | `exit = 0` | SEC-R4 lower bound | [ ] |
+| Rep-7 | `omamori report --json --last 7d \| jq .chain_status.status` | `"intact" or "broken" or "unavailable"` | chain_status 3-state (SEC-R8) | [ ] |
+| Rep-8 | `omamori report --json \| jq 'has("by_rule")'` | `false` | by_rule absent from JSON (SEC-R2) | [ ] |
 
 ## Audit Trail (A-*)
 
@@ -270,7 +308,7 @@ rmdir "$TEST_DIR"
 - **全 row PASS**: リリース可
 - **S-* または H-* または R-* に FAIL**: リリース不可、原因調査必須
 - **T-* に FAIL**: リリース不可、セキュリティクリティカル
-- **D-* または A-* に FAIL**: 機能 bug、重大度判断してリリース可否決定
+- **D-* または Rep-* または A-* に FAIL**: 機能 bug、重大度判断してリリース可否決定
 
 ---
 
@@ -289,6 +327,8 @@ rmdir "$TEST_DIR"
 | T-3 (PATH precedence) | `tests/cli.rs` の install path / shim ordering 確認 (直接 mapping は弱い、smoke check) |
 | D-1 / D-2 (`doctor`) | `tests/cli.rs` の doctor サブテスト |
 | D-3 / D-4 (`hook-check` dry-run) | `tests/cli.rs` の `cursor_hook_*` 系および `claude-code` provider テスト |
+| D-5 / D-6 / D-7 (`doctor --json` / trust dashboard) | `src/cli/doctor.rs` の `json_output_has_summary_and_items` + `checks_display.rs` tests |
+| Rep-* (`report`) | `src/cli/report.rs` の unit test 群 (duration parser, JSON schema, chain_status serialization) |
 | A-* (audit trail) | audit 専用 integration test (file format, HMAC chain, XDG path) |
 
 > 完全 1:1 mapping (各 acceptance row に対応する specific CI case 名) は follow-up PR (full 3D matrix 投入時) で確立予定。本 PR1 では領域単位の対応のみ示す。

--- a/ACCEPTANCE_TEST.md
+++ b/ACCEPTANCE_TEST.md
@@ -188,7 +188,7 @@ echo "exit=$?"
 |---|---|---|---|---|
 | Rep-1 | `omamori report` | `exit = 0 ∧ stdout ~~ /omamori report/` | default 7d report | [ ] |
 | Rep-2 | `omamori report --last 30d` | `exit = 0 ∧ stdout ~~ /last 30 days/` | explicit duration | [ ] |
-| Rep-3 | `omamori report --json \| jq keys` | `exit = 0 ∧ 7 keys (period_days, actual_window_days, total_blocks, by_layer, by_provider, chain_status, unknown_tool_fail_opens)` | SEC-R2 JSON schema | [ ] |
+| Rep-3 | `omamori report --json \| jq '[keys \| length == 7, has("by_rule") \| not] \| all'` | `exit = 0 ∧ output = true` | SEC-R2 JSON schema: exactly 7 fields, no by_rule | [ ] |
 | Rep-4 | `omamori report --last 91d` | `exit ≠ 0 ∧ stderr ~~ /out of range/` | SEC-R4 upper bound | [ ] |
 | Rep-5 | `omamori report --last 7` | `exit ≠ 0 ∧ stderr ~~ /invalid duration/` | no-unit rejection | [ ] |
 | Rep-6 | `omamori report --last 1d` | `exit = 0` | SEC-R4 lower bound | [ ] |

--- a/ACCEPTANCE_TEST.md
+++ b/ACCEPTANCE_TEST.md
@@ -171,8 +171,8 @@ echo "exit=$?"
 omamori report --last 30d
 echo "exit=$?"
 
-# Rep-3: JSON output
-omamori report --json | jq keys
+# Rep-3: JSON schema (SEC-R2: 7 fields, no by_rule)
+omamori report --json | jq '[keys | length == 7, has("by_rule") | not] | all'
 echo "exit=$?"
 
 # Rep-4: out-of-range duration

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ omamori test [--config PATH]             # Verify policy rules
 omamori status [--refresh]               # Health check all defense layers
 omamori exec [--config PATH] -- CMD      # Run command through policy engine
 
+omamori report [--last 7d] [--json]      # Aggregate audit summary (1d–90d)
+
 omamori audit verify                     # Verify hash chain integrity (exit 0/1/2)
 omamori audit show [--last N] [--json]   # View recent audit entries (default: last 20)
 omamori audit show --all                 # View all entries

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ omamori test [--config PATH]             # Verify policy rules
 omamori status [--refresh]               # Health check all defense layers
 omamori exec [--config PATH] -- CMD      # Run command through policy engine
 
-omamori report [--last 7d] [--json]      # Aggregate audit summary (1d–90d)
+omamori report [--last 7d] [--json] [--verbose]  # Aggregate audit summary (1d–90d)
 
 omamori audit verify                     # Verify hash chain integrity (exit 0/1/2)
 omamori audit show [--last N] [--json]   # View recent audit entries (default: last 20)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -505,6 +505,18 @@ This is consistent with the same-user OS threat model: HMAC integrity protects a
 
 Operators who treat AI tool usage itself as confidential should run AI tools under a dedicated OS user, mount the audit directory on an encrypted volume keyed outside the home directory, or both.
 
+### Report Read Access (v0.10.0+)
+
+`omamori report` aggregates audit log data into summary statistics (block counts by layer/provider, unknown-tool fail-open counts, chain integrity status). This is the same data surface as `audit show` — read-only, no AI environment guard — consistent with the same-user OS threat model established above.
+
+**Design boundaries**:
+- Duration window is capped at 90 days (SEC-R4). Longer history is available via `audit show --all`.
+- `--json` output is limited to 7 fields (SEC-R2): `period_days`, `actual_window_days`, `total_blocks`, `by_layer`, `by_provider`, `chain_status`, `unknown_tool_fail_opens`. Per-rule breakdowns are human-only to avoid exposing attack optimization information to machine consumers.
+- Provider aggregation uses the `provider` field (e.g. `claude-code`, `codex-cli`), not internal wrapper names (channel separation maintained per v0.9.5 invariant).
+- Unknown-tool shapes are reported as counts only; detailed tool names require `audit unknown` (SEC-R7).
+
+**Accepted risk**: An AI agent polling `omamori report --json` on a schedule can observe activity patterns (block frequency, provider distribution). This is inherent to the same-user model — the agent can already read `audit.jsonl` directly. The report subcommand adds convenience, not new information surface.
+
 ### Secret Loss
 
 If the secret file is deleted or unreadable:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -511,7 +511,7 @@ Operators who treat AI tool usage itself as confidential should run AI tools und
 
 **Design boundaries**:
 - Duration window is capped at 90 days (SEC-R4). Longer history is available via `audit show --all`.
-- `--json` output is limited to 7 fields (SEC-R2): `period_days`, `actual_window_days`, `total_blocks`, `by_layer`, `by_provider`, `chain_status`, `unknown_tool_fail_opens`. Per-rule breakdowns are human-only to avoid exposing attack optimization information to machine consumers.
+- `--json` output is limited to 7 fields (SEC-R2): `period_days`, `actual_window_days`, `total_blocks`, `by_layer`, `by_provider`, `chain_status`, `unknown_tool_fail_opens`. Per-rule breakdowns are not included in `report` output (human or JSON) to avoid exposing attack optimization information; use `audit show --rule <name>` for per-rule investigation.
 - Provider aggregation uses the `provider` field (e.g. `claude-code`, `codex-cli`), not internal wrapper names (channel separation maintained per v0.9.5 invariant).
 - Unknown-tool shapes are reported as counts only; detailed tool names require `audit unknown` (SEC-R7).
 

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -219,7 +219,7 @@ fn aggregate_events(path: &Path, days: u32) -> Option<EventStats> {
 fn classify_layer(detection_layer: Option<&str>) -> String {
     match detection_layer {
         Some("layer1") => "layer1".to_string(),
-        Some(dl) if dl.starts_with("layer2") => "layer2".to_string(),
+        Some(dl) if dl == "layer2" || dl.starts_with("layer2:") => "layer2".to_string(),
         Some("shape-routing") => "shape-routing".to_string(),
         Some(dl) => dl.to_string(), // preserve unknown values
         None => "unclassified".to_string(),
@@ -237,8 +237,17 @@ mod tests {
         assert_eq!(classify_layer(Some("layer2:meta-pattern")), "layer2");
         assert_eq!(classify_layer(Some("layer2:pipe-to-shell:sudo")), "layer2");
         assert_eq!(classify_layer(Some("layer2:structural")), "layer2");
+        assert_eq!(classify_layer(Some("layer2")), "layer2");
         assert_eq!(classify_layer(Some("shape-routing")), "shape-routing");
         assert_eq!(classify_layer(None), "unclassified");
+    }
+
+    #[test]
+    fn test_classify_layer_rejects_false_prefixes() {
+        assert_eq!(classify_layer(Some("layer20")), "layer20");
+        assert_eq!(classify_layer(Some("layer2evil")), "layer2evil");
+        assert_eq!(classify_layer(Some("layer2/")), "layer2/");
+        assert_eq!(classify_layer(Some("layer3")), "layer3");
     }
 
     #[test]
@@ -256,6 +265,90 @@ mod tests {
         assert!(report.by_layer.is_empty());
         assert!(report.by_provider.is_empty());
         assert_eq!(report.chain_status, ChainStatus::Unavailable);
+    }
+
+    fn make_event_line(
+        action: &str,
+        provider: &str,
+        detection_layer: Option<&str>,
+        minutes_ago: i64,
+    ) -> String {
+        let ts = OffsetDateTime::now_utc() - time::Duration::minutes(minutes_ago);
+        let ts_str = ts.format(&Rfc3339).unwrap();
+        let dl = match detection_layer {
+            Some(v) => format!("\"{v}\""),
+            None => "null".to_string(),
+        };
+        format!(
+            r#"{{"timestamp":"{ts_str}","provider":"{provider}","command":"test","rule_id":null,"action":"{action}","result":"done","target_count":0,"target_hash":"","detection_layer":{dl}}}"#,
+        )
+    }
+
+    fn write_temp_audit(lines: &[String], tag: &str) -> std::path::PathBuf {
+        let dir = std::env::var("HOME").unwrap();
+        let path = std::path::PathBuf::from(dir)
+            .join(format!(".omamori-test-{}-{tag}.jsonl", std::process::id()));
+        std::fs::write(&path, lines.join("\n") + "\n").unwrap();
+        path
+    }
+
+    #[test]
+    fn test_action_block_counted_deny_ignored() {
+        let lines = vec![
+            make_event_line("block", "claude-code", Some("layer1"), 10),
+            make_event_line("block", "claude-code", Some("layer2:rule"), 20),
+            make_event_line("deny", "claude-code", Some("layer1"), 30),
+            make_event_line("allow", "claude-code", Some("layer1"), 40),
+        ];
+        let path = write_temp_audit(&lines, "action");
+        let stats = aggregate_events(&path, 1).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(stats.total_blocks, 2);
+        assert_eq!(*stats.by_layer.get("layer1").unwrap_or(&0), 1);
+        assert_eq!(*stats.by_layer.get("layer2").unwrap_or(&0), 1);
+    }
+
+    #[test]
+    fn test_empty_provider_mapped_to_none() {
+        let lines = vec![make_event_line("block", "", Some("layer1"), 10)];
+        let path = write_temp_audit(&lines, "provider");
+        let stats = aggregate_events(&path, 1).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(stats.total_blocks, 1);
+        assert_eq!(*stats.by_provider.get("none").unwrap_or(&0), 1);
+        assert!(!stats.by_provider.contains_key(""));
+    }
+
+    #[test]
+    fn test_unknown_tool_fail_open_isolation() {
+        let lines = vec![
+            make_event_line("unknown_tool_fail_open", "claude-code", Some("layer1"), 10),
+            make_event_line("unknown_tool_fail_open", "codex", None, 20),
+            make_event_line("block", "claude-code", Some("layer1"), 30),
+        ];
+        let path = write_temp_audit(&lines, "unknown");
+        let stats = aggregate_events(&path, 1).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(stats.unknown_tool_fail_opens, 2);
+        assert_eq!(stats.total_blocks, 1);
+        assert_eq!(stats.by_layer.len(), 1);
+        assert_eq!(stats.by_provider.len(), 1);
+    }
+
+    #[test]
+    fn test_events_outside_window_excluded() {
+        let lines = vec![
+            make_event_line("block", "claude-code", Some("layer1"), 10),
+            make_event_line("block", "claude-code", Some("layer1"), 60 * 24 * 8),
+        ];
+        let path = write_temp_audit(&lines, "window");
+        let stats = aggregate_events(&path, 7).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(stats.total_blocks, 1);
     }
 
     #[test]

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -189,8 +189,8 @@ fn aggregate_events(path: &Path, days: u32) -> Option<EventStats> {
             continue;
         }
 
-        // Count blocks (action = "deny")
-        if event.action == "deny" {
+        // Count blocks (action = "block", written by rules.rs Block variant)
+        if event.action == "block" {
             stats.total_blocks += 1;
 
             // by_layer: classify detection_layer into 3 buckets

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,4 +14,5 @@ pub(crate) mod doctor;
 pub(crate) mod explain;
 pub(crate) mod install;
 pub(crate) mod policy_test;
+pub(crate) mod report;
 pub(crate) mod status;

--- a/src/cli/report.rs
+++ b/src/cli/report.rs
@@ -1,0 +1,256 @@
+//! `omamori report [--last <duration>] [--json] [--verbose]` subcommand.
+//!
+//! Read-only aggregation viewer for audit log events.
+//! No AI environment guard (SEC-R3: precedent with `audit show`).
+
+use std::ffi::OsString;
+
+use crate::AppError;
+use crate::audit::report::{ChainStatus, ReportAggregate, aggregate_report};
+use crate::config;
+use crate::util::usage_text;
+
+pub(crate) fn run_report_command(args: &[OsString]) -> Result<i32, AppError> {
+    let mut days: u32 = 7;
+    let mut json = false;
+    let mut verbose = false;
+    let mut index = 2usize;
+
+    while let Some(arg) = args.get(index).and_then(|item| item.to_str()) {
+        match arg {
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            "--verbose" => {
+                verbose = true;
+                index += 1;
+            }
+            "--last" => {
+                let value = args
+                    .get(index + 1)
+                    .and_then(|v| v.to_str())
+                    .ok_or_else(|| {
+                        AppError::Usage("report --last requires a duration (e.g. 7d)".to_string())
+                    })?;
+                days = parse_duration(value)?;
+                index += 2;
+            }
+            _ => {
+                return Err(AppError::Usage(format!(
+                    "unknown flag: {arg}\n\n{}",
+                    usage_text()
+                )));
+            }
+        }
+    }
+
+    let load_result = config::load_config(None)?;
+    let report = aggregate_report(&load_result.config.audit, days);
+
+    if json {
+        print_json_report(&report);
+    } else {
+        print_human_report(&report, verbose);
+    }
+
+    Ok(0)
+}
+
+// ---------------------------------------------------------------------------
+// Duration parser (SEC-R4: 1d–90d, case-insensitive)
+// ---------------------------------------------------------------------------
+
+fn parse_duration(s: &str) -> Result<u32, AppError> {
+    let s = s.trim().to_lowercase();
+    if !s.ends_with('d') {
+        return Err(AppError::Usage(format!(
+            "invalid duration \"{s}\": use format like 7d (1d–90d)"
+        )));
+    }
+    let num_str = &s[..s.len() - 1];
+    let n: u32 = num_str.parse().map_err(|_| {
+        AppError::Usage(format!(
+            "invalid duration \"{s}\": use format like 7d (1d–90d)"
+        ))
+    })?;
+    if !(1..=90).contains(&n) {
+        return Err(AppError::Usage(format!(
+            "duration out of range: {n}d (allowed: 1d–90d)"
+        )));
+    }
+    Ok(n)
+}
+
+// ---------------------------------------------------------------------------
+// Human output
+// ---------------------------------------------------------------------------
+
+fn print_human_report(report: &ReportAggregate, verbose: bool) {
+    println!("omamori report — last {} days", report.period_days);
+    println!();
+
+    // Retention caveat
+    if report.actual_window_days < report.period_days {
+        println!(
+            "  Note: showing {} days of {} requested",
+            report.actual_window_days, report.period_days
+        );
+        println!();
+    }
+
+    // Block events
+    if report.total_blocks == 0 {
+        println!("  Block events: none");
+    } else {
+        println!("  Block events: {}", report.total_blocks);
+        print_breakdown("    by layer", &report.by_layer);
+        print_breakdown("    by provider", &report.by_provider);
+    }
+
+    // Unknown tool fail-opens (SEC-R7: count only)
+    if report.unknown_tool_fail_opens > 0 {
+        println!(
+            "  Unknown-tool fail-opens: {}",
+            report.unknown_tool_fail_opens
+        );
+    }
+
+    // Chain integrity
+    match &report.chain_status {
+        ChainStatus::Intact => {
+            if verbose {
+                println!("  Audit log: intact");
+            }
+        }
+        ChainStatus::Broken { at_seq } => {
+            if verbose {
+                println!("  Audit log: broken at seq {at_seq}");
+            } else {
+                println!("  Audit log: broken");
+            }
+        }
+        ChainStatus::Unavailable => {
+            println!("  Audit log: unavailable");
+        }
+    }
+
+    // Follow-ups
+    let mut follow_ups = Vec::new();
+    if report.unknown_tool_fail_opens > 0 {
+        follow_ups.push("review unknown tools: omamori audit unknown");
+    }
+    if matches!(report.chain_status, ChainStatus::Broken { .. }) {
+        follow_ups.push("verify chain: omamori audit verify");
+    }
+    if !follow_ups.is_empty() {
+        println!();
+        println!("  Suggested follow-ups:");
+        for f in &follow_ups {
+            println!("    - {f}");
+        }
+    }
+}
+
+fn print_breakdown(label: &str, map: &std::collections::HashMap<String, u64>) {
+    if map.is_empty() {
+        return;
+    }
+    let mut entries: Vec<_> = map.iter().collect();
+    entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+    let parts: Vec<String> = entries.iter().map(|(k, v)| format!("{k}: {v}")).collect();
+    println!("{label}: {}", parts.join(", "));
+}
+
+// ---------------------------------------------------------------------------
+// JSON output (SEC-R2: 7 fields via ReportAggregate Serialize)
+// ---------------------------------------------------------------------------
+
+fn print_json_report(report: &ReportAggregate) {
+    println!("{}", serde_json::to_string_pretty(report).unwrap());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn parse_duration_valid() {
+        assert_eq!(parse_duration("7d").unwrap(), 7);
+        assert_eq!(parse_duration("1d").unwrap(), 1);
+        assert_eq!(parse_duration("90d").unwrap(), 90);
+        assert_eq!(parse_duration("30D").unwrap(), 30);
+        assert_eq!(parse_duration(" 14d ").unwrap(), 14);
+    }
+
+    #[test]
+    fn parse_duration_out_of_range() {
+        assert!(parse_duration("0d").is_err());
+        assert!(parse_duration("91d").is_err());
+        assert!(parse_duration("100d").is_err());
+    }
+
+    #[test]
+    fn parse_duration_invalid_format() {
+        assert!(parse_duration("7").is_err());
+        assert!(parse_duration("7h").is_err());
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("d").is_err());
+        assert!(parse_duration("abc").is_err());
+        assert!(parse_duration("-1d").is_err());
+    }
+
+    #[test]
+    fn json_output_has_seven_fields() {
+        let report = ReportAggregate {
+            period_days: 7,
+            actual_window_days: 7,
+            total_blocks: 3,
+            by_layer: HashMap::from([("layer1".to_string(), 2), ("layer2".to_string(), 1)]),
+            by_provider: HashMap::from([("claude-code".to_string(), 3)]),
+            chain_status: ChainStatus::Intact,
+            unknown_tool_fail_opens: 1,
+        };
+        let json: serde_json::Value = serde_json::to_value(&report).unwrap();
+        let obj = json.as_object().unwrap();
+
+        assert_eq!(obj.len(), 7, "SEC-R2: exactly 7 fields");
+        assert!(obj.contains_key("period_days"));
+        assert!(obj.contains_key("actual_window_days"));
+        assert!(obj.contains_key("total_blocks"));
+        assert!(obj.contains_key("by_layer"));
+        assert!(obj.contains_key("by_provider"));
+        assert!(obj.contains_key("chain_status"));
+        assert!(obj.contains_key("unknown_tool_fail_opens"));
+    }
+
+    #[test]
+    fn json_output_empty_report() {
+        let report = ReportAggregate::default();
+        let json: serde_json::Value = serde_json::to_value(&report).unwrap();
+        let obj = json.as_object().unwrap();
+
+        assert_eq!(obj.len(), 7);
+        assert_eq!(json["total_blocks"], 0);
+        assert_eq!(json["unknown_tool_fail_opens"], 0);
+        assert_eq!(json["chain_status"]["status"], "unavailable");
+    }
+
+    #[test]
+    fn json_chain_status_serialization() {
+        let intact = serde_json::to_value(ChainStatus::Intact).unwrap();
+        assert_eq!(intact["status"], "intact");
+
+        let broken = serde_json::to_value(ChainStatus::Broken { at_seq: 42 }).unwrap();
+        assert_eq!(broken["status"], "broken");
+        assert!(broken.get("at_seq").is_none(), "SEC-R8: at_seq not in JSON");
+
+        let unavail = serde_json::to_value(ChainStatus::Unavailable).unwrap();
+        assert_eq!(unavail["status"], "unavailable");
+    }
+}

--- a/src/cli/report.rs
+++ b/src/cli/report.rs
@@ -116,13 +116,9 @@ fn print_human_report(report: &ReportAggregate, verbose: bool) {
         );
     }
 
-    // Chain integrity
+    // Chain integrity (always shown; verbose adds seq detail)
     match &report.chain_status {
-        ChainStatus::Intact => {
-            if verbose {
-                println!("  Audit log: intact");
-            }
-        }
+        ChainStatus::Intact => println!("  Audit log: intact"),
         ChainStatus::Broken { at_seq } => {
             if verbose {
                 println!("  Audit log: broken at seq {at_seq}");
@@ -130,9 +126,7 @@ fn print_human_report(report: &ReportAggregate, verbose: bool) {
                 println!("  Audit log: broken");
             }
         }
-        ChainStatus::Unavailable => {
-            println!("  Audit log: unavailable");
-        }
+        ChainStatus::Unavailable => println!("  Audit log: unavailable"),
     }
 
     // Follow-ups
@@ -239,6 +233,49 @@ mod tests {
         assert_eq!(json["total_blocks"], 0);
         assert_eq!(json["unknown_tool_fail_opens"], 0);
         assert_eq!(json["chain_status"]["status"], "unavailable");
+    }
+
+    #[test]
+    fn run_command_default_succeeds() {
+        let args: Vec<OsString> = vec!["omamori".into(), "report".into()];
+        let code = run_report_command(&args).unwrap();
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn run_command_with_last_flag() {
+        let args: Vec<OsString> = vec![
+            "omamori".into(),
+            "report".into(),
+            "--last".into(),
+            "30d".into(),
+        ];
+        let code = run_report_command(&args).unwrap();
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn run_command_with_json_flag() {
+        let args: Vec<OsString> = vec!["omamori".into(), "report".into(), "--json".into()];
+        let code = run_report_command(&args).unwrap();
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn run_command_invalid_duration_errors() {
+        let args: Vec<OsString> = vec![
+            "omamori".into(),
+            "report".into(),
+            "--last".into(),
+            "91d".into(),
+        ];
+        assert!(run_report_command(&args).is_err());
+    }
+
+    #[test]
+    fn run_command_unknown_flag_errors() {
+        let args: Vec<OsString> = vec!["omamori".into(), "report".into(), "--bogus".into()];
+        assert!(run_report_command(&args).is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use cli::doctor::run_doctor_command;
 use cli::explain::run_explain_command;
 use cli::install::{run_install_command, run_uninstall_command};
 use cli::policy_test::run_policy_test_command;
+use cli::report::run_report_command;
 use cli::status::run_status_command;
 use engine::exec::run_exec_command;
 use engine::hook::{run_cursor_hook, run_hook_check};
@@ -84,6 +85,7 @@ pub fn run(args: &[OsString]) -> Result<i32, AppError> {
         Some("audit") => run_audit_command(args),
         Some("doctor") => run_doctor_command(args),
         Some("explain") => run_explain_command(args),
+        Some("report") => run_report_command(args),
         Some("status") => run_status_command(args),
         Some("cursor-hook") => run_cursor_hook(),
         Some("hook-check") => run_hook_check(args),

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,6 +24,7 @@ pub(crate) fn usage_text() -> &'static str {
   omamori audit verify                                    # Verify hash chain integrity
   omamori audit show [--last N] [--json] [--all]          # View audit log entries
   omamori doctor [--fix] [--verbose] [--json]             # Diagnose and repair installation
+  omamori report [--last <duration>] [--json] [--verbose] # Aggregate audit summary (e.g. --last 7d)
   omamori explain [--json] [--config PATH] -- <cmd...>   # Explain what would happen to a command
   omamori status [--refresh]                              # Health check all defense layers
   omamori override disable <rule>                        # Override a core safety rule


### PR DESCRIPTION
## Summary

- Add `omamori report` subcommand for audit log aggregation (#221)
- Fix critical bug in `aggregate_events`: action string mismatch ("deny" → "block") that caused report to always show 0 blocks on real data
- Fix `classify_layer` prefix matching to prevent false classification of "layer20" etc. as "layer2"
- Add docs for PR 1-3: README CLI reference, SECURITY.md report section, ACCEPTANCE_TEST.md (D-5/D-6/D-7 + Rep-1~Rep-8)

## Changes

### New: `omamori report` subcommand (`src/cli/report.rs`)
- `--last <duration>`: 1d–90d range, case-insensitive (SEC-R4)
- `--json`: 7-field JSON output (SEC-R2)
- `--verbose`: adds chain break sequence detail
- No AI environment guard (SEC-R3, precedent with `audit show`)
- 11 unit tests

### Bug fixes (`src/audit/report.rs`)
- **Action string mismatch**: `event.action == "deny"` → `"block"` — audit writer uses "block" (both Layer 1 `ActionKind::Block` and Layer 2 `hook.rs`), so report was counting 0 blocks on real audit data
- **classify_layer prefix**: `starts_with("layer2")` → `dl == "layer2" || dl.starts_with("layer2:")` — prevents "layer20", "layer2evil" from being classified as "layer2"
- 5 new regression tests for blind spots found in adversarial test review

### Docs
- README: CLI reference entry for `omamori report`
- SECURITY.md: "Report Read Access (v0.10.0+)" section
- ACCEPTANCE_TEST.md: D-5/D-6/D-7 (doctor trust dashboard) + Rep-1~Rep-8 (report)

## Security requirements verification

| SEC-R | Requirement | Verification |
|-------|-------------|-------------|
| SEC-R1 | by_provider aggregation | `test_empty_provider_mapped_to_none` |
| SEC-R2 | 7-field JSON | `json_output_has_seven_fields`, `json_output_empty_report` |
| SEC-R3 | No AI guard | No guard call in `run_report_command` |
| SEC-R4 | 1d–90d duration | `parse_duration_*` tests (14 cases) |
| SEC-R7 | Unknown count only | `test_unknown_tool_fail_open_isolation` |
| SEC-R8 | 3-state chain, no at_seq in JSON | `json_chain_status_serialization` |
| SEC-R10 | open_read_nofollow | Used in `aggregate_events` |
| SEC-R11 | Shared reader with verify_chain | Both use `open_read_nofollow` |

## Test plan

- [x] 20 report-specific tests pass (cli::report 11 + audit::report 9)
- [x] Full suite: 703 lib + 26 integration tests pass
- [x] `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Codex R1 exhaustive review → R2 Approve
- [x] Codex 6-B test adversarial → 5 blind spots addressed
- [x] QA verification: 24 V-IDs tracked, GO judgment

## Codex review

- **R1**: P0 fmt fix (auto), P1-1 chain hidden in non-verbose (fixed), P3-1 "deny"→"block" bug (fixed), P2/P3 minor
- **R2**: Approve. Rep-3 fenced block alignment re-fix.
- **6-B**: FAIL → 5 blind spots addressed (action regression, provider empty, unknown isolation, window boundary, classify_layer prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
