### PR TITLE
chore: release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.10.1] - 2026-05-05
+
+**Summary**: PATH bypass closure + defense boundary matrix. Layer 2 hook now detects PATH-override patterns (`PATH=/usr/bin:$PATH rm`, `env PATH=/usr/bin rm`, and GNU env grammar variants) that bypass the Layer 1 shim ([#227](https://github.com/yottayoshida/omamori/issues/227)). README reframed from feature catalog to bounded-guarantee style with verifiable claims table and deterministic-guard positioning. SECURITY.md gains a Defense Boundary Matrix (caught / not caught by design / structural limit) and a known-bypass-becomes-row maintenance rule. New RELEASE.md codifies the three-tier release gate (patch / security / v1.0).
+
+### Added
+
+- **`detect_path_shim_bypass()`** in `src/engine/hook.rs` ([#227](https://github.com/yottayoshida/omamori/issues/227)). Phase 1B detection for two categories: (1) inline `PATH=` assignment followed by a `SHIM_COMMANDS` member, (2) `env` grammar variants (`env`, `env -i`, `env -u`, `env --`, `/usr/bin/env`) with `PATH=` override targeting shimmed commands. Uses `installer::SHIM_COMMANDS` as single source of truth. Returns `BlockMeta("path_shim_bypass")`.
+- **Defense Boundary Matrix** in SECURITY.md. Three-category table: Caught (13 surfaces with layer coverage), Not caught by design (2 surfaces), Not caught structural limit (5 surfaces). Each row maps attack surface → layer coverage → verification method.
+- **Known-bypass-becomes-row rule** in SECURITY.md. Every new bypass must produce a matrix row, a `hook_integration.rs` corpus entry, and a Known Limitations entry.
+- **RELEASE.md**. Three-tier release gate model: patch (CI gates), security-affecting (bypass corpus + matrix + live path), v1.0 (full live-path acceptance).
+- 17 unit tests and 8 integration test cases for PATH override detection.
+
+### Changed
+
+- **README.md** reframed as verifiable deterministic guard ([#222](https://github.com/yottayoshida/omamori/issues/222)). "Guarantees" → "Verifiable Claims" with each claim mapped to a verification command. Position statement: "deterministic semantic guard — no model calls, no daemon, no network dependency." Capability paragraphs consolidated into Defense Layers table. Tool Compatibility restructured as per-tool matrix. "Real-world Effect" → "Field Notes."
+- **ACCEPTANCE_TEST.md** T-3' updated to reference `detect_path_shim_bypass()` closure.
+- **SECURITY.md** Hook Coverage table: PATH override bypass row added. Known Limitations section A: v0.10.1 closure row added. Operator reading-path updated to include Defense Boundary Matrix.
+
+### Fixed
+
+- **PATH override shim bypass** ([#227](https://github.com/yottayoshida/omamori/issues/227)). `PATH=/usr/bin:$PATH rm dummy.txt` previously bypassed Layer 1 shim and was not detected by Layer 2 hook. Now blocked as `BlockMeta("path_shim_bypass")`. Acceptance test T-3' now PASS.
+
+### References
+
+- [#229](https://github.com/yottayoshida/omamori/pull/229) — `fix(hook): detect PATH override that bypasses shim protection`. Closes [#227](https://github.com/yottayoshida/omamori/issues/227).
+- [#231](https://github.com/yottayoshida/omamori/pull/231) — `docs(readme): reframe as verifiable deterministic guard (#222 part 1)`.
+- [#232](https://github.com/yottayoshida/omamori/pull/232) — `docs(security): add Defense Boundary Matrix (#222 part 2)`.
+- [#233](https://github.com/yottayoshida/omamori/pull/233) — `docs: add RELEASE.md + update ACCEPTANCE_TEST.md T-3'`. Closes [#222](https://github.com/yottayoshida/omamori/issues/222).
+- [#230](https://github.com/yottayoshida/omamori/pull/230) — `ci(fuzz): pin nightly to 2026-05-03`.
+
 ## [0.10.0] - 2026-05-04
 
 **Summary**: Verifiability release — `omamori report` audit aggregation subcommand ([#221](https://github.com/yottayoshida/omamori/issues/221)) and `omamori doctor` trust dashboard restructure ([#220](https://github.com/yottayoshida/omamori/issues/220)). The report subcommand surfaces block counts by layer/provider, unknown-tool fail-open counts, and hash-chain integrity status over a configurable time window (1d–90d). The doctor command is restructured from a flat checklist into a 4-section trust dashboard (Layer 1 → Layer 2 → Integrity → Recent risk signals) with a top-line `Protection status: OK / WARN / FAIL` verdict and a new `--json` summary block for programmatic consumption. Together these close the verifiability gap: users can now answer "is omamori working?" (doctor) and "what has omamori done?" (report) without reading raw audit logs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -97,9 +97,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -474,12 +474,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -495,16 +495,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -550,9 +552,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -590,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "criterion",
  "hmac",
@@ -1173,9 +1175,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "trash"
-version = "5.2.5"
+version = "5.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b93a14fcf658568eb11b3ac4cb406822e916e2c55cdebc421beeb0bd7c94d8"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
 dependencies = [
  "chrono",
  "libc",
@@ -1191,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -1264,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1277,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1287,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1300,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -1343,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"


### PR DESCRIPTION
## Summary

- Bump version 0.10.0 → 0.10.1
- CHANGELOG entry for v0.10.1

Release subtitle: **v0.10.1 — PATH bypass closure + defense boundary matrix**

### Included PRs

| PR | Content |
|----|---------|
| #229 | PATH override bypass fix (#227) |
| #230 | Fuzz CI nightly pin |
| #231 | README verifiable claims reframe (#222 part 1) |
| #232 | SECURITY.md defense boundary matrix (#222 part 2) |
| #233 | RELEASE.md + ACCEPTANCE_TEST.md (#222 part 3) |

## Test plan

- [ ] CI all green
- [ ] `cargo publish --dry-run --locked` pass
- [ ] Version in Cargo.toml matches tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)