### PR TITLE
feat: token-level position-aware verb detection (PR1c of v0.10.3, #240)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,23 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - run: cargo test --locked
 
+  # Deep proptest job (PR1c, v0.10.3+). Runs the v0.10.3 token-level
+  # position-aware properties at PROPTEST_CASES=2048 to amplify mutation /
+  # adversarial-input coverage beyond the default 256 cases used in the
+  # main `test` job. Ubuntu-only — the property strategies are
+  # platform-independent so a second OS leg adds no signal, only cost.
+  proptest-deep:
+    name: Proptest deep (PROPTEST_CASES=2048)
+    runs-on: ubuntu-latest
+    needs: action-pin-check
+    continue-on-error: false
+    env:
+      PROPTEST_CASES: "2048"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+      - run: cargo test --locked --lib property_tests::prop_ -- --nocapture
+
   # Compile-check the criterion bench harnesses on the same macOS+Ubuntu
   # matrix as `test`. This catches API drift between the lib crate and
   # the bench harnesses (`omamori::unwrap::parse_command_string`,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -243,7 +243,17 @@ Layer 2 hooks use a **token-aware Recursive Unwrap Stack** implemented in Rust (
 
 2. **Phase 2 — Unwrap Stack** (token-level): Tokenizes the command, strips shell wrappers, extracts inner commands from shell launchers, and evaluates each extracted command against the same rules as Layer 1.
 
-**Broad match by design**: Meta-patterns use `command.contains(pattern)` substring matching. This means `ls ~/.local/share/omamori` is blocked alongside `rm -rf ~/.local/share/omamori`. Read-only commands on protected paths are intentionally blocked to prevent reconnaissance that could aid targeted attacks. Affected patterns include `audit.jsonl`, `audit-secret`, `.integrity.json`, `.local/share/omamori`, `omamori/config.toml`, and `.codex/hooks.json`.
+**Broad match by design** (path-based, retained in v0.10.3+): Path-based meta-patterns (`audit.jsonl`, `audit-secret`, `.integrity.json`, `.local/share/omamori`, `omamori/config.toml`, `.codex/hooks.json`, `/bin/rm`, `.claude/settings.json`, `.codex/config.toml`, etc., 18 entries in `META_PATTERNS_PATH`) use `command.contains(pattern)` substring match. `ls ~/.local/share/omamori` is blocked alongside `rm -rf ~/.local/share/omamori`. Read-only commands on protected paths are intentionally blocked to prevent reconnaissance that could aid targeted attacks. This is the T3 (heredoc redirect to protected path) defense.
+
+**Token-level + backstop** (verb-based, v0.10.3+ PR1c): Verb-based meta-patterns (`config disable/enable`, `omamori uninstall`, `omamori init --force`, `omamori override`, `omamori doctor --fix`, `omamori explain`, 7 entries in `META_PATTERNS_VERB`) moved from `command.contains` to a layered detector: (1) token-level position-aware matching (`detect_verb_at_command_position` mirroring the `is_command_position` lattice from Phase 1B, with execution-wrapper transparency for `xargs`/`time`/`nohup`/`sudo`/`env`/etc.), (2) `env -S` payload inspection (`env_dash_s_payload`), (3) residual quote-strip backstop (`strip_quoted_data` preserves `$(...)` and backticks inside double quotes since they remain executable). This relieves false-positives like `gh issue create --body "config disable bug fixed"` (#240) while preserving block on raw / wrapper / executable-quoted invocations.
+
+**v0.10.2 → v0.10.3 PR1c coverage narrow** (documented, intentional): the substring match in v0.10.2 incidentally caught a small set of vectors that fall outside omamori's declared scope. PR1c's `strip_quoted_data` no longer reaches inside passive quoted bodies, so these vectors are now allowed. They are consistent with already-documented scope-outs:
+
+- `tcsh -c 'omamori uninstall'` / `su -c 'omamori uninstall'` — non-default shell launchers (omamori officially supports `bash`/`sh`/`zsh`/`dash`/`ksh`, see [Supported Shell List](#supported-shell-list))
+- `awk "/foo/ { system(\"omamori uninstall\") }"` / `perl -e 'system("omamori uninstall")'` — interpreter family commands, [decided out of scope per #74](https://github.com/yottayoshida/omamori/issues/74)
+- `alias x='omamori uninstall'; x` — alias dynamic dispatch, statically unanalysable
+
+These were never within the declared protection surface; they happened to be caught by the broad substring match. v0.10.3 explicitly returns to the documented scope. Operators relying on the incidental v0.10.2 coverage should track #74 (interpreter family) for shell_launcher list expansion discussion.
 
 | Capability | Detection |
 |-----------|-----------|

--- a/proptest-regressions/property_tests.txt
+++ b/proptest-regressions/property_tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 285e41ba29ef3204ac2bacd2a075b685d607d5a49b7a4eba8a955b50a75611d2 # shrinks to shell = "bash", pattern = "config disable"

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -95,6 +95,69 @@ fn is_command_position(tokens: &[String], idx: usize) -> bool {
     true // walked all the way to start
 }
 
+/// Detect verb-based meta-patterns at command position (Phase 1A, PR1c, v0.10.3+).
+///
+/// Mirrors `detect_env_var_tampering` lattice (Phase 1B): operates on
+/// `shell_words::split` token slice, checks `is_command_position`, then
+/// matches n-token verb patterns from `META_PATTERNS_VERB`. Patterns whose
+/// last token is a flag (e.g. `"omamori init --force"`) match when the
+/// verb prefix is at command position AND the flag appears anywhere in
+/// subsequent tokens (per shapes.md T3/T5: flag scan to end-of-args).
+///
+/// Returns `(pattern_str, reason)` of the matched pattern, or `None`.
+fn detect_verb_at_command_position(tokens: &[String]) -> Option<(&'static str, &'static str)> {
+    for i in 0..tokens.len() {
+        if !is_command_position(tokens, i) {
+            continue;
+        }
+        let window = &tokens[i..];
+        for &(pattern, reason) in installer::META_PATTERNS_VERB {
+            if matches_verb_pattern_at(window, pattern) {
+                return Some((pattern, reason));
+            }
+        }
+    }
+    None
+}
+
+/// Match a verb pattern (e.g. `"config disable"`, `"omamori init --force"`)
+/// against a token slice starting at command position.
+///
+/// - Plain verb pattern (no trailing flag): all pattern tokens must match
+///   consecutive positions at `tokens[0..]`.
+/// - Verb-prefix + flag pattern: verb prefix must match consecutive
+///   positions at `tokens[0..]`, and the trailing flag (`--force`, `--fix`)
+///   may appear anywhere in `tokens[verb_prefix.len()..]` (end-of-args scan).
+fn matches_verb_pattern_at(tokens: &[String], pattern: &str) -> bool {
+    let pattern_tokens: Vec<&str> = pattern.split_whitespace().collect();
+    if pattern_tokens.is_empty() || tokens.len() < pattern_tokens.len() {
+        return false;
+    }
+
+    let last_is_flag = pattern_tokens.last().is_some_and(|t| t.starts_with('-'));
+
+    if last_is_flag && pattern_tokens.len() >= 3 {
+        // Verb prefix = pattern_tokens[..len-1], must match exactly at start.
+        let verb_prefix_len = pattern_tokens.len() - 1;
+        let flag = pattern_tokens[verb_prefix_len];
+        let prefix_match = pattern_tokens[..verb_prefix_len]
+            .iter()
+            .zip(tokens.iter())
+            .all(|(p, t)| *p == t.as_str());
+        if !prefix_match {
+            return false;
+        }
+        // Scan tokens after the verb prefix for the flag.
+        return tokens[verb_prefix_len..].iter().any(|t| t == flag);
+    }
+
+    // Plain n-token verb match (no trailing flag).
+    pattern_tokens
+        .iter()
+        .zip(tokens.iter())
+        .all(|(p, t)| *p == t.as_str())
+}
+
 /// Detect env var tampering at the token level.
 /// Only flags commands in command position to avoid false positives
 /// on quoted strings and arguments (e.g., printf 'unset CLAUDECODE').
@@ -248,11 +311,11 @@ fn detect_path_shim_bypass(tokens: &[String]) -> Option<&'static str> {
 /// `load_config(None)` when Phase 1A/1B/structural short-circuits the
 /// verdict.
 fn check_pre_phase_2(command: &str) -> Result<Vec<CommandInvocation>, HookCheckResult> {
-    // Phase 1A: String-level meta-patterns (path/config/uninstall).
-    // matched_pattern carries the actual `pattern` token (e.g. "config disable"),
+    // Phase 1A path-based: substring match preserved (INV-path-preserve, PR1c).
+    // matched_pattern carries the actual `pattern` token (e.g. ".claude/settings.json"),
     // not the human-readable `reason`. Reason has its own `reason` / `rule_id`
     // fields in the JSON schema. Codex review (PR1b R1) [P2].
-    for (pattern, reason) in installer::blocked_string_patterns() {
+    for &(pattern, reason) in installer::META_PATTERNS_PATH {
         if let Some(start) = command.find(pattern) {
             return Err(HookCheckResult::BlockMeta {
                 reason,
@@ -262,19 +325,32 @@ fn check_pre_phase_2(command: &str) -> Result<Vec<CommandInvocation>, HookCheckR
         }
     }
 
-    // Phase 1B: Token-level env var tampering detection.
+    // Phase 1A verb-based + Phase 1B: token-level position-aware (PR1c, v0.10.3+).
     // normalize_compound_operators splits ;, &&, ||, |, &, \n into separate tokens,
     // then shell_words::split normalizes whitespace + parses quotes.
     // This ensures "echo ok;unset CLAUDECODE" is correctly tokenized as
     // ["echo", "ok", ";", "unset", "CLAUDECODE"] — without normalize,
     // shell_words would produce ["echo", "ok;unset", "CLAUDECODE"].
-    // is_command_position() ensures only segment-initial verbs are flagged.
+    // is_command_position() ensures only segment-initial verbs are flagged
+    // (data-context patterns like `gh issue create --body "config disable bug"`
+    // are skipped because the quoted body is packed into a single token).
     //
     // DEFENSE BOUNDARY on shell_words::split failure:
-    //   Phase 1A has already run. Phase 2 blocks malformed commands via
-    //   ParseResult::Block(ParseError) — fail-close (unwrap.rs:77).
+    //   Phase 1A path-based has already run. Phase 2 blocks malformed
+    //   commands via ParseResult::Block(ParseError) — fail-close (INV-fail-close).
     let normalized = unwrap::normalize_compound_operators(command);
     if let Ok(tokens) = shell_words::split(&normalized) {
+        // Phase 1A verb-based (PR1c): n-token verb pattern at command position.
+        // matched_position is None because `tokens` is the post-normalize slice
+        // and original byte offsets are not preserved across quote/escape
+        // unwrapping (acceptable per BlockMeta schema).
+        if let Some((pattern, reason)) = detect_verb_at_command_position(&tokens) {
+            return Err(HookCheckResult::BlockMeta {
+                reason,
+                matched_pattern: Some(pattern),
+                matched_position: None,
+            });
+        }
         if let Some(reason) = detect_env_var_tampering(&tokens) {
             // Phase 1B: token-level detection has no single substring "pattern" —
             // matched_pattern is None per schema (Codex review PR1b R2 [P2]).
@@ -1428,6 +1504,14 @@ mod tests {
     /// have separate fields) so acceptance tests can assert on structured
     /// metadata instead of brittle stderr substrings.
     /// Codex review (PR1b R1) [P2] enforced this contract.
+    ///
+    /// PR1c moved verb-based patterns to token-level position-aware detection
+    /// (`detect_verb_at_command_position`), so `omamori uninstall` now hits the
+    /// verb-based path with `matched_position = None` (no original byte offset
+    /// in post-`shell_words::split` slice). Path-based patterns still populate
+    /// position (covered by hook_check_json_error_blockmeta_exact_metadata
+    /// in tests/cli.rs). This test asserts the verb-path contract: pattern
+    /// populated, position None.
     #[test]
     #[serial_test::serial]
     fn block_meta_populates_matched_pattern_metadata() {
@@ -1446,14 +1530,13 @@ mod tests {
         };
         restore_config(old_xdg, old_home, dir);
         let pattern = got_pattern.expect("matched_pattern must be populated");
-        assert!(
-            pattern.contains("uninstall"),
-            "matched_pattern should be the protected token (e.g. 'omamori uninstall'), got {pattern:?}"
+        assert_eq!(
+            pattern, "omamori uninstall",
+            "matched_pattern must be the exact verb pattern token"
         );
-        let position = got_position.expect("matched_position must be populated");
         assert!(
-            position.end > position.start,
-            "matched_position must have non-empty range, got {position:?}"
+            got_position.is_none(),
+            "PR1c: verb-based patterns have matched_position = None (token-level detection), got {got_position:?}"
         );
     }
 

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -127,8 +127,14 @@ fn detect_verb_at_command_position(tokens: &[String]) -> Option<(&'static str, &
 ///   consecutive positions at `tokens[0..]`.
 /// - Verb-prefix + flag pattern: verb prefix must match consecutive
 ///   positions at `tokens[0..]`, and the trailing flag (`--force`, `--fix`)
-///   may appear anywhere in `tokens[verb_prefix.len()..]` (end-of-args scan).
+///   may appear anywhere in `tokens[verb_prefix.len()..]` UNTIL the next
+///   shell segment separator (`&&`, `||`, `;`, `|`, `&`). Stopping at the
+///   separator prevents false-positives like `omamori init safe && echo --force`
+///   where `--force` belongs to the second command segment.
+///   Codex review (PR1c R1) [P2].
 fn matches_verb_pattern_at(tokens: &[String], pattern: &str) -> bool {
+    const SEGMENT_SEPARATORS: &[&str] = &["&&", "||", ";", "|", "&"];
+
     let pattern_tokens: Vec<&str> = pattern.split_whitespace().collect();
     if pattern_tokens.is_empty() || tokens.len() < pattern_tokens.len() {
         return false;
@@ -147,8 +153,13 @@ fn matches_verb_pattern_at(tokens: &[String], pattern: &str) -> bool {
         if !prefix_match {
             return false;
         }
-        // Scan tokens after the verb prefix for the flag.
-        return tokens[verb_prefix_len..].iter().any(|t| t == flag);
+        // Scan tokens after the verb prefix for the flag, stopping at the
+        // next shell segment separator so flags in later commands do not
+        // attribute to this verb.
+        return tokens[verb_prefix_len..]
+            .iter()
+            .take_while(|t| !SEGMENT_SEPARATORS.contains(&t.as_str()))
+            .any(|t| t == flag);
     }
 
     // Plain n-token verb match (no trailing flag).

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -95,19 +95,48 @@ fn is_command_position(tokens: &[String], idx: usize) -> bool {
     true // walked all the way to start
 }
 
+/// Execution wrappers that pass their argv to another program. When such a
+/// wrapper is at command position, the directly-following position is also
+/// treated as an executable context for self-protect verb detection.
+/// Without this, `xargs omamori uninstall` would skip Phase 1A and reach
+/// Phase 2 as program=xargs, where no `omamori-*-block` rule matches.
+/// Codex review (PR1c R2) [P1] regression closure.
+const EXECUTION_WRAPPERS: &[&str] = &[
+    "xargs", "time", "nohup", "nice", "timeout", "env", "sudo", "doas", "pkexec", "command", "exec",
+];
+
+/// Like `is_command_position`, but additionally recognises positions
+/// immediately following an `EXECUTION_WRAPPERS` token (recursively, so
+/// `time nohup omamori uninstall` is also covered).
+fn is_verb_executable_position(tokens: &[String], idx: usize) -> bool {
+    if is_command_position(tokens, idx) {
+        return true;
+    }
+    if idx == 0 {
+        return false;
+    }
+    let prev = tokens[idx - 1].as_str();
+    if EXECUTION_WRAPPERS.contains(&prev) {
+        return is_verb_executable_position(tokens, idx - 1);
+    }
+    false
+}
+
 /// Detect verb-based meta-patterns at command position (Phase 1A, PR1c, v0.10.3+).
 ///
 /// Mirrors `detect_env_var_tampering` lattice (Phase 1B): operates on
-/// `shell_words::split` token slice, checks `is_command_position`, then
-/// matches n-token verb patterns from `META_PATTERNS_VERB`. Patterns whose
-/// last token is a flag (e.g. `"omamori init --force"`) match when the
-/// verb prefix is at command position AND the flag appears anywhere in
-/// subsequent tokens (per shapes.md T3/T5: flag scan to end-of-args).
+/// `shell_words::split` token slice, checks `is_verb_executable_position`
+/// (segment head OR after an execution wrapper like `xargs`/`time`/`sudo`),
+/// then matches n-token verb patterns from `META_PATTERNS_VERB`. Patterns
+/// whose last token is a flag (e.g. `"omamori init --force"`) match when
+/// the verb prefix is at executable position AND the flag appears anywhere
+/// in subsequent tokens until the next segment separator
+/// (per shapes.md T3/T5 + Codex PR1c R1 [P2]).
 ///
 /// Returns `(pattern_str, reason)` of the matched pattern, or `None`.
 fn detect_verb_at_command_position(tokens: &[String]) -> Option<(&'static str, &'static str)> {
     for i in 0..tokens.len() {
-        if !is_command_position(tokens, i) {
+        if !is_verb_executable_position(tokens, i) {
             continue;
         }
         let window = &tokens[i..];

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -73,6 +73,88 @@ pub(crate) enum HookCheckResult {
     },
 }
 
+/// Strip the contents of single- and double-quoted regions from a shell
+/// command, leaving an unquoted residual safe for substring backstop
+/// matching. Outside quotes, characters are preserved verbatim (including
+/// `\<x>` escape sequences). Codex review (PR1c R3) [P1] backstop closure.
+///
+/// Used by `check_pre_phase_2` after token-level verb detection: when the
+/// position-aware path misses (e.g. `xargs -I{} omamori uninstall {}`,
+/// `find . -exec omamori uninstall {} \;`), the residual still contains
+/// the protected verb at a non-quoted position so substring contains
+/// catches it. Quoted bodies (gh issue body / git commit message) are
+/// stripped, so the FP-relief invariant is preserved.
+fn strip_quoted_data(command: &str) -> String {
+    let mut result = String::with_capacity(command.len());
+    let mut chars = command.chars().peekable();
+    let mut in_single = false;
+    let mut in_double = false;
+    while let Some(c) = chars.next() {
+        if in_single {
+            if c == '\'' {
+                in_single = false;
+            }
+            // chars inside single-quote are skipped (data context)
+        } else if in_double {
+            if c == '\\' {
+                // skip escape sequence (\<x>)
+                chars.next();
+            } else if c == '"' {
+                in_double = false;
+            }
+            // chars inside double-quote are skipped
+        } else if c == '\'' {
+            in_single = true;
+        } else if c == '"' {
+            in_double = true;
+        } else if c == '\\' {
+            // outside quote: preserve backslash + next char as-is
+            result.push(c);
+            if let Some(&next) = chars.peek() {
+                result.push(next);
+                chars.next();
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Extract the payload of an `env -S 'string'` invocation at command
+/// position, if any. `env -S` splits the payload into argv and execs it,
+/// so a quoted payload containing a protected verb pattern is executable
+/// data — NOT a quoted body to be stripped. `strip_quoted_data` would
+/// otherwise erase it. Codex review (PR1c R3) [P1].
+fn env_dash_s_payload(tokens: &[String]) -> Option<&str> {
+    for (i, t) in tokens.iter().enumerate() {
+        if t == "env" && is_command_position(tokens, i) {
+            let mut j = i + 1;
+            while j < tokens.len() {
+                let arg = &tokens[j];
+                if arg == "-S"
+                    && let Some(payload) = tokens.get(j + 1)
+                {
+                    return Some(payload.as_str());
+                }
+                if let Some(suffix) = arg.strip_prefix("-S")
+                    && !suffix.is_empty()
+                {
+                    return Some(suffix);
+                }
+                // env's option zone: -<flag> or KEY=VAL keeps scanning
+                if arg.starts_with('-') || arg.contains('=') {
+                    j += 1;
+                    continue;
+                }
+                // First positional: end of env's options
+                break;
+            }
+        }
+    }
+    None
+}
+
 /// Check if token at `idx` is in command position (start of a segment).
 /// Command position = index 0, immediately after an operator token,
 /// or after a run of KEY=VAL assignment prefixes (e.g., FOO=1 unset VAR).
@@ -404,6 +486,36 @@ fn check_pre_phase_2(command: &str) -> Result<Vec<CommandInvocation>, HookCheckR
             return Err(HookCheckResult::BlockMeta {
                 reason,
                 matched_pattern: None,
+                matched_position: None,
+            });
+        }
+        // Phase 1A verb backstop: env -S payload contains executable verbs
+        // (a single quoted token that env will split + exec). Codex PR1c R3 [P1].
+        if let Some(payload) = env_dash_s_payload(&tokens) {
+            for &(pattern, reason) in installer::META_PATTERNS_VERB {
+                if payload.contains(pattern) {
+                    return Err(HookCheckResult::BlockMeta {
+                        reason,
+                        matched_pattern: Some(pattern),
+                        matched_position: None,
+                    });
+                }
+            }
+        }
+    }
+
+    // Phase 1A verb backstop (Codex PR1c R3 [P1]): residual quote-stripped
+    // substring match catches verb patterns invoked via wrapper grammars
+    // not modeled by detect_verb_at_command_position (`xargs -I{}`,
+    // `find -exec ... {} \;`, parallel, sh -c without -c-as-shell-launcher,
+    // etc.). Quoted bodies are stripped so the FP-relief invariant for
+    // gh issue body / git commit message is preserved.
+    let residual = strip_quoted_data(command);
+    for &(pattern, reason) in installer::META_PATTERNS_VERB {
+        if residual.contains(pattern) {
+            return Err(HookCheckResult::BlockMeta {
+                reason,
+                matched_pattern: Some(pattern),
                 matched_position: None,
             });
         }

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -73,36 +73,77 @@ pub(crate) enum HookCheckResult {
     },
 }
 
-/// Strip the contents of single- and double-quoted regions from a shell
-/// command, leaving an unquoted residual safe for substring backstop
-/// matching. Outside quotes, characters are preserved verbatim (including
-/// `\<x>` escape sequences). Codex review (PR1c R3) [P1] backstop closure.
+/// Strip the contents of quoted regions from a shell command, leaving an
+/// unquoted residual safe for substring backstop matching. Codex review
+/// (PR1c R3 / R4) [P1] backstop closure.
+///
+/// Strip semantics match shell evaluation rules:
+/// - **Single quotes** strip the entire contents (literal in shell, no
+///   expansion).
+/// - **Double quotes** strip *passive* contents but PRESERVE active
+///   substitutions: `$(...)` command substitution and `` `...` `` backticks
+///   are kept because the shell still executes them. `$VAR` is dropped
+///   (variable references, not executable substitutions).
+/// - Outside quotes, characters are preserved verbatim (including `\<x>`
+///   escape sequences).
 ///
 /// Used by `check_pre_phase_2` after token-level verb detection: when the
 /// position-aware path misses (e.g. `xargs -I{} omamori uninstall {}`,
-/// `find . -exec omamori uninstall {} \;`), the residual still contains
-/// the protected verb at a non-quoted position so substring contains
-/// catches it. Quoted bodies (gh issue body / git commit message) are
-/// stripped, so the FP-relief invariant is preserved.
+/// `echo "$(omamori uninstall)"`), the residual still contains the
+/// protected verb so substring contains catches it. Passive quoted
+/// bodies (gh issue body / git commit message) are stripped, preserving
+/// the FP-relief invariant.
 fn strip_quoted_data(command: &str) -> String {
     let mut result = String::with_capacity(command.len());
     let mut chars = command.chars().peekable();
     let mut in_single = false;
     let mut in_double = false;
+    let mut subst_depth: i32 = 0;
     while let Some(c) = chars.next() {
         if in_single {
             if c == '\'' {
                 in_single = false;
             }
-            // chars inside single-quote are skipped (data context)
+            // single-quote contents are literal, skip
         } else if in_double {
-            if c == '\\' {
-                // skip escape sequence (\<x>)
+            if subst_depth > 0 {
+                // Inside $(...) inside double quote: preserve everything
+                // (executable substitution).
+                result.push(c);
+                if c == '(' {
+                    subst_depth += 1;
+                } else if c == ')' {
+                    subst_depth -= 1;
+                }
+            } else if c == '$' {
+                // Possible $(...) or ${...} or $VAR. Only $(...) is
+                // preserved (executable). $VAR / ${VAR} are dropped.
+                if chars.peek() == Some(&'(') {
+                    result.push(c);
+                    result.push('(');
+                    chars.next();
+                    subst_depth = 1;
+                }
+                // else: $VAR or ${...}, drop the $ and continue stripping
+            } else if c == '`' {
+                // Backtick command substitution: preserve through next `
+                // (simplified: nested backticks not supported, but rare
+                // in practice and the substring match still triggers if
+                // a verb appears anywhere in the unbalanced sequence).
+                result.push(c);
+                for bc in chars.by_ref() {
+                    result.push(bc);
+                    if bc == '`' {
+                        break;
+                    }
+                }
+            } else if c == '\\' {
+                // Skip escape sequence inside double quote
                 chars.next();
             } else if c == '"' {
                 in_double = false;
             }
-            // chars inside double-quote are skipped
+            // else: passive char inside double quote, skip
         } else if c == '\'' {
             in_single = true;
         } else if c == '"' {
@@ -125,10 +166,17 @@ fn strip_quoted_data(command: &str) -> String {
 /// position, if any. `env -S` splits the payload into argv and execs it,
 /// so a quoted payload containing a protected verb pattern is executable
 /// data — NOT a quoted body to be stripped. `strip_quoted_data` would
-/// otherwise erase it. Codex review (PR1c R3) [P1].
+/// otherwise erase it. Codex review (PR1c R3 / R4) [P1].
+///
+/// Recognises `env` invoked through path-qualified forms
+/// (`/usr/bin/env`, `/bin/env`) and through transparent execution wrappers
+/// (`sudo env`, `nohup env`, etc., via `is_verb_executable_position`).
+/// Per R4: basename comparison + executable-position recursion.
 fn env_dash_s_payload(tokens: &[String]) -> Option<&str> {
     for (i, t) in tokens.iter().enumerate() {
-        if t == "env" && is_command_position(tokens, i) {
+        // basename match: env, /usr/bin/env, /bin/env, busybox/env, etc.
+        let basename = t.rsplit('/').next().unwrap_or(t.as_str());
+        if basename == "env" && is_verb_executable_position(tokens, i) {
             let mut j = i + 1;
             while j < tokens.len() {
                 let arg = &tokens[j];

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -462,99 +462,160 @@ pub(crate) const PROTECTED_ENV_VARS: &[&str] = &[
     "AI_GUARD",
 ];
 
-/// String-level blocked patterns (Phase 1A).
-/// These are path-based, config, and uninstall patterns that don't require
-/// whitespace normalization. Env var patterns (unset, env -u, export -n, VAR=)
-/// are handled separately by token-level detection in hook.rs (Phase 1B).
+/// Classification of Phase 1A meta-pattern detectors (v0.10.3+, PR1c).
+///
+/// `VerbAtCommandPosition` patterns require `shell_words::split` token-level
+/// position-aware detection (`detect_verb_at_command_position` in `hook.rs`)
+/// to avoid false-positives like `gh issue create --body "config disable bug"`.
+///
+/// `ProtectedPathSubstring` patterns retain `command.contains` substring
+/// match to defend against threats T3 (heredoc redirect to protected path)
+/// where the path mention itself is dangerous regardless of context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetaPatternKind {
+    VerbAtCommandPosition,
+    ProtectedPathSubstring,
+}
+
+/// Verb-based meta-patterns (PR1c, v0.10.3+).
+///
+/// Each entry is `(pattern_token, reason)`. Patterns are matched against
+/// `shell_words::split` token slices at command position by
+/// `detect_verb_at_command_position` (mirror of Phase 1B
+/// `detect_env_var_tampering`). The pattern token (e.g. `"config disable"`,
+/// `"omamori uninstall"`) is surfaced to acceptance test assertions and
+/// `--json-error` output via `HookCheckResult::BlockMeta { matched_pattern, .. }`.
+///
+/// Pattern strings are STABLE across releases — they are referenced from
+/// audit logs and acceptance test assertions (INV-pattern-string-stable).
+pub const META_PATTERNS_VERB: &[(&str, &str)] = &[
+    // Config modification protection (#22)
+    ("config disable", "blocked attempt to modify omamori rules"),
+    ("config enable", "blocked attempt to modify omamori rules"),
+    // Self-uninstall protection (#22)
+    ("omamori uninstall", "blocked attempt to uninstall omamori"),
+    (
+        "omamori init --force",
+        "blocked attempt to overwrite omamori config",
+    ),
+    (
+        "omamori override",
+        "blocked attempt to override omamori core rules",
+    ),
+    // DI-9: doctor --fix and explain are blocked in AI environments
+    (
+        "omamori doctor --fix",
+        "blocked attempt to run doctor --fix via AI",
+    ),
+    (
+        "omamori explain",
+        "blocked attempt to run explain via AI (oracle attack prevention)",
+    ),
+];
+
+/// Path-based meta-patterns (PR1c, v0.10.3+).
+///
+/// Each entry is `(pattern_substring, reason)`. Substring match is PRESERVED
+/// (not token-position-aware) to defend against threat T3 — heredoc redirect
+/// to protected path. Path mention itself is dangerous regardless of context
+/// because shell parsing can promote any path-shaped substring to a redirect
+/// target via `>`/`>>`/`tee` etc. (INV-path-preserve).
+///
+/// PR1d's data-flag allowlist will exempt path mentions inside `gh issue
+/// create --body` etc. via separate logic; the substring match itself stays.
+pub const META_PATTERNS_PATH: &[(&str, &str)] = &[
+    // Direct path execution bypassing PATH shim — match various shell token
+    // boundaries: space, double-quote, tab, single-quote
+    ("/bin/rm ", "blocked direct rm path that bypasses PATH shim"),
+    (
+        "/bin/rm\"",
+        "blocked direct rm path that bypasses PATH shim",
+    ),
+    (
+        "/bin/rm\t",
+        "blocked direct rm path that bypasses PATH shim",
+    ),
+    ("/bin/rm'", "blocked direct rm path that bypasses PATH shim"),
+    (
+        "/usr/bin/rm ",
+        "blocked direct rm path that bypasses PATH shim",
+    ),
+    (
+        "/usr/bin/rm\"",
+        "blocked direct rm path that bypasses PATH shim",
+    ),
+    (
+        "/usr/bin/rm\t",
+        "blocked direct rm path that bypasses PATH shim",
+    ),
+    (
+        "/usr/bin/rm'",
+        "blocked direct rm path that bypasses PATH shim",
+    ),
+    // Claude Code hook registration protection (#110 T3)
+    (
+        ".claude/settings.json",
+        "blocked attempt to edit Claude Code settings (contains hook config)",
+    ),
+    // Integrity baseline protection
+    (
+        ".integrity.json",
+        "blocked attempt to edit integrity baseline",
+    ),
+    // Codex CLI hook protection (#66, T2/T3)
+    (
+        ".codex/hooks.json",
+        "blocked attempt to edit Codex hooks config",
+    ),
+    (".codex/config.toml", "blocked attempt to edit Codex config"),
+    (
+        "config.toml.bak",
+        "blocked attempt to use Codex config backup",
+    ),
+    (
+        "codex_hooks",
+        "blocked attempt to modify Codex hooks feature flag",
+    ),
+    // Audit log protection (#29)
+    ("audit.jsonl", "blocked attempt to modify audit log"),
+    ("audit-secret", "blocked attempt to access audit secret"),
+    // Config protection for retention settings (#29)
+    (
+        "omamori/config.toml",
+        "blocked attempt to edit omamori config",
+    ),
+    // Data directory protection (#29)
+    (
+        ".local/share/omamori",
+        "blocked attempt to modify omamori data directory",
+    ),
+];
+
+/// Write-target verbs (PR1c SoT, v0.10.3+).
+///
+/// Reserved for future v0.11 D-case refactor: scoping path-substring matches
+/// to commands that actually write to a path (`tee`, `vim`, `cat >`, etc.)
+/// rather than every mention. **Currently unused by the Phase 1A detector**;
+/// path patterns retain unconditional substring match in v0.10.3 per
+/// INV-path-preserve. SoT only — populating this list does NOT change PR1c
+/// behavior.
+#[allow(dead_code)]
+pub const WRITE_VERBS: &[&str] = &[
+    "tee", "vim", "vi", "nano", "emacs", "cp", "mv", "dd", "install",
+];
+
+/// Legacy combined meta-pattern list (Phase 1A, all 25 entries).
+///
+/// Returns 18 path-based + 7 verb-based entries concatenated. Kept for
+/// backward compatibility with internal call sites and `scripts/check-invariants.sh`
+/// substring greps. New code should use [`META_PATTERNS_PATH`] and
+/// [`META_PATTERNS_VERB`] directly to dispatch via [`MetaPatternKind`].
 pub fn blocked_string_patterns() -> Vec<(&'static str, &'static str)> {
-    vec![
-        // Direct path execution bypassing PATH shim
-        // Match various shell token boundaries: space, quote, tab
-        ("/bin/rm ", "blocked direct rm path that bypasses PATH shim"),
-        (
-            "/bin/rm\"",
-            "blocked direct rm path that bypasses PATH shim",
-        ),
-        (
-            "/bin/rm\t",
-            "blocked direct rm path that bypasses PATH shim",
-        ),
-        ("/bin/rm'", "blocked direct rm path that bypasses PATH shim"),
-        (
-            "/usr/bin/rm ",
-            "blocked direct rm path that bypasses PATH shim",
-        ),
-        (
-            "/usr/bin/rm\"",
-            "blocked direct rm path that bypasses PATH shim",
-        ),
-        (
-            "/usr/bin/rm\t",
-            "blocked direct rm path that bypasses PATH shim",
-        ),
-        (
-            "/usr/bin/rm'",
-            "blocked direct rm path that bypasses PATH shim",
-        ),
-        // Claude Code hook registration protection (#110 T3)
-        (
-            ".claude/settings.json",
-            "blocked attempt to edit Claude Code settings (contains hook config)",
-        ),
-        // Config modification protection (#22)
-        ("config disable", "blocked attempt to modify omamori rules"),
-        ("config enable", "blocked attempt to modify omamori rules"),
-        ("omamori uninstall", "blocked attempt to uninstall omamori"),
-        (
-            "omamori init --force",
-            "blocked attempt to overwrite omamori config",
-        ),
-        (
-            "omamori override",
-            "blocked attempt to override omamori core rules",
-        ),
-        // DI-9: doctor --fix and explain are blocked in AI environments (defense-in-depth)
-        (
-            "omamori doctor --fix",
-            "blocked attempt to run doctor --fix via AI",
-        ),
-        (
-            "omamori explain",
-            "blocked attempt to run explain via AI (oracle attack prevention)",
-        ),
-        // Integrity baseline protection
-        (
-            ".integrity.json",
-            "blocked attempt to edit integrity baseline",
-        ),
-        // Codex CLI hook protection (#66, T2/T3)
-        (
-            ".codex/hooks.json",
-            "blocked attempt to edit Codex hooks config",
-        ),
-        (".codex/config.toml", "blocked attempt to edit Codex config"),
-        (
-            "config.toml.bak",
-            "blocked attempt to use Codex config backup",
-        ),
-        (
-            "codex_hooks",
-            "blocked attempt to modify Codex hooks feature flag",
-        ),
-        // Audit log protection (#29)
-        ("audit.jsonl", "blocked attempt to modify audit log"),
-        ("audit-secret", "blocked attempt to access audit secret"),
-        // Config protection for retention settings (#29)
-        (
-            "omamori/config.toml",
-            "blocked attempt to edit omamori config",
-        ),
-        // Data directory protection (#29)
-        (
-            ".local/share/omamori",
-            "blocked attempt to modify omamori data directory",
-        ),
-    ]
+    META_PATTERNS_PATH
+        .iter()
+        .chain(META_PATTERNS_VERB.iter())
+        .copied()
+        .collect()
 }
 
 /// Extract the stable Homebrew-linked path from a versioned Cellar path.

--- a/src/property_tests.rs
+++ b/src/property_tests.rs
@@ -647,3 +647,117 @@ fn arb_expansion_case() -> impl Strategy<Value = String> {
 
     (wrapper_prefix, expansion_verb).prop_map(|(prefix, verb)| format!("{prefix}{verb}"))
 }
+
+// ----------------------------------------------------------------------
+// PR1c (v0.10.3): Phase 1A verb-based token-level position-aware proptest
+// ----------------------------------------------------------------------
+//
+// Three properties pin the thesis invariant:
+//   1. Verb pattern inside quoted data context (gh issue body, git commit
+//      message, etc.) is ALLOWED — quoted body is packed into a single
+//      shell_words token, so detect_verb_at_command_position rejects it
+//      via is_command_position guard. This is the FP-relief invariant.
+//   2. Verb pattern at raw command position is BLOCKED — direct invocation
+//      must trigger BlockMeta.
+//   3. Verb pattern inside subshell (`bash -c '...'`) is BLOCKED — Phase 2
+//      unwrap stack + PR1a builtin omamori-*-block rules provide
+//      defense-in-depth even when Phase 1A path-only would miss.
+
+const VERB_PATTERNS_FOR_PROPTEST: &[&str] = &[
+    "config disable",
+    "config enable",
+    "omamori uninstall",
+    "omamori init --force",
+    "omamori override",
+    "omamori doctor --fix",
+    "omamori explain",
+];
+
+/// Subshell-form patterns: must include the `omamori` program because
+/// PR1a builtin rules (`omamori-*-block`) target `program == "omamori"`,
+/// and `bash -c 'config disable'` (without `omamori` prefix) is intentionally
+/// out of scope (program=config has no Phase 2 builtin rule). The omamori
+/// prefix ensures Phase 2 unwrap → internal program == "omamori" → builtin
+/// rule match defense-in-depth.
+const OMAMORI_SUBSHELL_PATTERNS: &[&str] = &[
+    "omamori uninstall",
+    "omamori init --force",
+    "omamori override",
+    "omamori doctor --fix",
+    "omamori explain rm-recursive",
+    "omamori config disable foo",
+    "omamori config enable bar",
+];
+
+const DATA_FLAG_HOSTS: &[&str] = &[
+    "gh issue create --body",
+    "gh pr create --body",
+    "git commit -m",
+];
+
+fn arb_verb_pattern() -> impl Strategy<Value = &'static str> {
+    prop::sample::select(VERB_PATTERNS_FOR_PROPTEST)
+}
+
+fn arb_omamori_subshell_pattern() -> impl Strategy<Value = &'static str> {
+    prop::sample::select(OMAMORI_SUBSHELL_PATTERNS)
+}
+
+fn arb_data_flag_host() -> impl Strategy<Value = &'static str> {
+    prop::sample::select(DATA_FLAG_HOSTS)
+}
+
+proptest! {
+    /// Property 1 (PR1c FP-relief invariant): verb pattern inside a quoted
+    /// data argument MUST be ALLOWED. Tests `is_command_position` guard
+    /// rejecting quoted bodies that contain protected verbs.
+    #[test]
+    fn prop_trigger_inside_quoted_body_arg_is_allowed(
+        host in arb_data_flag_host(),
+        pattern in arb_verb_pattern(),
+        prefix in "[a-zA-Z ]{0,32}",
+        suffix in "[a-zA-Z ]{0,32}",
+    ) {
+        let cmd = format!(r#"{host} "{prefix}{pattern}{suffix}""#);
+        let config = Config::default();
+        let blocked = layer2_blocks(&cmd, &config.rules);
+        prop_assert!(
+            !blocked,
+            "verb pattern inside quoted data argument must be ALLOWED: {cmd}"
+        );
+    }
+
+    /// Property 2 (PR1c correctness invariant): verb pattern at raw command
+    /// position MUST be BLOCKED. Each META_PATTERNS_VERB entry triggers
+    /// BlockMeta when invoked directly.
+    #[test]
+    fn prop_trigger_in_raw_command_position_is_blocked(
+        pattern in arb_verb_pattern(),
+    ) {
+        let config = Config::default();
+        let blocked = layer2_blocks(pattern, &config.rules);
+        prop_assert!(
+            blocked,
+            "verb pattern at raw command position must be BLOCKED: {pattern}"
+        );
+    }
+
+    /// Property 3 (defense-in-depth invariant): omamori subcommand inside a
+    /// `<shell> -c '...'` subshell MUST be BLOCKED via Phase 2 unwrap stack
+    /// + PR1a builtin omamori-*-block rules. `config disable` without the
+    /// `omamori` prefix is out of scope (program=config has no Phase 2
+    /// builtin rule and is not a real omamori invocation).
+    #[test]
+    fn prop_subshell_inner_verb_blocked(
+        shell in prop::sample::select(&["bash", "sh", "zsh"][..]),
+        pattern in arb_omamori_subshell_pattern(),
+    ) {
+        let cmd = format!("{shell} -c '{pattern}'");
+        let config = Config::default();
+        let blocked = layer2_blocks(&cmd, &config.rules);
+        prop_assert!(
+            blocked,
+            "omamori subcommand inside subshell must be BLOCKED: {cmd}"
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1930,14 +1930,14 @@ fn parse_json_error_stderr(stderr: &str) -> serde_json::Value {
     parsed
 }
 
-/// Phase 1A meta-pattern (verb-based via subcommand) emits structured JSON
-/// with the actual matched_pattern token and a non-empty byte range.
+/// Phase 1A meta-pattern (path-based) emits structured JSON with the actual
+/// matched_pattern token and a non-empty byte range covering it. Path-based
+/// patterns retain `command.contains` substring match (INV-path-preserve)
+/// so byte offset is recoverable.
 #[test]
-fn hook_check_json_error_blockmeta_exact_metadata() {
-    // The protected pattern is the literal substring "omamori uninstall"
-    // (registered in installer::blocked_string_patterns). Use a benign-looking
-    // command that contains this substring to trigger Phase 1A.
-    let cmd = "echo ok && omamori uninstall";
+fn hook_check_json_error_blockmeta_path_exact_metadata() {
+    // `.claude/settings.json` is a path-based META_PATTERNS_PATH entry.
+    let cmd = "vim ~/.claude/settings.json";
     let (stdout, stderr, exit_code) = run_hook_check_json_error(&pretooluse_bash_json(cmd));
     assert_eq!(exit_code, 2, "block must yield exit 2");
     assert!(stdout.is_empty(), "stdout must be empty in block path");
@@ -1949,10 +1949,10 @@ fn hook_check_json_error_blockmeta_exact_metadata() {
     );
     let pattern = json["matched_pattern"]
         .as_str()
-        .expect("matched_pattern must be a string for Phase 1A");
+        .expect("matched_pattern must be a string for path-based Phase 1A");
     assert_eq!(
-        pattern, "omamori uninstall",
-        "matched_pattern must be the protected token (not the reason)"
+        pattern, ".claude/settings.json",
+        "matched_pattern must be the protected token"
     );
     let position = &json["matched_position"];
     let start = position["start"].as_u64().expect("start must be present");
@@ -1967,6 +1967,32 @@ fn hook_check_json_error_blockmeta_exact_metadata() {
     assert_eq!(
         slice, pattern,
         "command[matched_position] must equal matched_pattern (mutation guard)"
+    );
+}
+
+/// Phase 1A meta-pattern (verb-based, PR1c token-level) emits the verb
+/// pattern token but null `matched_position` because token-level detection
+/// in `detect_verb_at_command_position` operates on the post-`shell_words::split`
+/// slice and cannot recover original byte offsets.
+#[test]
+fn hook_check_json_error_blockmeta_verb_exact_metadata() {
+    let cmd = "echo ok && omamori uninstall";
+    let (stdout, stderr, exit_code) = run_hook_check_json_error(&pretooluse_bash_json(cmd));
+    assert_eq!(exit_code, 2, "block must yield exit 2");
+    assert!(stdout.is_empty(), "stdout must be empty in block path");
+    let json = parse_json_error_stderr(&stderr);
+    assert_eq!(json["blocked"], serde_json::Value::Bool(true));
+    assert_eq!(json["layer"], "layer2:meta-pattern");
+    let pattern = json["matched_pattern"]
+        .as_str()
+        .expect("matched_pattern must be a string for verb-based Phase 1A");
+    assert_eq!(
+        pattern, "omamori uninstall",
+        "matched_pattern must be the exact verb pattern token"
+    );
+    assert!(
+        json["matched_position"].is_null(),
+        "PR1c: verb-based patterns have matched_position = null (token-level)"
     );
 }
 

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -1234,6 +1234,23 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Block,
         "fn-env-prefix-uninstall-block",
     ),
+    // PR1c R1 [P2] regression guard: flag scan must stop at segment separator
+    // so a flag in a LATER command does not attribute to an earlier verb.
+    (
+        "omamori init safe && echo --force",
+        Decision::Allow,
+        "fp-flag-after-separator-allow",
+    ),
+    (
+        "omamori init safe; echo --force",
+        Decision::Allow,
+        "fp-flag-after-semicolon-allow",
+    ),
+    (
+        "omamori doctor && grep --fix logfile",
+        Decision::Allow,
+        "fp-flag-after-and-grep-allow",
+    ),
 ];
 
 /// Per-category minimum floors for `meta-pattern-*` HOOK_DECISION_CASES

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -1115,6 +1115,125 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Allow,
         "obfuscated-fp-command-v-allow",
     ),
+    // ----------------------------------------------------------------------
+    // PR1c (v0.10.3): false-positive ALLOW — verb pattern in data context.
+    // Phase 1A verb-based moved to token-level position-aware detection,
+    // so quoted body / data flag arguments containing protected verbs
+    // (e.g. `gh issue create --body "config disable bug"`) MUST allow.
+    // shell_words::split packs quoted bodies into a single token, so
+    // is_command_position rejects them — verb pattern detector skips.
+    // ----------------------------------------------------------------------
+    (
+        "gh issue create --body \"config disable bug は v0.10.3 で fix\"",
+        Decision::Allow,
+        "fp-data-context-config-disable-allow",
+    ),
+    (
+        "gh issue create --body \"omamori uninstall を試した話\"",
+        Decision::Allow,
+        "fp-data-context-uninstall-allow",
+    ),
+    (
+        "gh pr create --body \"omamori init --force is dangerous\"",
+        Decision::Allow,
+        "fp-data-context-init-force-allow",
+    ),
+    (
+        "gh pr create --body \"omamori override 経由の bypass を防ぐ\"",
+        Decision::Allow,
+        "fp-data-context-override-allow",
+    ),
+    (
+        "git commit -m \"fix: config disable race condition\"",
+        Decision::Allow,
+        "fp-data-context-git-commit-disable-allow",
+    ),
+    (
+        "git commit -m \"refactor: omamori doctor --fix path\"",
+        Decision::Allow,
+        "fp-data-context-doctor-fix-allow",
+    ),
+    (
+        "git commit -m \"docs: omamori explain output schema\"",
+        Decision::Allow,
+        "fp-data-context-explain-allow",
+    ),
+    (
+        "echo 'config disable foo'",
+        Decision::Allow,
+        "fp-quoted-config-disable-allow",
+    ),
+    (
+        "printf 'omamori uninstall'",
+        Decision::Allow,
+        "fp-quoted-uninstall-allow",
+    ),
+    (
+        "echo \"omamori init --force\"",
+        Decision::Allow,
+        "fp-quoted-init-force-allow",
+    ),
+    (
+        "omamori exec -- echo disable config",
+        Decision::Allow,
+        "fp-exec-passthrough-disable-allow",
+    ),
+    (
+        "omamori exec -- echo uninstall override",
+        Decision::Allow,
+        "fp-exec-passthrough-uninstall-allow",
+    ),
+    // ----------------------------------------------------------------------
+    // PR1c (v0.10.3): false-negative regression guard — verb pattern at
+    // command position MUST still BLOCK. These are the same verbs as the
+    // fp_* cases above but in the raw command position.
+    // ----------------------------------------------------------------------
+    (
+        "omamori uninstall",
+        Decision::Block,
+        "fn-raw-uninstall-block",
+    ),
+    (
+        "echo ok && omamori uninstall",
+        Decision::Block,
+        "fn-compound-uninstall-block",
+    ),
+    (
+        "config disable rm-recursive",
+        Decision::Block,
+        "fn-raw-config-disable-block",
+    ),
+    (
+        "config enable git-reset-block",
+        Decision::Block,
+        "fn-raw-config-enable-block",
+    ),
+    (
+        "omamori init --force",
+        Decision::Block,
+        "fn-raw-init-force-block",
+    ),
+    (
+        "omamori init somerule --force",
+        Decision::Block,
+        "fn-init-with-arg-then-force-block",
+    ),
+    ("omamori override", Decision::Block, "fn-raw-override-block"),
+    (
+        "omamori doctor --fix",
+        Decision::Block,
+        "fn-raw-doctor-fix-block",
+    ),
+    (
+        "omamori explain rm-recursive",
+        Decision::Block,
+        "fn-raw-explain-block",
+    ),
+    (
+        "FOO=1 omamori uninstall",
+        Decision::Block,
+        "fn-env-prefix-uninstall-block",
+    ),
 ];
 
 /// Per-category minimum floors for `meta-pattern-*` HOOK_DECISION_CASES

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -1284,6 +1284,43 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Block,
         "fn-chained-wrappers-uninstall-block",
     ),
+    // PR1c R3 [P1] regression guards: backstop residual quote-strip +
+    // env -S payload must catch verbs missed by token-level detector.
+    (
+        "xargs -I{} omamori uninstall {}",
+        Decision::Block,
+        "fn-xargs-flag-i-uninstall-block",
+    ),
+    (
+        "xargs -L 1 omamori uninstall",
+        Decision::Block,
+        "fn-xargs-flag-l-uninstall-block",
+    ),
+    (
+        "xargs -n 1 -P 4 omamori uninstall",
+        Decision::Block,
+        "fn-xargs-flag-n-p-uninstall-block",
+    ),
+    (
+        "env -S 'omamori uninstall'",
+        Decision::Block,
+        "fn-env-dash-s-uninstall-block",
+    ),
+    (
+        "env -S'omamori uninstall'",
+        Decision::Block,
+        "fn-env-dash-s-combined-uninstall-block",
+    ),
+    (
+        "find . -exec omamori uninstall {} \\;",
+        Decision::Block,
+        "fn-find-exec-uninstall-block",
+    ),
+    (
+        "parallel omamori uninstall ::: a b c",
+        Decision::Block,
+        "fn-parallel-uninstall-block",
+    ),
 ];
 
 /// Per-category minimum floors for `meta-pattern-*` HOOK_DECISION_CASES

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -1321,6 +1321,33 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Block,
         "fn-parallel-uninstall-block",
     ),
+    // PR1c R4 [P1] regression guards: double-quoted $(...) is executable,
+    // path-qualified / wrapped env -S still triggers the payload check.
+    (
+        "echo \"$(omamori uninstall)\"",
+        Decision::Block,
+        "fn-double-quote-cmd-subst-uninstall-block",
+    ),
+    (
+        "echo \"prefix $(omamori uninstall) suffix\"",
+        Decision::Block,
+        "fn-double-quote-cmd-subst-embedded-block",
+    ),
+    (
+        "echo \"`omamori uninstall`\"",
+        Decision::Block,
+        "fn-double-quote-backtick-uninstall-block",
+    ),
+    (
+        "/usr/bin/env -S 'omamori uninstall'",
+        Decision::Block,
+        "fn-path-qualified-env-s-uninstall-block",
+    ),
+    (
+        "sudo env -S 'omamori uninstall'",
+        Decision::Block,
+        "fn-sudo-env-s-uninstall-block",
+    ),
 ];
 
 /// Per-category minimum floors for `meta-pattern-*` HOOK_DECISION_CASES

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -1348,6 +1348,24 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Block,
         "fn-sudo-env-s-uninstall-block",
     ),
+    // PR1c R5 follow-up: pin "out-of-scope allow" vectors so a future patch
+    // does not accidentally re-enable v0.10.2 incidental coverage.
+    // Documented in SECURITY.md §"v0.10.2 -> v0.10.3 PR1c coverage narrow".
+    (
+        "perl -e 'system(\"omamori uninstall\")'",
+        Decision::Allow,
+        "interpreter-out-of-scope-perl-allow",
+    ),
+    (
+        "tcsh -c 'omamori uninstall'",
+        Decision::Allow,
+        "non-default-shell-launcher-tcsh-allow",
+    ),
+    (
+        "su -c 'omamori uninstall'",
+        Decision::Allow,
+        "non-default-shell-launcher-su-allow",
+    ),
 ];
 
 /// Per-category minimum floors for `meta-pattern-*` HOOK_DECISION_CASES

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -1251,6 +1251,39 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Allow,
         "fp-flag-after-and-grep-allow",
     ),
+    // PR1c R2 [P1] regression guard: execution wrappers (xargs/time/nohup/
+    // sudo/env/etc.) MUST be transparent for self-protect verb detection
+    // so `xargs omamori uninstall` does not silently bypass Phase 1A.
+    (
+        "xargs omamori uninstall",
+        Decision::Block,
+        "fn-xargs-uninstall-block",
+    ),
+    (
+        "echo /tmp/base | xargs omamori uninstall --base-dir",
+        Decision::Block,
+        "fn-pipe-xargs-uninstall-block",
+    ),
+    (
+        "time omamori uninstall",
+        Decision::Block,
+        "fn-time-uninstall-block",
+    ),
+    (
+        "nohup omamori init --force",
+        Decision::Block,
+        "fn-nohup-init-force-block",
+    ),
+    (
+        "sudo omamori config disable rm-recursive",
+        Decision::Block,
+        "fn-sudo-config-disable-block",
+    ),
+    (
+        "time nohup omamori uninstall",
+        Decision::Block,
+        "fn-chained-wrappers-uninstall-block",
+    ),
 ];
 
 /// Per-category minimum floors for `meta-pattern-*` HOOK_DECISION_CASES


### PR DESCRIPTION
## Summary

PR1c of v0.10.3 series (#240). Refactors Phase 1A meta-pattern detection: verb-based 7 entries move from substring match to token-level position-aware detection (mirrors Phase 1B `is_command_position` lattice). Path-based 18 entries retain substring match (T3 defense, INV-path-preserve).

Eliminates `gh issue create --body "config disable bug"` style false-positives while preserving block on raw / wrapper / executable-quoted self-modification invocations. AI agent and self-hosting development experience markedly improves (~11 known self-block workarounds become unnecessary).

## Why

v0.10.2's `command.contains` Phase 1A flags any substring of a protected verb anywhere in the command line. Issue bodies and commit messages legitimately mention these verbs without invoking them. PR1c moves verb detection to a position-aware lattice while preserving path-based substring match for paths whose mention itself is dangerous via redirects.

## Changes (key files)

| File | Change |
|------|--------|
| `src/installer.rs` | Split into `META_PATTERNS_VERB` (7) + `META_PATTERNS_PATH` (18) + `MetaPatternKind` enum + `WRITE_VERBS` SoT (v0.11 reservation) |
| `src/engine/hook.rs` | New `detect_verb_at_command_position` + `matches_verb_pattern_at` + `is_verb_executable_position` (segment head OR after execution wrapper recursively) + `EXECUTION_WRAPPERS` const + `strip_quoted_data` (preserves `$(...)` and backticks inside double quotes) + `env_dash_s_payload` (basename match for path-qualified env, recursive wrapper position) |
| `tests/hook_integration.rs` | HOOK_DECISION_CASES +30 cases (fp_data-context 12 / fn_raw-position 10 / fp-flag-after-separator 3 / fn-wrapper 6 / fn-xargs-flag 3 / fn-env-dash-s 2 / fn-find-parallel 2 / fn-double-quote-subst 3 / fn-path-qualified-env 2 / out-of-scope-allow 3) |
| `src/property_tests.rs` | 3 new properties: `prop_trigger_inside_quoted_body_arg_is_allowed` / `_in_raw_command_position_is_blocked` / `prop_subshell_inner_verb_blocked` |
| `tests/cli.rs` | Split `hook_check_json_error_blockmeta_*` into path/verb cases (different `matched_position` semantics) |
| `.github/workflows/ci.yml` | New `proptest-deep` job (PROPTEST_CASES=2048, ubuntu-latest) |
| `SECURITY.md` | "Broad match by design" section split: path-based / verb-based / v0.10.2 -> PR1c coverage narrow paragraph documenting 5 out-of-scope vectors |

## Test plan

- [x] `cargo test --lib` passes (756 tests)
- [x] `cargo test --test hook_integration` passes (90+ table-driven cases)
- [x] `cargo test --test cli hook_check_json_error` passes (6 tests)
- [x] `RUSTFLAGS='-D warnings' cargo test` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `scripts/check-invariants.sh` OK (DI-13 intact)
- [x] External Claude review verdict: CONDITIONAL -> closed via SECURITY.md doc paragraph + 3 out-of-scope test pins
- [ ] CI green

## v0.10.2 -> v0.10.3 PR1c coverage narrow (documented)

5 vectors that v0.10.2's incidental substring match caught are now allowed in PR1c. All consistent with previously-declared scope-outs:

- `tcsh -c 'omamori uninstall'` / `su -c 'omamori uninstall'` — non-default shell launchers (Supported Shell List in SECURITY.md)
- `awk system(...)` / `perl -e 'system(...)'` — interpreter family (#74)
- `alias x='omamori uninstall'; x` — dynamic dispatch (statically unanalysable)

Documented in `SECURITY.md` "Broad match by design" section. HOOK_DECISION_CASES pin these as Allow with `*-out-of-scope-*` category names so future patches do not accidentally re-enable them.

## Issue proposals (PR1c block しない follow-up)

- **G1** (pre-existing, not introduced by PR1c): `omamori\nuninstall` newline-split is allowed; `normalize_compound_operators` may not split `\n` as a segment separator. Track separately.
- **G2**: word-boundary residual backstop FP (`echo omamori uninstaller` blocked). v0.10.2 also blocked, no regression. PR1c thesis ideally fixes this but the trade-off (security weakening via `omamori uninstall;rm` style escapes) needs design review.
- **#74-paired**: shell_launcher list expansion (tcsh/su/etc.) is product-level discussion, not a PR1c blocker.

## Codex review history

R1-R5 walked through 6 P1 security regressions vs v0.10.2 substring match, all fixed (segment separator stop / xargs naive wrapper / xargs flag + env -S / double-quote `$(...)` + path-qualified env). External Claude review (separate session) re-verified 27 attack vectors + 6 FP relief vectors PASS, surfaced the 5-vector coverage narrow as the CONDITIONAL closing item.

## PR series context

PR1a (merged) -> PR1b (merged) -> **PR1c (this)** -> PR1d (data-flag allowlist + UX + invariants + perf bench) -> PR2 (#239 acceptance test doc fix) -> tag/release/publish/brew

🤖 Generated with [Claude Code](https://claude.com/claude-code)
