### PR TITLE
docs(readme): reflect v0.10.3 scope expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Bypass classes outside this coverage scope remain possible — this is inherent 
 
 </details>
 
-Layer 2 hooks additionally block evasion patterns such as pipe-to-shell (`curl URL | bash`), dynamic command generation (`bash -c "$(cmd)"`), static shell expansion obfuscation (`$'rm'`, `{rm,-rf,/}`), environment-variable tampering, and PATH override attempts targeting shimmed commands.
+Layer 2 hooks additionally block evasion patterns such as pipe-to-shell (`curl URL | bash`), dynamic command generation (`bash -c "$(cmd)"`), static shell expansion obfuscation (`$'rm'`, `{rm,-rf,/}`), environment-variable tampering, and PATH override attempts targeting shimmed commands. Since v0.10.3, trigger words inside data arguments (`git commit -m "..."`, `gh issue create --body "..."`) are recognized as non-command context and allowed through.
 
 All rules are customizable via TOML config. See [Configuration](#configuration) below.
 
@@ -116,13 +116,13 @@ Terminal → rm -rf src/
 |------------|--------------|-------------|
 | **Layer 1 — PATH shim** | Intercepts destructive commands (`rm`, `git`, `chmod`, `find`, `rsync`) by name when an AI env var is detected | `omamori test`, CI |
 | **Layer 2 — Hooks** | Catches evasion patterns: shell wrappers, pipe-to-shell, dynamic generation, PATH override bypass | Hook integration tests |
-| **Self-defense** | Blocks `config disable`, `uninstall`, hook/config editing, env-var unsetting while AI-detected | Acceptance test suite |
+| **Self-defense** | Blocks self-modification commands (`config disable`, `uninstall`, etc.), hook/config editing, env-var unsetting while AI-detected | Acceptance test suite |
 | **Audit chain** | HMAC-SHA256 signed, hash-chained tamper-evident JSONL log at `~/.local/share/omamori/audit.jsonl` | `omamori audit verify` |
 | **Integrity monitoring** | Verifies shims, hooks, config, core policy, PATH order. Detects subtle hook body rewrites | `omamori doctor`, `omamori status` |
 | **File protection** | Blocks AI Edit/Write on config, hooks, audit log, integrity baseline, Claude Code settings.json | Hook integration tests |
 | **Auto-sync** | Detects version mismatch after `brew upgrade` and auto-regenerates hook files | Smoke test |
 
-Core policy: the 7 built-in rules cannot be disabled via `config.toml` — an AI agent setting `enabled = false` is ignored. For legitimate overrides, see `omamori override` in [CLI Reference](#cli-reference).
+Core policy: built-in rules (13 as of v0.10.3, including self-protection rules) cannot be disabled via `config.toml` — an AI agent setting `enabled = false` is ignored. For legitimate overrides, see `omamori override` in [CLI Reference](#cli-reference).
 
 **Performance**: hook check completes in well under 0.1ms in the benchmark harness — typically ~1 µs to block and ~57 µs to allow. Subprocess startup by the AI tool dominates total cost. See `benches/` and [#124](https://github.com/yottayoshida/omamori/issues/124) for methodology.
 
@@ -263,6 +263,7 @@ omamori audit show [--last N] [--json]   # View recent audit entries (default: l
 omamori audit show --all                 # View all entries
 omamori audit show --rule <name>         # Filter by rule (substring match)
 omamori audit show --provider <name>     # Filter by provider
+omamori audit show --relaxed             # Filter to data-context relaxed allows
 
 omamori config list                      # Show rules with status
 omamori config disable <rule>            # Disable a rule
@@ -272,7 +273,7 @@ omamori override enable <rule>           # Restore a core safety rule
 
 omamori init [--force] [--stdout]        # Create/reset config
 omamori uninstall                        # Remove shims + hooks
-omamori hook-check [--provider NAME]     # Hook detection engine (used internally by hooks)
+omamori hook-check [--provider NAME] [--json-error]  # Hook detection engine (used internally by hooks)
 omamori cursor-hook                      # Cursor hook handler
 omamori --version                        # Show version
 ```


### PR DESCRIPTION
## Summary
- Add data-context awareness description to Layer 2 section
- Update built-in rule count (7 → 13) to match `core_rule_names()` after PR1a
- Broaden Self-defense table row to cover all self-modification commands
- Add `--relaxed` and `--json-error` flags to CLI Reference

## Context
Pre-release README update for v0.10.3. UX designer review identified P0 (factual rule count mismatch) and P1 (missing CLI flags) gaps. Data-context awareness — the core v0.10.3 capability — was not surfaced in README at all.

No code change, no version bump.

## Test plan
- [ ] Verify `core_rule_names()` returns 13 entries (matches README claim)
- [ ] Verify `--relaxed` and `--json-error` flags exist in CLI help output
- [ ] Visual review: no #196 structure regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)