### PR TITLE
feat: scope FILE-tier path patterns to write surface only (#248)

### DIFF
--- a/ACCEPTANCE_TEST.md
+++ b/ACCEPTANCE_TEST.md
@@ -337,6 +337,69 @@ echo "exit=$?"
 
 ---
 
+## v0.10.4 #248 effect (ws-*) — write-surface scoping for path patterns
+
+> 用語: `Tier 2 FILE` = 8 protected file path patterns (`.claude/settings.json`, `.integrity.json`, `.codex/hooks.json`, etc.)。v0.10.3 までは unconditional substring match で block していたものを、write context (write redirect target / WRITE_VERB argument) でのみ block に変更。`WRITE_VERBS` = `tee`, `vim`, `vi`, `nano`, `emacs`, `cp`, `mv`, `dd`, `install`, `sed`, `truncate`, `patch`, `ln`, `touch`, `chmod`, `chown` (16 total)。
+>
+> 実行: Claude Code session または下記 fenced block の `hook-check` JSON dry-run。
+
+### Fenced Block #5 — ws-* hook-check dry-run
+
+```bash
+# ws-1: cat reading a protected path → ALLOW (read context, no write surface)
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"cat ~/.claude/settings.json"}}' \
+  | omamori hook-check --provider claude-code
+echo "exit=$?"
+
+# ws-2: grep reading a protected path → ALLOW
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"grep pattern ~/.claude/settings.json"}}' \
+  | omamori hook-check --provider claude-code
+echo "exit=$?"
+
+# ws-3: input redirect (read, not write) → ALLOW
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"sort < ~/.claude/settings.json"}}' \
+  | omamori hook-check --provider claude-code
+echo "exit=$?"
+
+# ws-4: path in quoted data → ALLOW
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"gh issue create --body \"see ~/.claude/settings.json\""}}' \
+  | omamori hook-check --provider claude-code
+echo "exit=$?"
+
+# ws-5: shell launcher with read command → ALLOW
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"bash -c \"cat ~/.claude/settings.json\""}}' \
+  | omamori hook-check --provider claude-code
+echo "exit=$?"
+
+# ws-6: write redirect → BLOCK
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"echo x > ~/.claude/settings.json"}}' \
+  | omamori hook-check --provider claude-code
+echo "exit=$?"
+
+# ws-7: WRITE_VERB (tee) → BLOCK
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"tee ~/.claude/settings.json"}}' \
+  | omamori hook-check --provider claude-code
+echo "exit=$?"
+
+# ws-8: shell launcher with WRITE_VERB → BLOCK
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"bash -c \"tee ~/.claude/settings.json\""}}' \
+  | omamori hook-check --provider claude-code
+echo "exit=$?"
+```
+
+| # | コマンド | AI-executable assertion | 人間 summary | PASS |
+|---|---------|-------------------------|--------------|------|
+| ws-1 | Fenced Block #5 の ws-1 dry-run | `exit = 0 ∧ stdout JSON ~~ /"permissionDecision":"allow"/` | `cat` は read 操作。Tier 2 FILE pattern は write surface に無いので ALLOW。v0.10.3 では false-positive BLOCK (#248 closure) | [ ] |
+| ws-2 | Fenced Block #5 の ws-2 dry-run | `exit = 0 ∧ stdout JSON ~~ /"permissionDecision":"allow"/` | `grep` は read 操作。write surface に無いので ALLOW | [ ] |
+| ws-3 | Fenced Block #5 の ws-3 dry-run | `exit = 0 ∧ stdout JSON ~~ /"permissionDecision":"allow"/` | input redirect `<` は read。write redirect (`>`) と区別され ALLOW | [ ] |
+| ws-4 | Fenced Block #5 の ws-4 dry-run | `exit = 0 ∧ stdout JSON ~~ /"permissionDecision":"allow"/` | path は `--body` 内の passive quoted data。strip_quoted_data で除去され ALLOW | [ ] |
+| ws-5 | Fenced Block #5 の ws-5 dry-run | `exit = 0 ∧ stdout JSON ~~ /"permissionDecision":"allow"/` | shell launcher payload に `cat` (read)。payload の write-surface 検査で write evidence なし → ALLOW | [ ] |
+| ws-6 | Fenced Block #5 の ws-6 dry-run | `exit = 2 ∧ stderr ~~ /omamori hook:/` | `>` は write redirect。path が write-redirect target なので BLOCK | [ ] |
+| ws-7 | Fenced Block #5 の ws-7 dry-run | `exit = 2 ∧ stderr ~~ /omamori hook:/` | `tee` は WRITE_VERB。path が WRITE_VERB argument なので BLOCK | [ ] |
+| ws-8 | Fenced Block #5 の ws-8 dry-run | `exit = 2 ∧ stderr ~~ /omamori hook:/` | shell launcher payload に `tee` (WRITE_VERB)。payload の write-surface 検査で BLOCK | [ ] |
+
+---
+
 ## Recovery (destructive row 実行後の回復)
 
 | 実行 row | 期待 (block 成立) | block 失敗時の対応 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.10.4] - 2026-05-09
+
+**Summary**: Write-surface scoping for path-based meta-patterns ([#248](https://github.com/yottayoshida/omamori/issues/248)). The former 18-entry `META_PATTERNS_PATH` is split into a 3-tier classification (EXEC / FILE / TOKEN), where Tier 2 FILE patterns (8 protected file paths) are blocked only when the path appears in write context — a write-redirect target (`>`, `>>`, `>|`, `&>`, `&>>`) or a `WRITE_VERB` argument. Read/data mentions are now allowed, resolving the remaining false positives from v0.10.3 known limitations (e.g. `cat ~/.claude/settings.json`, `grep pattern settings.json`, `gh issue create --body "see settings.json"`).
+
+### Added
+
+- **3-tier path pattern classification**: `META_PATTERNS_PATH_EXEC` (8 `/bin/rm` boundary variants, raw substring), `META_PATTERNS_PATH_FILE` (8 protected file paths, write-surface only), `META_PATTERNS_PATH_TOKEN` (2 sensitive tokens `codex_hooks`/`audit-secret`, raw unconditional). Legacy `blocked_string_patterns()` returns the concatenation for backward compat.
+- **`is_path_in_write_surface`**: detects whether a protected path is a write-redirect operand (output redirects only — input redirects `<`/`<<`/`<<<`/`<>` excluded), a `WRITE_VERB` argument, or a `dd of=` target.
+- **`shell_dash_c_payload`**: extracts `-c` argument from shell launchers (`bash`/`sh`/`zsh`/`dash`/`ksh`), applies write-surface detection recursively to payload. `bash -c "cat path"` allows; `bash -c "tee path"` blocks.
+- **`is_write_redirect_op` / `is_write_redirect_concatenated`**: discriminates write redirects (`>`, `>>`, `>|`, `&>`, `&>>`) from read redirects (`<`, `<<`, `<<<`, `<>`). The existing `RedirectToken::classify` treats all redirects uniformly; these helpers add write/read discrimination.
+- **`WRITE_VERBS` expanded** from 9 to 16: added `sed`, `truncate`, `patch`, `ln`, `touch`, `chmod`, `chown`. Removed `#[allow(dead_code)]`.
+- **14 new HOOK_DECISION_CASES**: 6 FP-relief Allow cases (`cat`, `grep`, `sort <`, `bash -c "cat"`, quoted data, audit read) + 8 write-surface Block cases (redirect, append, tee, cp, sed, `bash -c` write verb/redirect, `dd of=`). Per-category floors added to `META_PATTERN_CATEGORY_FLOORS`.
+
+### Fixed
+
+- **#248 false positives on read/data context**: `cat ~/.claude/settings.json`, `grep pattern ~/.claude/settings.json`, `sort < ~/.claude/settings.json`, `gh issue create --body "see settings.json"`, `bash -c "cat settings.json"` now allow. This resolves the v0.10.3 known limitation "Path-based 18 entries retain substring match".
+
+### Security
+
+- **Reconnaissance trade-off documented**: allowing read access to protected paths exposes configuration content. Acceptable because config format is open-source, Edit/Write tool gates independently prevent modification, and FP cost significantly degrades AI workflows.
+- **INV-fail-close**: tokenization failure with a protected path present in the residual triggers Block (not Allow).
+- **INV-path-raw-first**: raw `command.contains` check before `strip_quoted_data` prevents `bash -c "tee path"` bypass.
+- **INV-sensitive-raw**: Tier 3 TOKEN patterns (`codex_hooks`, `audit-secret`) retain unconditional raw match (DREAD 9.2).
+
+### Known limitations
+
+- **Known conservative FP**: `cp ~/.claude/settings.json /tmp/backup` blocks because `cp` is a `WRITE_VERB` and per-verb source/destination argument mapping is deferred to a future release.
+- **`eval "tee path"` bypass**: `eval` is not in `SHELL_NAMES` and does not receive shell launcher payload extraction. Consistent with #74 precedent (interpreter family out of scope).
+- **Variable indirection (`$VAR`)**: static analysis cannot resolve runtime variable values. Fundamental limitation documented in SECURITY.md.
+
 ## [0.10.3] - 2026-05-08
 
 **Summary**: Self-block relief for AI workflows ([#240](https://github.com/yottayoshida/omamori/issues/240)). Verb-based meta-pattern detection moves from `command.contains` substring matching to token-level position-aware lattice (mirroring Phase 1B). Path-based 18 entries retain substring match for T3 defense. The data-context residual quote-strip backstop catches verbs invoked via wrapper grammars (`xargs`, `find -exec`, `env -S`, double-quoted `$(...)`, etc.) without re-introducing FP on quoted bodies. Self-modification verbs gain Phase 2 builtin rules (`omamori-*-block`) as defense-in-depth, with `subcommand` position constraint preventing false positives like `omamori exec -- echo disable config`. ACCEPTANCE_TEST.md doc inaccuracies fixed in [#239](https://github.com/yottayoshida/omamori/issues/239) (PR2).
@@ -42,7 +72,7 @@ The format is based on Keep a Changelog.
 ### Known limitations
 
 - **`--break-glass` flag not yet implemented**: if a new false-positive pattern surfaces post-v0.10.3, recovery path is `omamori uninstall` → wait for patch release → `omamori install`. A proper `--break-glass` with audit emission and rate-limit is planned for v0.11.x.
-- **Path-based 18 entries retain substring match**: `gh issue create --body "see ~/.claude/settings.json"` is still BLOCKED by design (T3 heredoc redirect to protected path defense). Use `--body-file <path>` as a one-off bypass. A structural revision scoping path patterns to writeable surface only is planned for v0.11.x.
+- **Path-based 18 entries retain substring match**: `gh issue create --body "see ~/.claude/settings.json"` is still BLOCKED by design (T3 heredoc redirect to protected path defense). Use `--body-file <path>` as a one-off bypass. **Resolved in v0.10.4** (#248): path patterns split into 3 tiers, FILE tier scoped to write-surface only.
 - **v0.10.2 → v0.10.3 incidental coverage narrow**: 5 vectors that v0.10.2's broad substring match incidentally caught are now allowed. All consistent with previously-declared scope-outs (non-default shells `tcsh`/`su`, interpreter family `awk`/`perl` per [#74](https://github.com/yottayoshida/omamori/issues/74), alias dynamic dispatch). Documented in `SECURITY.md` "Broad match by design" section.
 - **`--json-error` JSON contract scope**: applies to the shell-command path only. Other deny paths (malformed hook input, file-op deny, unknown-tool fail-open) retain free-form stderr; extension is a follow-up.
 - **`--json-error` mode skips audit emission**: the trade-off keeps stderr a single parseable JSON object even in degraded audit environments. Operators needing full audit coverage should not pass `--json-error`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "criterion",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -246,7 +246,19 @@ Layer 2 hooks use a **token-aware Recursive Unwrap Stack** implemented in Rust (
 
 2. **Phase 2 — Unwrap Stack** (token-level): Tokenizes the command, strips shell wrappers, extracts inner commands from shell launchers, and evaluates each extracted command against the same rules as Layer 1.
 
-**Broad match by design** (path-based, retained in v0.10.3+): Path-based meta-patterns (`audit.jsonl`, `audit-secret`, `.integrity.json`, `.local/share/omamori`, `omamori/config.toml`, `.codex/hooks.json`, `/bin/rm`, `.claude/settings.json`, `.codex/config.toml`, etc., 18 entries in `META_PATTERNS_PATH`) use `command.contains(pattern)` substring match. `ls ~/.local/share/omamori` is blocked alongside `rm -rf ~/.local/share/omamori`. Read-only commands on protected paths are intentionally blocked to prevent reconnaissance that could aid targeted attacks. This is the T3 (heredoc redirect to protected path) defense.
+**3-tier path pattern classification** (v0.10.4+, #248): The former 18-entry `META_PATTERNS_PATH` is split into three tiers with different detection strategies:
+
+| Tier | Name | Count | Detection | Examples |
+|------|------|-------|-----------|----------|
+| 1 — EXEC | Exec-bypass paths | 8 | Raw `command.contains` substring | `/bin/rm `, `/usr/bin/rm"` (4 boundary variants × 2 paths) |
+| 2 — FILE | Protected file paths | 8 | **Write-surface only**: blocked when path is a write-redirect target (`>`, `>>`, `>|`, `&>`, `&>>`) or a `WRITE_VERB` argument | `.claude/settings.json`, `.integrity.json`, `.codex/hooks.json`, `audit.jsonl`, etc. |
+| 3 — TOKEN | Sensitive tokens | 2 | Raw `command.contains` substring (unconditional) | `codex_hooks`, `audit-secret` |
+
+**Tier 2 write-surface detection** (v0.10.4+): `cat ~/.claude/settings.json`, `grep pattern ~/.claude/settings.json`, and `gh issue create --body "see settings.json"` are now **allowed** — the path appears in read or data context, not write context. Write operations (`echo x > ~/.claude/settings.json`, `tee ~/.claude/settings.json`, `sed -i 's/./' ~/.claude/settings.json`) remain **blocked**. Shell launcher payloads (`bash -c "..."`) are recursively inspected: `bash -c "cat path"` allows, `bash -c "tee path"` blocks. Input redirects (`<`, `<<`, `<<<`, `<>`) are classified as read, not write. `WRITE_VERBS`: `tee`, `vim`, `vi`, `nano`, `emacs`, `cp`, `mv`, `dd`, `install`, `sed`, `truncate`, `patch`, `ln`, `touch`, `chmod`, `chown` (16 total). Known conservative FP: `cp protected_path /tmp/backup` blocks because per-verb source/dest argument mapping is deferred. Tokenization failure with a path present in the residual triggers fail-close (INV-fail-close).
+
+**Reconnaissance trade-off** (v0.10.4): allowing read access to protected paths (e.g. `cat ~/.claude/settings.json`) exposes configuration content. This is an acceptable trade-off because: (1) omamori's config format is open-source and documented, (2) Claude Code's Edit/Write tool gates independently prevent modification through the tool-use path, (3) the false-positive cost of blocking all read operations significantly degrades AI development workflows (11 known self-block patterns in v0.10.2). Tier 1 EXEC and Tier 3 TOKEN retain unconditional raw substring match.
+
+**Broad match retained** (Tier 1 EXEC + Tier 3 TOKEN): `/bin/rm` boundary patterns and sensitive tokens (`codex_hooks`, `audit-secret`) remain unconditional raw substring match. These patterns do not cause false positives in normal workflows and protect high-severity attack surfaces (DREAD 8.8+ for exec bypass, 9.2 for codex_hooks tampering).
 
 **Token-level + backstop** (verb-based, v0.10.3+ PR1c): Verb-based meta-patterns (`config disable/enable`, `omamori uninstall`, `omamori init --force`, `omamori override`, `omamori doctor --fix`, `omamori explain`, 7 entries in `META_PATTERNS_VERB`) moved from `command.contains` to a layered detector: (1) token-level position-aware matching (`detect_verb_at_command_position` mirroring the `is_command_position` lattice from Phase 1B, with execution-wrapper transparency for `xargs`/`time`/`nohup`/`sudo`/`env`/etc.), (2) `env -S` payload inspection (`env_dash_s_payload`), (3) residual quote-strip backstop (`strip_quoted_data` preserves `$(...)` and backticks inside double quotes since they remain executable). This relieves false-positives like `gh issue create --body "config disable bug fixed"` (#240) while preserving block on raw / wrapper / executable-quoted invocations.
 
@@ -732,22 +744,21 @@ Entries written before v0.7.0 lack chain fields. When `append()` encounters a le
 
 ## Known Operational Caveats
 
-### Layer 2 meta-pattern false-positives on developer workflows (v0.9.7+)
+### Layer 2 meta-pattern false-positives on developer workflows (v0.9.7–v0.10.3)
 
-Layer 2 meta-pattern matching uses substring inclusion (`command.contains(pattern)`) on the full Bash command string. This is correct for the protection guarantee — `unset CLAUDECODE` anywhere in a command must block, including inside `echo`. The same broadness produces false-positive blocks on developer workflows that *describe* protected configuration without modifying it. Reproducible cases observed during omamori's own development:
+> **Resolved in v0.10.4.** The 3-tier path pattern classification (see [Path pattern classification](#path-pattern-classification) above) scopes FILE-tier patterns to write surface only, eliminating the false-positive classes listed below. TOKEN-tier and EXEC-tier patterns retain unconditional matching.
 
-- `git commit -m '...'` where the commit message body mentions paths like `~/.claude/settings.json`, `.integrity.json`, `audit.jsonl`, or `audit-secret` (release-note prose, threat-model documentation, this very file)
-- `grep` / `rg` invocations that pass these strings as search arguments
-- AI-assisted code-review prompts that surface protected-path words densely in a single Bash invocation (e.g. quoting threat-model excerpts inline)
+In v0.9.7–v0.10.3, Layer 2 meta-pattern matching used substring inclusion (`command.contains(pattern)`) on the full Bash command string for all path patterns. This produced false-positive blocks on developer workflows that *described* protected configuration without modifying it:
 
-These blocks are correct under the v0.9.7 design: the meta-pattern cannot tell *describing* from *modifying* without a full shell parse, and conservatively blocks both. Workarounds for legitimate developer workflows:
+- `git commit -m '...'` where the commit message body mentions paths like `~/.claude/settings.json`
+- `grep` / `rg` / `cat` invocations that pass protected paths as read-only arguments
+- AI-assisted code-review prompts that quote protected-path words in a single Bash invocation
 
-1. Pass commit messages via file: `git commit -F /tmp/msg.txt` keeps the trigger words off the command line.
-2. Split contiguous strings on the Bash command line: e.g. `A=audit B=.jsonl; rg "$A$B"` — the meta-pattern matches the *literal* command string, not its expanded form.
-3. Use AI-tool file-edit interfaces (Read / Edit / Write) instead of Bash for reading or modifying file content; those routes go through `is_protected_file_path`, which is path-aware and does not false-positive on incidental substring mentions in unrelated files.
-4. Use the Codex MCP channel (`mcp__codex__codex`, `mcp__codex__review`) for AI review prompts that necessarily quote protected paths; the MCP transport bypasses the Bash PreToolUse hook entirely.
+Starting with v0.10.4, FILE-tier patterns (`.claude/settings.json`, `.integrity.json`, `audit.jsonl`, etc.) block only when the path appears in a write context: as a write redirect target (`>`, `>>`, `>|`, `&>`, `&>>`, `>&`) or as an argument to a WRITE_VERB (`tee`, `cp`, `mv`, `sed`, etc.). Read-only mentions (`cat`, `grep`, quoted data in `--body` arguments) pass through.
 
-This is a known trade-off, not a bug. Loosening the meta-pattern toward syntactic precision (e.g. tokenizing every Bash command before substring matching) would weaken the protection against obfuscated access to `audit-secret` / `.integrity.json` and is therefore not on the roadmap. The trade-off is documented here so operators reading omamori's own commit history understand that an occasional false-positive block during development is *evidence the layer is working*, not a regression to investigate.
+TOKEN-tier patterns (`codex_hooks`, `audit-secret`) remain unconditional raw substring matches — these tokens are dangerous in any context, and loosening them would weaken the protection against obfuscated access.
+
+**Remaining workaround need**: TOKEN-tier patterns still require the v0.9.7 workarounds (split contiguous strings, pass via file, use Read/Edit tools) when the literal token appears in a Bash command for legitimate reasons.
 
 ### Test-suite pollution of contributor `~/.claude/settings.json` (v0.9.7)
 

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -246,8 +246,181 @@ fn is_verb_executable_position(tokens: &[String], idx: usize) -> bool {
         return false;
     }
     let prev = tokens[idx - 1].as_str();
-    if EXECUTION_WRAPPERS.contains(&prev) {
+    let prev_base = prev.rsplit('/').next().unwrap_or(prev);
+    if EXECUTION_WRAPPERS.contains(&prev_base) {
         return is_verb_executable_position(tokens, idx - 1);
+    }
+    // Wrappers with flags: `env -i cmd`, `sudo -u root cmd`
+    if prev.starts_with('-') {
+        return is_after_wrapper_with_flags(tokens, idx);
+    }
+    false
+}
+
+/// Check if a redirect operator is a write redirect (output direction).
+///
+/// Write: `>`, `>>`, `>|`, `&>`, `&>>`, `>&`, `n>`, `n>>` (output).
+/// Read:  `<`, `<<`, `<<<`, `<<-`, `<>`, `n<` (input).
+/// `>&` is included: `>&file` is a write redirect to a file (same as `&>`).
+/// `>&2` is fd duplication but won't match a protected path pattern.
+fn is_write_redirect_op(op: &str) -> bool {
+    let core = op.trim_start_matches(|c: char| c.is_ascii_digit());
+    if core.is_empty() {
+        return false;
+    }
+    matches!(core, ">" | ">>" | ">|" | "&>" | "&>>" | ">&")
+}
+
+/// Check if a concatenated redirect token starts with a write redirect prefix.
+fn is_write_redirect_concatenated(token: &str) -> bool {
+    let core = token.trim_start_matches(|c: char| c.is_ascii_digit());
+    if core.is_empty() {
+        return false;
+    }
+    core.starts_with(">>")
+        || core.starts_with(">|")
+        || core.starts_with("&>>")
+        || core.starts_with("&>")
+        || core.starts_with(">&")
+        || core.starts_with('>')
+}
+
+/// Check if a token is a write verb from `installer::WRITE_VERBS`.
+fn is_write_verb(token: &str) -> bool {
+    let basename = token.rsplit('/').next().unwrap_or(token);
+    installer::WRITE_VERBS.contains(&basename)
+}
+
+/// Check if `tokens[idx]` is preceded by an execution wrapper with optional
+/// flags (e.g. `env -i bash`, `sudo -u root bash`). Walks backwards past
+/// flag tokens (starting with `-`) looking for a wrapper at exec position.
+fn is_after_wrapper_with_flags(tokens: &[String], idx: usize) -> bool {
+    if idx == 0 {
+        return false;
+    }
+    let mut j = idx - 1;
+    loop {
+        let t = tokens[j].as_str();
+        if t.starts_with('-') {
+            if j == 0 {
+                return false;
+            }
+            j -= 1;
+            continue;
+        }
+        let basename = t.rsplit('/').next().unwrap_or(t);
+        return EXECUTION_WRAPPERS.contains(&basename)
+            && is_verb_executable_position(tokens, j);
+    }
+}
+
+/// Extract the payload of a `shell -c 'string'` invocation at executable
+/// position. Recognises all `SHELL_NAMES` (bash, sh, zsh, dash, ksh) via
+/// basename match, transparent through execution wrappers (sudo, env, etc.)
+/// including wrapper flags (`env -i bash -c`, `sudo -u root bash -c`).
+/// Also handles combined shell flags (`bash -lc "cmd"`).
+fn shell_dash_c_payload(tokens: &[String]) -> Option<&str> {
+    for (i, t) in tokens.iter().enumerate() {
+        let basename = t.rsplit('/').next().unwrap_or(t.as_str());
+        if unwrap::SHELL_NAMES.contains(&basename)
+            && is_verb_executable_position(tokens, i)
+        {
+            let mut j = i + 1;
+            while j < tokens.len() {
+                let arg = &tokens[j];
+                if arg == "-c" {
+                    if let Some(payload) = tokens.get(j + 1) {
+                        return Some(payload.as_str());
+                    }
+                    return None;
+                }
+                // Combined flag ending with `c` (e.g. -lc, -ec, -xc)
+                if arg.starts_with('-')
+                    && !arg.starts_with("--")
+                    && arg.len() > 2
+                    && arg.ends_with('c')
+                {
+                    if let Some(payload) = tokens.get(j + 1) {
+                        return Some(payload.as_str());
+                    }
+                    return None;
+                }
+                if arg.starts_with('-') {
+                    j += 1;
+                    continue;
+                }
+                break;
+            }
+        }
+    }
+    None
+}
+
+const SEGMENT_SEPARATORS: &[&str] = &[";", "&&", "||", "|", "&"];
+
+/// Check if a protected path pattern appears in write surface within the
+/// given token slice.
+///
+/// Write surface = write redirect target (`>`, `>>`, `>|`, `&>`, `&>>`, `>&`)
+/// or argument to a `WRITE_VERB` at executable position (bounded to current
+/// command segment). Input redirects (`<`, `<<`, `<<<`) and redirect operands
+/// in general are excluded from WRITE_VERB scanning (caught separately by
+/// the redirect checks).
+fn is_path_in_write_surface(tokens: &[String], pattern: &str) -> bool {
+    for (i, token) in tokens.iter().enumerate() {
+        // Check 1: write redirect operand (separate operator token before this one).
+        // Use is_write_redirect_op directly — it handles arbitrary-digit fd
+        // prefixes via trim_start_matches, covering multi-digit fds (10>&)
+        // that RedirectToken::classify misses.
+        if token.contains(pattern) && i > 0 {
+            let prev = &tokens[i - 1];
+            if is_write_redirect_op(prev) {
+                return true;
+            }
+        }
+        // Check 2: concatenated write redirect (operator + operand fused).
+        // Same rationale: is_write_redirect_concatenated handles multi-digit fds.
+        if token.contains(pattern) && is_write_redirect_concatenated(token) {
+            return true;
+        }
+        // Check 3: WRITE_VERB at exec position — scan args within segment,
+        // skipping redirect operators and their operands
+        if is_write_verb(token) && is_verb_executable_position(tokens, i) {
+            let mut skip_next = false;
+            for t in &tokens[i + 1..] {
+                if SEGMENT_SEPARATORS.contains(&t.as_str()) {
+                    break;
+                }
+                if skip_next {
+                    skip_next = false;
+                    continue;
+                }
+                let kind = unwrap::RedirectToken::classify(t);
+                if kind == unwrap::RedirectToken::PureWithOperand {
+                    skip_next = true;
+                    continue;
+                }
+                if kind == unwrap::RedirectToken::Concatenated {
+                    continue;
+                }
+                if t.contains(pattern) {
+                    return true;
+                }
+            }
+        }
+        // Check 4: dd of=<pattern> — require dd at exec position in same segment.
+        // Walk backwards from of= and stop at any segment separator.
+        if token.starts_with("of=") && token[3..].contains(pattern) {
+            for (k, t) in tokens[..i].iter().enumerate().rev() {
+                let b = t.rsplit('/').next().unwrap_or(t.as_str());
+                if SEGMENT_SEPARATORS.contains(&b) {
+                    break;
+                }
+                if b == "dd" && is_verb_executable_position(tokens, k) {
+                    return true;
+                }
+            }
+        }
     }
     false
 }
@@ -487,11 +660,13 @@ fn detect_path_shim_bypass(tokens: &[String]) -> Option<&'static str> {
 type PrePhase2Ok = (Vec<CommandInvocation>, Option<&'static str>);
 
 fn check_pre_phase_2(command: &str) -> Result<PrePhase2Ok, HookCheckResult> {
-    // Phase 1A path-based: substring match preserved (INV-path-preserve, PR1c).
-    // matched_pattern carries the actual `pattern` token (e.g. ".claude/settings.json"),
-    // not the human-readable `reason`. Reason has its own `reason` / `rule_id`
-    // fields in the JSON schema. Codex review (PR1b R1) [P2].
-    for &(pattern, reason) in installer::META_PATTERNS_PATH {
+    // 0. Compute residual once (shared with Tier 1/2 and verb backstop).
+    let residual = strip_quoted_data(command);
+
+    // --- Phase 1A: 3-tier path meta-pattern detection (#248, v0.10.4+) ---
+
+    // Tier 3 TOKEN: raw unconditional match (INV-sensitive-raw, DREAD 9.2).
+    for &(pattern, reason) in installer::META_PATTERNS_PATH_TOKEN {
         if let Some(start) = command.find(pattern) {
             return Err(HookCheckResult::BlockMeta {
                 reason,
@@ -501,51 +676,107 @@ fn check_pre_phase_2(command: &str) -> Result<PrePhase2Ok, HookCheckResult> {
         }
     }
 
-    // Phase 1A verb-based + Phase 1B: token-level position-aware (PR1c, v0.10.3+).
-    // normalize_compound_operators splits ;, &&, ||, |, &, \n into separate tokens,
-    // then shell_words::split normalizes whitespace + parses quotes.
-    // This ensures "echo ok;unset CLAUDECODE" is correctly tokenized as
-    // ["echo", "ok", ";", "unset", "CLAUDECODE"] — without normalize,
-    // shell_words would produce ["echo", "ok;unset", "CLAUDECODE"].
-    // is_command_position() ensures only segment-initial verbs are flagged
-    // (data-context patterns like `gh issue create --body "config disable bug"`
-    // are skipped because the quoted body is packed into a single token).
-    //
-    // DEFENSE BOUNDARY on shell_words::split failure:
-    //   Phase 1A path-based has already run. Phase 2 blocks malformed
-    //   commands via ParseResult::Block(ParseError) — fail-close (INV-fail-close).
+    // Tier 1 EXEC: raw substring match (unchanged from v0.10.3).
+    // EXEC patterns include boundary characters (space, dquote, tab, squote)
+    // that interact with strip_quoted_data, so raw match is required.
+    // These patterns are not the source of FPs — FP relief targets Tier 2 FILE.
+    for &(pattern, reason) in installer::META_PATTERNS_PATH_EXEC {
+        if let Some(start) = command.find(pattern) {
+            return Err(HookCheckResult::BlockMeta {
+                reason,
+                matched_pattern: Some(pattern),
+                matched_position: Some(start..start + pattern.len()),
+            });
+        }
+    }
+
+    // Tokenize (shared with Tier 2, verb detection, and Phase 1B below).
     let normalized = unwrap::normalize_compound_operators(command);
-    if let Ok(tokens) = shell_words::split(&normalized) {
-        // Phase 1A verb-based (PR1c): n-token verb pattern at command position.
-        // matched_position is None because `tokens` is the post-normalize slice
-        // and original byte offsets are not preserved across quote/escape
-        // unwrapping (acceptable per BlockMeta schema).
-        if let Some((pattern, reason)) = detect_verb_at_command_position(&tokens) {
+    let tokens_result = shell_words::split(&normalized);
+
+    // Tier 2 FILE: write-surface check only (#248).
+    // Read/data mentions are allowed; only redirect targets and WRITE_VERB
+    // arguments are blocked.
+    for &(pattern, reason) in installer::META_PATTERNS_PATH_FILE {
+        let raw_pos = command.find(pattern);
+        if raw_pos.is_none() {
+            continue;
+        }
+        let pos_range = || raw_pos.map(|s| s..s + pattern.len());
+
+        // Shell launcher payload (bash -c "tee path") — recursive write-surface.
+        if let Ok(ref tokens) = tokens_result {
+            if let Some(payload) = shell_dash_c_payload(tokens) {
+                if payload.contains(pattern) {
+                    let p_norm = unwrap::normalize_compound_operators(payload);
+                    if let Ok(p_tokens) = shell_words::split(&p_norm) {
+                        if is_path_in_write_surface(&p_tokens, pattern) {
+                            return Err(HookCheckResult::BlockMeta {
+                                reason,
+                                matched_pattern: Some(pattern),
+                                matched_position: pos_range(),
+                            });
+                        }
+                    } else {
+                        return Err(HookCheckResult::BlockMeta {
+                            reason,
+                            matched_pattern: Some(pattern),
+                            matched_position: pos_range(),
+                        });
+                    }
+                }
+            }
+        }
+        // Quoted data filter: if pattern only appears inside passive quotes,
+        // it is data — not a write target.
+        if !residual.contains(pattern) {
+            continue;
+        }
+        // Write-surface check on the outer command tokens.
+        if let Ok(ref tokens) = tokens_result {
+            if is_path_in_write_surface(tokens, pattern) {
+                return Err(HookCheckResult::BlockMeta {
+                    reason,
+                    matched_pattern: Some(pattern),
+                    matched_position: pos_range(),
+                });
+            }
+        } else {
+            // Tokenization failed + path in residual → fail-close (INV-fail-close).
+            return Err(HookCheckResult::BlockMeta {
+                reason,
+                matched_pattern: Some(pattern),
+                matched_position: pos_range(),
+            });
+        }
+        // No positive write evidence → allow this pattern (blocklist-writes).
+    }
+
+    // --- Phase 1A verb-based + Phase 1B (unchanged, reuse tokens_result) ---
+
+    if let Ok(ref tokens) = tokens_result {
+        if let Some((pattern, reason)) = detect_verb_at_command_position(tokens) {
             return Err(HookCheckResult::BlockMeta {
                 reason,
                 matched_pattern: Some(pattern),
                 matched_position: None,
             });
         }
-        if let Some(reason) = detect_env_var_tampering(&tokens) {
-            // Phase 1B: token-level detection has no single substring "pattern" —
-            // matched_pattern is None per schema (Codex review PR1b R2 [P2]).
+        if let Some(reason) = detect_env_var_tampering(tokens) {
             return Err(HookCheckResult::BlockMeta {
                 reason,
                 matched_pattern: None,
                 matched_position: None,
             });
         }
-        if let Some(reason) = detect_path_shim_bypass(&tokens) {
+        if let Some(reason) = detect_path_shim_bypass(tokens) {
             return Err(HookCheckResult::BlockMeta {
                 reason,
                 matched_pattern: None,
                 matched_position: None,
             });
         }
-        // Phase 1A verb backstop: env -S payload contains executable verbs
-        // (a single quoted token that env will split + exec). Codex PR1c R3 [P1].
-        if let Some(payload) = env_dash_s_payload(&tokens) {
+        if let Some(payload) = env_dash_s_payload(tokens) {
             for &(pattern, reason) in installer::META_PATTERNS_VERB {
                 if payload.contains(pattern) {
                     return Err(HookCheckResult::BlockMeta {
@@ -558,13 +789,7 @@ fn check_pre_phase_2(command: &str) -> Result<PrePhase2Ok, HookCheckResult> {
         }
     }
 
-    // Phase 1A verb backstop (Codex PR1c R3 [P1]): residual quote-stripped
-    // substring match catches verb patterns invoked via wrapper grammars
-    // not modeled by detect_verb_at_command_position (`xargs -I{}`,
-    // `find -exec ... {} \;`, parallel, sh -c without -c-as-shell-launcher,
-    // etc.). Quoted bodies are stripped so the FP-relief invariant for
-    // gh issue body / git commit message is preserved.
-    let residual = strip_quoted_data(command);
+    // Phase 1A verb backstop (reuse pre-computed residual).
     for &(pattern, reason) in installer::META_PATTERNS_VERB {
         if residual.contains(pattern) {
             return Err(HookCheckResult::BlockMeta {
@@ -578,16 +803,9 @@ fn check_pre_phase_2(command: &str) -> Result<PrePhase2Ok, HookCheckResult> {
     // Phase 2 parse: structural block (parse error / pipe-to-shell etc.)
     match unwrap::parse_command_string(command) {
         unwrap::ParseResult::Block(reason) => {
-            // Carry the wrapper basename through to the audit log via
-            // `wrapper_kind`. `message` stays wrapper-agnostic (block-reason
-            // text is the v0.9.5 fixed string) so the AI-iteration channel
-            // and the forensic channel remain separated. v0.9.7 #181 C-1.
             let wrapper_kind = match &reason {
                 unwrap::BlockReason::PipeToShell { wrapper } => *wrapper,
                 unwrap::BlockReason::ObfuscatedExpansion => {
-                    // Distinct detection_layer for forensic attribution.
-                    // We encode this as a sentinel that the audit path
-                    // recognises — avoids adding a new field to BlockStructural.
                     Some("__obfuscated_expansion__")
                 }
                 _ => None,
@@ -600,12 +818,6 @@ fn check_pre_phase_2(command: &str) -> Result<PrePhase2Ok, HookCheckResult> {
             })
         }
         unwrap::ParseResult::Commands(invocations) => {
-            // PR1d Gap 1: tag Allow path with the relaxation source so audit
-            // log can flag "this command was allowed because the residual
-            // backstop saw nothing after data-context stripping". Future
-            // forensic surface for FP regression analysis. Equality check
-            // costs O(n) but only on the Phase 2 entry path (path-based
-            // already short-circuited).
             let relaxed_by: Option<&'static str> = if residual != command {
                 Some("data-context")
             } else {

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -468,9 +468,11 @@ pub(crate) const PROTECTED_ENV_VARS: &[&str] = &[
 /// position-aware detection (`detect_verb_at_command_position` in `hook.rs`)
 /// to avoid false-positives like `gh issue create --body "config disable bug"`.
 ///
-/// `ProtectedPathSubstring` patterns retain `command.contains` substring
-/// match to defend against threats T3 (heredoc redirect to protected path)
-/// where the path mention itself is dangerous regardless of context.
+/// `ProtectedPathSubstring` covers three tiers of path/token patterns (v0.10.4+):
+/// - **EXEC** (Tier 1): `/bin/rm` variants — raw substring match on residual
+/// - **FILE** (Tier 2): protected file paths — write-surface scoped
+///   (block only on write redirect target or WRITE_VERB argument)
+/// - **TOKEN** (Tier 3): `codex_hooks`, `audit-secret` — raw unconditional match
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetaPatternKind {
     VerbAtCommandPosition,
@@ -513,19 +515,13 @@ pub const META_PATTERNS_VERB: &[(&str, &str)] = &[
     ),
 ];
 
-/// Path-based meta-patterns (PR1c, v0.10.3+).
+/// Tier 1 EXEC: direct path execution bypassing PATH shim (#248, v0.10.4+).
 ///
-/// Each entry is `(pattern_substring, reason)`. Substring match is PRESERVED
-/// (not token-position-aware) to defend against threat T3 — heredoc redirect
-/// to protected path. Path mention itself is dangerous regardless of context
-/// because shell parsing can promote any path-shaped substring to a redirect
-/// target via `>`/`>>`/`tee` etc. (INV-path-preserve).
-///
-/// PR1d's data-flag allowlist will exempt path mentions inside `gh issue
-/// create --body` etc. via separate logic; the substring match itself stays.
-pub const META_PATTERNS_PATH: &[(&str, &str)] = &[
-    // Direct path execution bypassing PATH shim — match various shell token
-    // boundaries: space, double-quote, tab, single-quote
+/// Raw substring match (unchanged from v0.10.3). These patterns include
+/// boundary characters (space, dquote, tab, squote) that interact with
+/// `strip_quoted_data`, so raw match is required. EXEC patterns are not
+/// the source of false positives — FP relief targets Tier 2 FILE only.
+pub const META_PATTERNS_PATH_EXEC: &[(&str, &str)] = &[
     ("/bin/rm ", "blocked direct rm path that bypasses PATH shim"),
     (
         "/bin/rm\"",
@@ -552,67 +548,79 @@ pub const META_PATTERNS_PATH: &[(&str, &str)] = &[
         "/usr/bin/rm'",
         "blocked direct rm path that bypasses PATH shim",
     ),
-    // Claude Code hook registration protection (#110 T3)
+];
+
+/// Tier 2 FILE: protected file paths (#248, v0.10.4+).
+///
+/// Blocked only in write context: redirect target (`>`, `>>`, `>|`, `&>`,
+/// `&>>`) or WRITE_VERB argument. Read/data mentions (e.g. `cat path`,
+/// `grep pattern path`, `gh issue create --body "see path"`) are allowed.
+/// INV-redirect-primary: redirect targeting a protected path is always
+/// treated as write surface.
+pub const META_PATTERNS_PATH_FILE: &[(&str, &str)] = &[
     (
         ".claude/settings.json",
-        "blocked attempt to edit Claude Code settings (contains hook config)",
+        "blocked attempt to write to Claude Code settings (contains hook config)",
     ),
-    // Integrity baseline protection
     (
         ".integrity.json",
-        "blocked attempt to edit integrity baseline",
+        "blocked attempt to write to integrity baseline",
     ),
-    // Codex CLI hook protection (#66, T2/T3)
     (
         ".codex/hooks.json",
-        "blocked attempt to edit Codex hooks config",
+        "blocked attempt to write to Codex hooks config",
     ),
-    (".codex/config.toml", "blocked attempt to edit Codex config"),
+    (
+        ".codex/config.toml",
+        "blocked attempt to write to Codex config",
+    ),
     (
         "config.toml.bak",
-        "blocked attempt to use Codex config backup",
+        "blocked attempt to write to Codex config backup",
     ),
+    ("audit.jsonl", "blocked attempt to write to audit log"),
+    (
+        "omamori/config.toml",
+        "blocked attempt to write to omamori config",
+    ),
+    (
+        ".local/share/omamori",
+        "blocked attempt to write to omamori data directory",
+    ),
+];
+
+/// Tier 3 TOKEN: sensitive feature-flag tokens (#248, v0.10.4+).
+///
+/// Raw unconditional substring match — any mention is blocked regardless of
+/// context. These tokens control security-critical feature flags whose mere
+/// presence in a command is suspicious (INV-sensitive-raw, DREAD 9.2).
+pub const META_PATTERNS_PATH_TOKEN: &[(&str, &str)] = &[
     (
         "codex_hooks",
         "blocked attempt to modify Codex hooks feature flag",
     ),
-    // Audit log protection (#29)
-    ("audit.jsonl", "blocked attempt to modify audit log"),
     ("audit-secret", "blocked attempt to access audit secret"),
-    // Config protection for retention settings (#29)
-    (
-        "omamori/config.toml",
-        "blocked attempt to edit omamori config",
-    ),
-    // Data directory protection (#29)
-    (
-        ".local/share/omamori",
-        "blocked attempt to modify omamori data directory",
-    ),
 ];
 
-/// Write-target verbs (PR1c SoT, v0.10.3+).
+/// Write-target verbs used by Tier 2 FILE write-surface detection (#248, v0.10.4+).
 ///
-/// Reserved for future v0.11 D-case refactor: scoping path-substring matches
-/// to commands that actually write to a path (`tee`, `vim`, `cat >`, etc.)
-/// rather than every mention. **Currently unused by the Phase 1A detector**;
-/// path patterns retain unconditional substring match in v0.10.3 per
-/// INV-path-preserve. SoT only — populating this list does NOT change PR1c
-/// behavior.
-#[allow(dead_code)]
+/// A command containing a WRITE_VERB at executable position with a protected
+/// path in its arguments is classified as write surface and blocked.
 pub const WRITE_VERBS: &[&str] = &[
-    "tee", "vim", "vi", "nano", "emacs", "cp", "mv", "dd", "install",
+    "tee", "vim", "vi", "nano", "emacs", "cp", "mv", "dd", "install", "sed", "truncate", "patch",
+    "ln", "touch", "chmod", "chown",
 ];
 
-/// Legacy combined meta-pattern list (Phase 1A, all 25 entries).
+/// Combined meta-pattern list (all 25 entries).
 ///
-/// Returns 18 path-based + 7 verb-based entries concatenated. Kept for
-/// backward compatibility with internal call sites and `scripts/check-invariants.sh`
-/// substring greps. New code should use [`META_PATTERNS_PATH`] and
-/// [`META_PATTERNS_VERB`] directly to dispatch via [`MetaPatternKind`].
+/// Returns all path-based (EXEC + FILE + TOKEN) + verb-based entries
+/// concatenated. Used by `scripts/check-invariants.sh` and internal call
+/// sites that need the full pattern set.
 pub fn blocked_string_patterns() -> Vec<(&'static str, &'static str)> {
-    META_PATTERNS_PATH
+    META_PATTERNS_PATH_EXEC
         .iter()
+        .chain(META_PATTERNS_PATH_FILE.iter())
+        .chain(META_PATTERNS_PATH_TOKEN.iter())
         .chain(META_PATTERNS_VERB.iter())
         .copied()
         .collect()

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -15,7 +15,7 @@ const MAX_SEGMENTS: usize = 20;
 
 // --- Shells recognized by basename ---
 
-const SHELL_NAMES: &[&str] = &["bash", "sh", "zsh", "dash", "ksh"];
+pub(crate) const SHELL_NAMES: &[&str] = &["bash", "sh", "zsh", "dash", "ksh"];
 
 // --- Transparent wrappers (single source of truth) ---
 //

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1965,7 +1965,7 @@ fn parse_json_error_stderr(stderr: &str) -> serde_json::Value {
 /// so byte offset is recoverable.
 #[test]
 fn hook_check_json_error_blockmeta_path_exact_metadata() {
-    // `.claude/settings.json` is a path-based META_PATTERNS_PATH entry.
+    // `.claude/settings.json` is a Tier 2 FILE (META_PATTERNS_PATH_FILE) entry.
     let cmd = "vim ~/.claude/settings.json";
     let (stdout, stderr, exit_code) = run_hook_check_json_error(&pretooluse_bash_json(cmd));
     assert_eq!(exit_code, 2, "block must yield exit 2");

--- a/tests/hook_integration.rs
+++ b/tests/hook_integration.rs
@@ -1366,16 +1366,188 @@ const HOOK_DECISION_CASES: &[(&str, Decision, &str)] = &[
         Decision::Allow,
         "non-default-shell-launcher-su-allow",
     ),
+    // =========================================================================
+    // v0.10.4: Write-surface scoping (#248) — Tier 2 FILE patterns block ONLY
+    // when the path is in write context (redirect target / WRITE_VERB arg).
+    // Read/data mentions are allowed, fixing FP on `cat`, `grep`, `gh --body`.
+    // =========================================================================
+    // ws-1. FP relief: `cat` reading a protected path is not a write
+    (
+        "cat ~/.claude/settings.json",
+        Decision::Allow,
+        "ws-file-read-cat-allow",
+    ),
+    // ws-2. FP relief: `grep` reading a protected path
+    (
+        "grep pattern ~/.claude/settings.json",
+        Decision::Allow,
+        "ws-file-read-grep-allow",
+    ),
+    // ws-3. FP relief: input redirect (`<`) is read, not write surface
+    (
+        "sort < ~/.claude/settings.json",
+        Decision::Allow,
+        "ws-file-input-redirect-allow",
+    ),
+    // ws-4. FP relief: path in passive quoted data (gh issue body)
+    (
+        "gh issue create --body \"see ~/.claude/settings.json\"",
+        Decision::Allow,
+        "ws-file-quoted-data-allow",
+    ),
+    // ws-5. FP relief: shell launcher with read-only command in payload
+    (
+        "bash -c \"cat ~/.claude/settings.json\"",
+        Decision::Allow,
+        "ws-file-launcher-read-allow",
+    ),
+    // ws-6. FP relief: audit.jsonl in read context
+    (
+        "cat audit.jsonl",
+        Decision::Allow,
+        "ws-file-read-audit-allow",
+    ),
+    // ws-7. Write-surface block: output redirect target
+    (
+        "echo x > ~/.claude/settings.json",
+        Decision::Block,
+        "ws-file-write-redirect-block",
+    ),
+    // ws-8. Write-surface block: WRITE_VERB (tee)
+    (
+        "tee ~/.claude/settings.json",
+        Decision::Block,
+        "ws-file-write-verb-tee-block",
+    ),
+    // ws-9. Write-surface block: WRITE_VERB (cp) — known conservative FP
+    //       when protected path is the source (not dest); per-verb arg
+    //       mapping deferred to v0.10.5+
+    (
+        "cp bad.json ~/.claude/settings.json",
+        Decision::Block,
+        "ws-file-write-verb-cp-block",
+    ),
+    // ws-10. Write-surface block: new WRITE_VERB (sed)
+    (
+        "sed -i 's/./' ~/.claude/settings.json",
+        Decision::Block,
+        "ws-file-write-verb-sed-block",
+    ),
+    // ws-11. Write-surface block: shell launcher with WRITE_VERB in payload
+    (
+        "bash -c \"tee ~/.claude/settings.json\"",
+        Decision::Block,
+        "ws-file-launcher-write-verb-block",
+    ),
+    // ws-12. Write-surface block: shell launcher with write redirect in payload
+    (
+        "bash -c \"echo x > ~/.claude/settings.json\"",
+        Decision::Block,
+        "ws-file-launcher-write-redirect-block",
+    ),
+    // ws-13. Write-surface block: append redirect to audit log
+    (
+        "echo x >> audit.jsonl",
+        Decision::Block,
+        "ws-file-write-append-block",
+    ),
+    // ws-14. Write-surface block: dd of= syntax targeting protected path
+    (
+        "dd if=/dev/zero of=audit.jsonl bs=1 count=0",
+        Decision::Block,
+        "ws-file-write-dd-of-block",
+    ),
+    // ws-15. Tier 3 TOKEN isolation: `codex_hooks` in read context still blocks
+    (
+        "cat codex_hooks",
+        Decision::Block,
+        "ws-token-codex-hooks-read-block",
+    ),
+    // ws-16. Tier 3 TOKEN isolation: `audit-secret` in quoted data still blocks
+    (
+        "echo \"audit-secret value\"",
+        Decision::Block,
+        "ws-token-audit-secret-quoted-block",
+    ),
+    // ws-17. Codex R1 fix: segment boundary — WRITE_VERB in earlier segment
+    //        must not reach into later read-only segment
+    (
+        "touch /tmp/x; cat ~/.claude/settings.json",
+        Decision::Allow,
+        "ws-file-segment-boundary-allow",
+    ),
+    // ws-18. Codex R1 fix: input redirect operand after WRITE_VERB is read
+    (
+        "tee < ~/.claude/settings.json",
+        Decision::Allow,
+        "ws-file-write-verb-input-redirect-allow",
+    ),
+    // ws-19. Codex R1 fix: shell launcher with combined flag -lc
+    (
+        "bash -lc \"tee ~/.claude/settings.json\"",
+        Decision::Block,
+        "ws-file-launcher-combined-flag-block",
+    ),
+    // ws-20. Codex R1 fix: wrapper flags (env -i) before shell launcher
+    (
+        "env -i bash -c \"tee ~/.claude/settings.json\"",
+        Decision::Block,
+        "ws-file-launcher-wrapper-flags-block",
+    ),
+    // ws-21. Codex R1 fix: >& redirect to protected path
+    (
+        "echo x >& ~/.claude/settings.json",
+        Decision::Block,
+        "ws-file-write-redirect-dup-block",
+    ),
+    // ws-22. Codex R2 fix: multi-digit fd redirect bypass
+    (
+        "echo x 10>& ~/.claude/settings.json",
+        Decision::Block,
+        "ws-file-write-redirect-multifd-block",
+    ),
+    // ws-23. Codex R2 fix: dd of= segment crossing FP
+    (
+        "dd if=/dev/null of=/tmp/out; cat of=audit.jsonl",
+        Decision::Allow,
+        "ws-file-segment-dd-cross-allow",
+    ),
+    // ws-24. dd of= within same segment still blocks
+    (
+        "dd if=/dev/null of=audit.jsonl",
+        Decision::Block,
+        "ws-file-write-dd-same-segment-block",
+    ),
+    // ws-25. 6-B: concatenated write redirect (no space after >)
+    (
+        "echo x >~/.claude/settings.json",
+        Decision::Block,
+        "ws-file-write-concat-redirect-block",
+    ),
+    // ws-26. 6-B: &> redirect operator
+    (
+        "echo x &>audit.jsonl",
+        Decision::Block,
+        "ws-file-write-ampersand-redirect-block",
+    ),
+    // ws-27. 6-B: absolute path WRITE_VERB
+    (
+        "/usr/bin/tee ~/.claude/settings.json",
+        Decision::Block,
+        "ws-file-write-verb-abspath-block",
+    ),
+    // ws-28. 6-B: wrapper + direct WRITE_VERB (not shell launcher)
+    (
+        "env -i tee ~/.claude/settings.json",
+        Decision::Block,
+        "ws-file-write-verb-wrapper-block",
+    ),
 ];
 
-/// Per-category minimum floors for `meta-pattern-*` HOOK_DECISION_CASES
-/// entries. Catches category-selective drop that the global ≥18 floor in
-/// `corpus_includes_meta_pattern_coverage` misses (e.g. deleting all 8
-/// `15a` rm boundary fixtures and adding 8 new fixtures elsewhere keeps
-/// the total ≥ 18 but silently drops rm coverage). Sum is 23 — the full
-/// HEAD count including the PR #187 DI-9 additions.
-///
-/// Each prefix anchors with a trailing `-` to prevent accidental
+/// Per-category minimum floors for HOOK_DECISION_CASES entries. Catches
+/// category-selective drop that global floors would miss. Meta-pattern
+/// sum is 23 (PR #187 DI-9 included); ws-* sum is 28 (#248 write-surface
+/// scoping + Codex R1/R2/6-B fix pins). Each prefix anchors with a trailing `-` to prevent accidental
 /// sub-prefix matching: `meta-pattern-bin-rm-` does NOT match
 /// `meta-pattern-bin-rmdir-` because the next char after `rm` is `-` vs
 /// `d`. PR #187 item 1 / PR #186 R5 P3 B2.
@@ -1392,6 +1564,18 @@ const META_PATTERN_CATEGORY_FLOORS: &[(&str, usize)] = &[
     ("meta-pattern-rmdir-", 1),         // 15d FP guard
     ("meta-pattern-bin-rmdir-", 1),     // 15d FP guard
     ("meta-pattern-usr-bin-rmdir-", 1), // 15d FP guard
+    // v0.10.4 write-surface scoping (#248)
+    ("ws-file-read-", 3),              // FP relief: cat, grep, audit read
+    ("ws-file-input-", 1),             // FP relief: input redirect
+    ("ws-file-quoted-", 1),            // FP relief: path in quoted data
+    ("ws-file-launcher-read-", 1),     // FP relief: shell launcher read
+    ("ws-file-launcher-write-", 2),    // write block: launcher write verb + redirect
+    ("ws-file-launcher-combined-", 1), // Codex R1: -lc combined flag
+    ("ws-file-launcher-wrapper-", 1),  // Codex R1: env -i wrapper flags
+    ("ws-file-write-", 12),            // write block: redirect, concat, dup, multifd, &>, append, verb×5, dd
+    ("ws-file-segment-", 2),           // Codex R1/R2: segment boundary FP fixes
+    ("ws-file-write-verb-input-", 1),  // Codex R1: input redirect after WRITE_VERB
+    ("ws-token-", 2),                  // Tier 3 TOKEN isolation
 ];
 
 /// Cross-OS invariant: the same bash input must yield the same Decision on
@@ -1475,11 +1659,20 @@ fn corpus_includes_meta_pattern_coverage() {
             .count();
         assert!(
             count >= *floor,
-            "meta-pattern category '{prefix}*' must have ≥{floor} entries; got {count}. \
-             Category-selective deletion would silently drop this surface coverage even \
-             when the global ≥18 floor still passes."
+            "category '{prefix}*' must have ≥{floor} entries; got {count}. \
+             Category-selective deletion would silently drop this surface coverage."
         );
     }
+
+    // v0.10.4 write-surface scoping (#248): 21 fixtures (9 Allow + 12 Block)
+    let ws_count = HOOK_DECISION_CASES
+        .iter()
+        .filter(|(_, _, cat)| cat.starts_with("ws-"))
+        .count();
+    assert!(
+        ws_count >= 21,
+        "write-surface corpus (#248) must have ≥21 entries; got {ws_count}."
+    );
 }
 
 /// Pin the Block exit code contract at exactly 2. The `cross_os_invariant`


### PR DESCRIPTION
## Summary
- Split `META_PATTERNS_PATH` into 3-tier classification (EXEC/FILE/TOKEN) to scope FILE-tier patterns to write-surface only, eliminating false positives on read/data context
- FILE-tier patterns (8 protected file paths) now block only on write redirect target or WRITE_VERB argument
- TOKEN-tier (sensitive tokens) retains raw unconditional matching; EXEC-tier (rm variants) retains residual substring matching

## Changes
- **hook.rs**: Add write-surface detection (`is_path_in_write_surface`, `is_write_redirect_op`, `is_write_redirect_concatenated`, `is_write_verb`, `shell_dash_c_payload`, `is_after_wrapper_with_flags`), refactor `check_pre_phase_2` to 3-tier processing
- **installer.rs**: Split `META_PATTERNS_PATH` into 3 sub-arrays, expand `WRITE_VERBS` from 9 to 16, update `blocked_string_patterns()` backward compat
- **unwrap.rs**: Make `SHELL_NAMES` `pub(crate)`
- **tests**: 28 write-surface test cases (ws-1 through ws-28) with category floors
- **SECURITY.md**: 3-tier classification docs, stale caveat section updated
- **ACCEPTANCE_TEST.md**: Fenced Block #5 for ws-* dry-run
- **CHANGELOG.md + Cargo.toml**: v0.10.4

## FP relief (Allow)
- `cat ~/.claude/settings.json` — read context
- `grep pattern ~/.claude/settings.json` — read context
- `gh issue create --body "see ~/.claude/settings.json"` — quoted data
- `sort < ~/.claude/settings.json` — input redirect (not write)
- `bash -c "cat ~/.claude/settings.json"` — read inside shell launcher

## Security preservation (Block)
- `echo x > ~/.claude/settings.json` — write redirect target
- `tee ~/.claude/settings.json` — WRITE_VERB
- `bash -c "tee ~/.claude/settings.json"` — shell launcher + WRITE_VERB
- `echo x 10>& ~/.claude/settings.json` — multi-digit fd redirect
- `/bin/rm -rf /tmp/x` — Tier 1 unchanged
- Tier 3 sensitive tokens — raw unconditional unchanged

## Known conservative FP
- `cp ~/.claude/settings.json /tmp/backup` blocks (WRITE_VERB, path is source not dest — per-verb arg mapping deferred)

## Test plan
- [x] 28 ws-* integration tests pass
- [x] All 911 existing tests pass under `RUSTFLAGS="-D warnings"`
- [x] Real binary verification for all 15 success criteria
- [x] Codex R1 exhaustive review (6 findings, all fixed)
- [x] Codex R2 scoped fix verification (2 findings, all fixed)
- [x] Codex 6-B test adversarial review (4 test gaps found, 4 tests added)

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)
