### PR TITLE
style: apply cargo fmt to 3 files (10 hunks)

### DIFF
--- a/src/engine/shim.rs
+++ b/src/engine/shim.rs
@@ -203,9 +203,7 @@ pub(crate) fn ensure_settings_current_for(base_dir: &Path, claude_dir: &Path) ->
                                 let u = c.trim_matches('\'').trim_matches('"');
                                 Path::new(u) == expected_script
                             });
-                    version != env!("CARGO_PKG_VERSION")
-                        || matcher != "Bash"
-                        || !path_current
+                    version != env!("CARGO_PKG_VERSION") || matcher != "Bash" || !path_current
                 }
                 _ => true, // multiple entries → stale accumulation, force cleanup
             }
@@ -930,8 +928,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn ensure_settings_resyncs_when_multiple_entries() {
-        let dir =
-            std::env::temp_dir().join(format!("omamori-shim-multi-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("omamori-shim-multi-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let claude_dir = dir.join(".claude");
         std::fs::create_dir_all(&claude_dir).unwrap();
@@ -943,9 +940,8 @@ mod tests {
         )
         .unwrap();
 
-        let current_entry = installer::claude_settings_entry(
-            &omamori_hooks.join("claude-pretooluse.sh"),
-        );
+        let current_entry =
+            installer::claude_settings_entry(&omamori_hooks.join("claude-pretooluse.sh"));
         let stale_entry = serde_json::json!({
             "matcher": "Bash",
             "hooks": [{"type": "command", "command": "/var/folders/old/hooks/claude-pretooluse.sh"}],
@@ -972,7 +968,11 @@ mod tests {
             .pointer("/hooks/PreToolUse")
             .and_then(|v| v.as_array())
             .unwrap();
-        assert_eq!(arr.len(), 1, "only canonical entry should remain after cleanup");
+        assert_eq!(
+            arr.len(),
+            1,
+            "only canonical entry should remain after cleanup"
+        );
         let remaining = &arr[0];
         let remaining_ver = remaining
             .get("x-omamori-version")

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -834,7 +834,11 @@ pub(crate) fn is_safe_to_remove(entry: &serde_json::Value) -> bool {
 /// false positives on user scripts that happen to share the filename.
 pub(crate) fn is_omamori_hook_path(path: &Path) -> bool {
     path.file_name().and_then(|f| f.to_str()) == Some("claude-pretooluse.sh")
-        && path.parent().and_then(|p| p.file_name()).and_then(|d| d.to_str()) == Some("hooks")
+        && path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|d| d.to_str())
+            == Some("hooks")
 }
 
 /// True if `matcher` is a legacy form that the current Claude Code parser
@@ -2565,11 +2569,7 @@ mod tests {
             .pointer("/hooks/PreToolUse")
             .and_then(|v| v.as_array())
             .unwrap();
-        assert_eq!(
-            arr.len(),
-            2,
-            "hybrid (user-only now) + canonical pushed"
-        );
+        assert_eq!(arr.len(), 2, "hybrid (user-only now) + canonical pushed");
         // The hybrid entry should now have only the user hook (omamori extracted)
         assert_eq!(
             arr[0].pointer("/hooks/0/command").and_then(|v| v.as_str()),
@@ -2873,9 +2873,7 @@ mod tests {
         let hybrid_hooks = hybrid.get("hooks").and_then(|v| v.as_array()).unwrap();
         assert_eq!(hybrid_hooks.len(), 1, "only user hook remains in hybrid");
         assert_eq!(
-            hybrid_hooks[0]
-                .get("command")
-                .and_then(|v| v.as_str()),
+            hybrid_hooks[0].get("command").and_then(|v| v.as_str()),
             Some("/usr/local/bin/userhook")
         );
 

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -408,9 +408,7 @@ fn check_claude_settings_integration(base_dir: &Path) -> CheckItem {
         }
     };
 
-    let arr_opt = doc
-        .pointer("/hooks/PreToolUse")
-        .and_then(|v| v.as_array());
+    let arr_opt = doc.pointer("/hooks/PreToolUse").and_then(|v| v.as_array());
 
     // Count all omamori-managed entries (tag OR path OR filename pattern).
     let omamori_count = arr_opt
@@ -1727,8 +1725,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn doctor_detects_duplicate_omamori_entries() {
-        let dir =
-            std::env::temp_dir().join(format!("omamori-int-dup-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("omamori-int-dup-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         let claude_dir = dir.join(".claude");
         fs::create_dir_all(&claude_dir).unwrap();
@@ -1790,8 +1787,7 @@ mod tests {
     /// be counted as a duplicate omamori entry.
     #[test]
     fn doctor_does_not_count_user_hook_as_duplicate() {
-        let dir =
-            std::env::temp_dir().join(format!("omamori-int-nodup-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("omamori-int-nodup-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         let claude_dir = dir.join(".claude");
         fs::create_dir_all(&claude_dir).unwrap();


### PR DESCRIPTION
## Summary
- Apply `cargo fmt --all` to fix formatting violations in 3 files (10 hunks)
- Whitespace-only changes, zero semantic impact
- Unblocks CI format check for subsequent PRs

## Files
- `src/engine/shim.rs` (4 hunks)
- `src/installer.rs` (3 hunks)
- `src/integrity.rs` (3 hunks)

## Test plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] `git diff` confirms whitespace-only changes
- [x] `cargo test --locked` passes (1 pre-existing flaky in #260, unrelated)

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)