### PR TITLE
fix(security): replace fs::copy with atomic_write for backup path

### DIFF
--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1131,7 +1131,7 @@ pub(crate) fn update_codex_config(codex_dir: &Path) -> Result<CodexConfigOutcome
 
     // Backup before modifying
     let backup_path = codex_dir.join("config.toml.bak");
-    fs::copy(&config_path, &backup_path)?;
+    atomic_write(&backup_path, &raw)?;
 
     // Set features.codex_hooks = true (creates [features] section if needed)
     doc["features"]["codex_hooks"] = toml_edit::value(true);
@@ -1879,6 +1879,39 @@ mod tests {
         // File not modified
         let content = fs::read_to_string(dir.join("config.toml")).unwrap();
         assert!(content.contains("codex_hooks = false"));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn update_codex_config_bak_symlink_is_safe() {
+        let dir = std::env::temp_dir().join(format!("omamori-toml-sym-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let original = "model = \"gpt-5.3-codex\"\n";
+        fs::write(dir.join("config.toml"), original).unwrap();
+
+        // Place a symlink at config.toml.bak -> canary file
+        let canary = dir.join("canary.txt");
+        fs::write(&canary, "DO NOT OVERWRITE").unwrap();
+        std::os::unix::fs::symlink(&canary, dir.join("config.toml.bak")).unwrap();
+
+        let result = update_codex_config(&dir).unwrap();
+        assert!(matches!(result, CodexConfigOutcome::Added));
+
+        // Canary must be untouched (symlink target not followed)
+        assert_eq!(fs::read_to_string(&canary).unwrap(), "DO NOT OVERWRITE");
+
+        // Backup must be a regular file (symlink replaced by atomic_write rename)
+        let bak = dir.join("config.toml.bak");
+        assert!(!bak.is_symlink(), "backup must not be a symlink after fix");
+        assert_eq!(fs::read_to_string(&bak).unwrap(), original);
+
+        // Config must be updated
+        let config = fs::read_to_string(dir.join("config.toml")).unwrap();
+        assert!(config.contains("codex_hooks = true"));
 
         let _ = fs::remove_dir_all(dir);
     }


### PR DESCRIPTION
## Summary

- Replace `fs::copy` with `atomic_write` for the backup path in `update_codex_config` (installer.rs L1134), eliminating symlink-via-backup arbitrary file overwrite
- `atomic_write` uses temp file + `rename(2)`, which atomically replaces a symlink without following it — no TOCTOU race window
- After this change, zero `fs::copy` calls remain in the codebase

## Security

**Vulnerability**: A symlink planted at `~/.codex/config.toml.bak` would cause `fs::copy` to follow the symlink and overwrite the target file with config content (DREAD 5.2 Medium).

**Fix**: `atomic_write` writes to a temp file in the same directory, then calls `rename(2)`. `rename(2)` replaces the symlink entry itself, leaving the former target untouched.

## Changes

| File | Change |
|------|--------|
| `src/installer.rs` L1134 | `fs::copy(&config_path, &backup_path)?` → `atomic_write(&backup_path, &raw)?` |
| `src/installer.rs` L1886+ | New test: `update_codex_config_bak_symlink_is_safe` |

## Verification

| V-ID | What | Result |
|------|------|--------|
| V-001 | Symlink at .bak doesn't follow target | PASS (new test) |
| V-002 | Zero `fs::copy` in codebase | PASS (`grep -r 'fs::copy' src/` → empty) |

## Test plan

- [x] `cargo test update_codex_config` — 5/5 pass (including new symlink test)
- [x] `cargo fmt --all -- --check` — clean
- [x] `grep -r 'fs::copy' src/` — zero results

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)