### PR TITLE
fix(test): add serial annotation to HOME-mutating test

### DIFF
--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -1786,6 +1786,7 @@ mod tests {
     /// claude-pretooluse.sh (but outside omamori's hooks/ dir) must NOT
     /// be counted as a duplicate omamori entry.
     #[test]
+    #[serial_test::serial]
     fn doctor_does_not_count_user_hook_as_duplicate() {
         let dir = std::env::temp_dir().join(format!("omamori-int-nodup-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

- Add missing `#[serial_test::serial]` to `doctor_does_not_count_user_hook_as_duplicate` in `src/integrity.rs`
- This test mutates the HOME environment variable but ran in parallel with other HOME-dependent tests, causing intermittent CI failures (e.g. PR #268 macOS run)

## Evidence

The flaky failure manifests as `merge_claude_cleans_legacy_entry_without_version_tag` asserting `left: 2, right: 1` — the unserialized HOME mutation from `doctor_does_not_count_user_hook_as_duplicate` leaks into serialized tests running concurrently.

Exhaustive scan confirmed this was the **only** HOME-mutating test missing the annotation (22+ others all have it).

## Changes

| File | Change |
|------|--------|
| `src/integrity.rs` L1789 | Add `#[serial_test::serial]` between `#[test]` and `fn doctor_does_not_count_user_hook_as_duplicate` |

## Verification

| V-ID | What | Result |
|------|------|--------|
| V-003 | Serial annotation present | PASS |
| V-004 | `cargo test` 3x stable (764 passed, 0 failed each run) | PASS |

## Test plan

- [x] `cargo test` — 3 consecutive runs, 0 failures
- [x] `cargo fmt --all -- --check` — clean

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)