### PR TITLE
chore: bump to v0.10.6

### DIFF
--- a/ACCEPTANCE_TEST.md
+++ b/ACCEPTANCE_TEST.md
@@ -49,7 +49,7 @@ omamori install --force
 #    既存 session 内 hook script は古い binary path を embed している場合がある
 
 # (4) 開始時 sanity check (このセクションを始める前に必ず通す)
-omamori --version | grep -qE '0\.10\.3' && echo "v0.10.3 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
+omamori --version | grep -qE '0\.10\.6' && echo "v0.10.6 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
 
 # (5) AI 環境を維持 (raw terminal でも同じ)
 export CLAUDECODE=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.10.6] - 2026-05-12
+
+**Summary**: Four bug fixes — CI format blocker, symlink-via-backup arbitrary file overwrite (security), flaky parallel test, and stale acceptance test version.
+
+### Fixed
+
+- **CI format blocker** — `cargo fmt --all` applied to `src/engine/shim.rs`, `src/installer.rs`, `src/integrity.rs` (10 hunks, whitespace-only). Unblocked CI for all subsequent PRs. ([#259](https://github.com/yottayoshida/omamori/issues/259))
+- **Symlink-via-backup file overwrite (security)** — Replaced `fs::copy` with `atomic_write` for the backup path in `update_codex_config`. `fs::copy` followed symlinks, so a symlink at `config.toml.bak` could overwrite an arbitrary file. `atomic_write` uses temp file + `rename(2)`, which atomically replaces the symlink without following it. Zero `fs::copy` calls remain in the codebase. DREAD 5.2 (Medium). ([#258](https://github.com/yottayoshida/omamori/issues/258))
+- **Flaky parallel test** — Added missing `#[serial_test::serial]` to `doctor_does_not_count_user_hook_as_duplicate`, which mutated HOME without serialization, causing intermittent failures in other HOME-dependent tests. ([#260](https://github.com/yottayoshida/omamori/issues/260))
+- **Stale acceptance test version** — Updated `ACCEPTANCE_TEST.md` sanity check from `0.10.3` to `0.10.6`. ([#261](https://github.com/yottayoshida/omamori/issues/261))
+
 ## [0.10.5] - 2026-05-10
 
 **Summary**: Fix stale hook entry accumulation in `~/.claude/settings.json` ([#254](https://github.com/yottayoshida/omamori/issues/254)). When the omamori install root changed (brew upgrade, `--base-dir`, CI temp dirs), `merge_claude_settings()` failed to detect old entries and accumulated duplicates. Now uses `x-omamori-version` tag (primary) + path-based fallback (secondary) to identify ALL omamori-managed entries regardless of origin root, removing stale entries via `retain()` before inserting one clean canonical entry. Also a security fix: stale entries pointing to predictable `/var/folders/` temp paths were exploitable (T3 DREAD 7.6).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "criterion",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.10.5"
+version = "0.10.6"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"


### PR DESCRIPTION
## Summary

- Bump version 0.10.5 → 0.10.6 in `Cargo.toml` and `Cargo.lock`
- Add v0.10.6 CHANGELOG entry covering all 4 fixes (#258 #259 #260 #261)
- Update `ACCEPTANCE_TEST.md` sanity check version from `0.10.3` to `0.10.6`

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | version `"0.10.5"` → `"0.10.6"` |
| `Cargo.lock` | auto-updated |
| `CHANGELOG.md` | v0.10.6 entry added |
| `ACCEPTANCE_TEST.md` L52 | `0\.10\.3` → `0\.10\.6` |

## Test plan

- [x] `cargo check` — compiles with new version
- [x] `cargo fmt --all -- --check` — clean
- [x] Version consistent across Cargo.toml, Cargo.lock, ACCEPTANCE_TEST.md

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)