### PR TITLE
fix: terminology, CI clippy parity, and script diagnostics (#263, #264, #265, #266)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: clippy
-      - run: cargo clippy --locked -- -D warnings
+      - run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
   fmt:
     name: Format

--- a/scripts/check-lockfile-regressions.sh
+++ b/scripts/check-lockfile-regressions.sh
@@ -60,7 +60,7 @@ direct_deps() {
     # Splitting on "@" and taking the last element yields the version.
     # (Git / path dependencies also suffix "@X.Y.Z" when resolved, so this
     # holds across source types.)
-    cargo metadata --locked --format-version 1 2>/dev/null \
+    cargo metadata --locked --format-version 1 \
         | jq -r '
             .resolve.root as $root
             | .resolve.nodes[] | select(.id == $root) | .deps[]

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -5,7 +5,7 @@
 //! - `retention`: Automatic pruning of old entries
 //! - `secret`: HMAC key management, symlink-safe I/O, key rotation
 //! - `verify`: Chain verification, entry display, summary for CLI
-//! - `report`: Aggregation for `omamori report` (v0.10.0, #221)
+//! - `report`: Aggregation for `omamori report` (since v0.10.0, #221)
 
 pub mod chain;
 pub mod report;

--- a/src/cli/checks_display.rs
+++ b/src/cli/checks_display.rs
@@ -1,7 +1,7 @@
 //! Shared display utilities for doctor/status check output.
 //!
 //! Maps integrity `CheckItem.category` strings to doctor's 4-section model.
-//! Status retains its own legacy formatter (v0.10.0 compat).
+//! Status retains its own legacy formatter (since v0.10.0).
 
 use crate::integrity::CheckItem;
 

--- a/src/cli/explain.rs
+++ b/src/cli/explain.rs
@@ -75,7 +75,7 @@ pub(crate) fn run_explain_command(args: &[OsString]) -> Result<i32, AppError> {
     // --- Layer 1 evaluation (shim / PATH-level) ---
     let layer1 = evaluate_layer1(&command_parts, config_path.as_deref());
 
-    // --- Layer 2 evaluation (hook / string-level) ---
+    // --- Layer 2 evaluation (hook / token-level) ---
     let layer2 = evaluate_layer2(&command_str);
 
     // --- Verdict ---

--- a/src/context.rs
+++ b/src/context.rs
@@ -498,7 +498,7 @@ mod tests {
     //     to their intent (exercising git-aware evaluation that shells out
     //     to `git`).
     //
-    // v0.10.0 #175 tracks the full public-API promotion of
+    // Since v0.10.0, #175 tracks the full public-API promotion of
     // `normalize_path`/`resolve_path`/`evaluate_context` to require an
     // explicit `base: &Path`, at which point the process CWD can be banned
     // outside the shim/hook entry points via `.clippy.toml` disallowed_methods.

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -29,7 +29,7 @@ use crate::unwrap;
 pub(crate) enum HookCheckResult {
     /// Command is allowed — no protected pattern matched.
     Allow,
-    /// Command is blocked by a meta-pattern (string-level).
+    /// Command is blocked by a phase-1b token-level meta-pattern.
     ///
     /// `matched_pattern` carries the protected pattern token (`"config disable"`,
     /// `"omamori uninstall"`, etc.) for acceptance test assertions and
@@ -498,14 +498,14 @@ fn run_hook_check_command(
                 eprintln!("omamori hook: blocked — {reason}");
                 if verbose {
                     eprintln!("  provider: {provider}");
-                    eprintln!("  layer: meta-pattern (string-level)");
+                    eprintln!("  layer: phase-1b (token-level)");
                     if let Some(p) = matched_pattern {
                         eprintln!("  matched: {p:?}");
                     }
                 }
                 eprintln!("  hint: run `omamori explain -- {command}` for details");
                 eprintln!(
-                    "  bypass: if the protected token is inside data context (e.g. `gh issue create --body`), use --body-file <path> for one-off"
+                    "  hint: if the protected token is inside data context, pass it via a file (e.g. `--body-file <path>`) to avoid the match"
                 );
             }
             Ok(2)

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1346,8 +1346,8 @@ mod tests {
     #[test]
     fn protected_env_vars_constant_covers_all_detectors() {
         // Verify PROTECTED_ENV_VARS covers all expected detector variables.
-        // Env var tampering detection is now handled by Phase 1B (token-level)
-        // in hook.rs, not by string-level patterns.
+        // Env var tampering detection is handled by Phase 1B (token-level)
+        // in hook.rs.
         for var in &[
             "CLAUDECODE",
             "CODEX_CI",

--- a/src/property_tests.rs
+++ b/src/property_tests.rs
@@ -5,7 +5,7 @@
 //! hook) MUST block the wrapped command string. The reverse direction is
 //! intentionally not pinned: Layer 2 may legitimately block strings whose
 //! tokenized form Layer 1 allows (e.g. parse errors, env-var tampering on
-//! non-shim verbs, structural pipe-to-shell, meta-pattern path bypass).
+//! non-shim verbs, structural pipe-to-shell, phase-1b token-level bypass).
 //!
 //! ## Why a crate-internal test, not `tests/`
 //!
@@ -120,7 +120,7 @@ fn layer1_destructive(program: &str, args: &[String], rules: &[RuleConfig]) -> b
 
 /// Layer 2 blocking verdict against an explicit rule slice (hermetic; does
 /// not read on-disk config). Returns true for any of the three blocking
-/// variants of `check_command_for_hook_with_rules` (meta-pattern,
+/// variants of `check_command_for_hook_with_rules` (phase-1b token,
 /// structural unwrap, rule match).
 fn layer2_blocks(command: &str, rules: &[RuleConfig]) -> bool {
     matches!(

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -1113,9 +1113,9 @@ pub(crate) fn is_env_assignment(token: &str) -> bool {
 /// -s` consume `-s` as a script path (Codex Round 2 Axis 5/Axis 1 P0).
 ///
 /// Single source of truth for redirect classification in this module.
-/// Designed to migrate to `src/parser/redirect.rs` in v0.10.0
-/// (shape_complexity refactor, Codex Round 2 Axis 6 + architect Round 3
-/// confidence 0.88).
+/// Originally planned for v0.10.0, now deferred to v0.11.0 with
+/// `src/parser/` extraction (shape_complexity refactor, Codex Round 2
+/// Axis 6 + architect Round 3 confidence 0.88).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RedirectToken {
     /// Standalone redirect operator that consumes the *next* token as its
@@ -1166,7 +1166,7 @@ impl RedirectToken {
     /// Multi-digit fd (`10<file`) is deliberately NOT recognized; only
     /// single digits 0-9 are accepted as fd prefix. Real-world AI default
     /// mutation uses single-digit fd; multi-digit expansion deferred to
-    /// v0.10.0 with `src/parser/` extraction (architect Round 3 Open Q 2,
+    /// v0.11.0 with `src/parser/` extraction (architect Round 3 Open Q 2,
     /// orchestrator pre-defer recommendation).
     pub(crate) fn classify(token: &str) -> Self {
         if token.is_empty() {
@@ -1566,7 +1566,7 @@ fn segment_has_stdin_redirect(tokens: &[String]) -> bool {
         // exemption. shell_words::split strips quotes, leaving the bare
         // operator indistinguishable from the real form except by the
         // presence of an operand (QA P0-2 fix).
-        // TODO(v0.10.0): unify with `RedirectToken` after `src/parser/`
+        // TODO(v0.11.0): unify with `RedirectToken` after `src/parser/`
         // extraction. The literal sets here intentionally diverge from
         // `RedirectToken::classify` because this function answers a
         // different question (does the segment have an *explicit stdin*
@@ -4870,7 +4870,7 @@ mod tests {
     // protected (pipe-to-shell detection catches the RHS of the synthetic
     // pipe split), but the FP side cannot round-trip through the parser
     // intact. Correct handling requires `src/parser/` extraction to layer
-    // redirect tokenization above pipe normalization, deferred to v0.10.0.
+    // redirect tokenization above pipe normalization, deferred to v0.11.0.
 
     #[test]
     fn fp_pin_readwrite_redirect_allowed() {


### PR DESCRIPTION
## Summary

- Rename human-facing "string-level" → "token-level" / "phase-1b" in doc comments and verbose stderr; JSON/audit/taxonomy strings frozen for v0.11.0 (#263)
- Add `--all-targets --all-features` to CI clippy job for local parity (#264)
- Remove `2>/dev/null` from lockfile script so `cargo metadata` errors surface (#265)
- Update stale `v0.10.0` TODO/version refs to `v0.11.0` or "since v0.10.0" (#266)

## Freeze boundary verification

`layer2:meta-pattern` appears in 9 locations (JSON output, audit log, taxonomy constant, test assertions). All 9 verified unchanged before and after this PR via `grep -rn 'layer2:meta-pattern' src/ tests/`.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo test --locked` — all pass
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `bash scripts/check-lockfile-regressions.sh` — exit 0
- [x] Frozen ref count: 9 → 9 (unchanged)
- [x] Stale `v0.10.0` refs: 0 remaining as future-intent (4 remain as accurate history "since v0.10.0")

🤖 Generated with [Claude Code](https://claude.com/claude-code)