### PR TITLE
fix(config): use neutral messages for shared rule strings (#274)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -451,10 +451,7 @@ pub fn default_rules() -> Vec<RuleConfig> {
                 "-fr".to_string(),
                 "--recursive".to_string(),
             ],
-            Some(
-                "omamori moved the recursive rm targets to Trash instead of deleting them"
-                    .to_string(),
-            ),
+            Some("omamori intercepted recursive rm — targets not deleted".to_string()),
         )
         .with_builtin(true),
         RuleConfig::new(
@@ -463,7 +460,7 @@ pub fn default_rules() -> Vec<RuleConfig> {
             ActionKind::StashThenExec,
             vec!["reset".to_string(), "--hard".to_string()],
             Vec::new(),
-            Some("omamori stashed changes before running git reset --hard".to_string()),
+            Some("omamori intercepted git reset --hard — changes preserved".to_string()),
         )
         .with_builtin(true),
         RuleConfig::new(


### PR DESCRIPTION
## Summary

- Replace misleading `RuleConfig.message` strings that claimed actions were performed ("moved to Trash", "stashed changes") with neutral wording that is accurate in both the shim path (where actions execute) and the hook-check path (where commands are only blocked)
- `rm-recursive-to-trash`: "omamori intercepted recursive rm — targets not deleted"
- `git-reset-hard-stash`: "omamori intercepted git reset --hard — changes preserved"

## Context

`RuleConfig.message` is shared across three output paths:
1. **Shim** (`shim.rs`): prints after Trash/stash action completes
2. **Hook-check** (`hook.rs`): prints when blocking a command (no action taken)
3. **Cursor hook** (`hook.rs`): prints when blocking (same as hook-check)

The old messages ("moved to Trash", "stashed changes") were accurate only in path 1 but false in paths 2 and 3. The new "intercepted" wording is truthful in all three.

## Test plan

- [x] `cargo test` — all pass
- [x] `RUSTFLAGS="-D warnings" cargo test` — all pass
- [x] `echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/test"}}' | cargo run -- hook-check --provider claude-code` outputs "intercepted recursive rm"
- [x] `echo '{"tool_name":"Bash","tool_input":{"command":"git reset --hard"}}' | cargo run -- hook-check --provider claude-code` outputs "intercepted git reset --hard"
- [x] No occurrences of "moved the recursive rm" or "stashed changes before" remain in `src/`

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)