### PR TITLE
docs: bump to v0.10.8, update CHANGELOG and ACCEPTANCE_TEST

### DIFF
--- a/ACCEPTANCE_TEST.md
+++ b/ACCEPTANCE_TEST.md
@@ -61,7 +61,7 @@ omamori install --force
 #    既存 session 内 hook script は古い binary path を embed している場合がある
 
 # (4) 開始時 sanity check (このセクションを始める前に必ず通す)
-omamori --version | grep -qE '0\.10\.7' && echo "v0.10.7 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
+omamori --version | grep -qE '0\.10\.8' && echo "v0.10.8 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
 
 # (5) AI 環境を維持 (raw terminal でも同じ)
 export CLAUDECODE=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.10.8] - 2026-05-13
+
+**Summary**: Fix misleading hook-check messages — `RuleConfig.message` is shared by both the shim path (which executes Trash/stash actions) and the hook-check path (which only blocks), so the old action-completed wording ("moved to Trash", "stashed changes") was false in the hook-check path. Replaced with neutral wording ("intercepted … targets not deleted", "intercepted … changes preserved") that is accurate in both paths.
+
+### Fixed
+
+- **Misleading hook-check messages** — The `rm-recursive-to-trash` and `git-reset-hard-stash` rules claimed actions were taken ("moved to Trash", "stashed changes before running") even when the hook-check path only blocked the command without executing any action. Replaced with neutral "intercepted" wording that is truthful in both the shim path (action executed) and hook-check path (block only). ([#274](https://github.com/yottayoshida/omamori/issues/274))
+
 ## [0.10.7] - 2026-05-13
 
 **Summary**: Documentation accuracy, CI parity, and developer tooling improvements — no detection logic changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "criterion",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.10.7"
+version = "0.10.8"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"


### PR DESCRIPTION
## Summary

- Bump version to v0.10.8
- Add CHANGELOG entry for #274 (misleading hook-check messages fix)
- Update ACCEPTANCE_TEST.md sanity check version

## Test plan

- [x] `cargo check` passes with new version
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)