### PR TITLE
feat(context): enable context-aware evaluation by default

### DIFF
--- a/ACCEPTANCE_TEST.md
+++ b/ACCEPTANCE_TEST.md
@@ -61,7 +61,7 @@ omamori install --force
 #    既存 session 内 hook script は古い binary path を embed している場合がある
 
 # (4) 開始時 sanity check (このセクションを始める前に必ず通す)
-omamori --version | grep -qE '0\.10\.8' && echo "v0.10.8 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
+omamori --version | grep -qE '0\.10\.9' && echo "v0.10.9 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
 
 # (5) AI 環境を維持 (raw terminal でも同じ)
 export CLAUDECODE=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.10.9] - 2026-05-17
+
+**Summary**: Context-aware evaluation is now enabled by default. New installs get smart regenerable-path downgrade (Tier 1) and git-aware evaluation (Tier 2) out of the box, eliminating first-day false positives on `rm -rf target/`, `rm -rf node_modules/`, etc. Existing users without a `[context]` section in their config are completely unaffected (`context` remains `None`). Users with `[context]` but no `[context.git]` will now get git-aware evaluation activated (safer direction — opt out by adding `[context.git]\nenabled = false`).
+
+### Changed
+
+- **`Config::default()` now includes `context: Some(ContextConfig::default())`** — previously `context: None`. First-time users (no config file) and `omamori init` users both get context-aware evaluation active from the start. ([#279](https://github.com/yottayoshida/omamori/issues/279))
+- **`GitContextConfig` serde default for `enabled` field** — changed from `#[serde(default)]` (= `false`) to `#[serde(default = "default_git_enabled")]` (= `true`). When a config file has `[context.git]` without an explicit `enabled` key, git-aware evaluation is now on by default. ([#279](https://github.com/yottayoshida/omamori/issues/279))
+- **`config_template()` output** — `[context]` section header is now uncommented so that `omamori init` creates a config file with context-aware evaluation active. Individual fields remain commented (serde defaults apply). ([#279](https://github.com/yottayoshida/omamori/issues/279))
+- **`config.default.toml`** — `[context]` and `[context.git]` sections uncommented. `regenerable_paths` aligned with code defaults (added `.next/`, `.cache/`). ([#279](https://github.com/yottayoshida/omamori/issues/279))
+
+### Added
+
+- **`impl Default for ContextConfig`** — explicit default implementation with `default_regenerable_paths()`, `default_protected_paths()`, and `GitContextConfig::default()`.
+- **4 new tests** — `default_config_has_context_enabled`, `config_default_toml_context_matches_defaults`, `config_template_roundtrip_has_context`, `serde_empty_git_section_defaults_enabled_true`.
+
 ## [0.10.8] - 2026-05-13
 
 **Summary**: Fix misleading hook-check messages — `RuleConfig.message` is shared by both the shim path (which executes Trash/stash actions) and the hook-check path (which only blocks), so the old action-completed wording ("moved to Trash", "stashed changes") was false in the hook-check path. Replaced with neutral wording ("intercepted … targets not deleted", "intercepted … changes preserved") that is accurate in both paths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "criterion",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.10.8"
+version = "0.10.9"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"

--- a/README.md
+++ b/README.md
@@ -175,12 +175,11 @@ omamori can adjust actions based on what the command targets:
 | `rm -rf src/` | trash | **block** (protected) |
 | `git reset --hard` (no changes) | stash-then-exec | **log-only** (git-aware) |
 
-**Opt-in**: add `[context]` to `~/.config/omamori/config.toml`. Built-in lists for regenerable (`target/`, `node_modules/`, etc.) and protected (`src/`, `.git/`, `.env`, etc.) paths activate automatically.
+**Enabled by default** (v0.10.9+). Built-in lists for regenerable (`target/`, `node_modules/`, etc.) and protected (`src/`, `.git/`, `.env`, etc.) paths are active out of the box. To customize, add a `[context]` section to `~/.config/omamori/config.toml`:
 
 ```toml
 [context]
-# Built-in defaults activate with just [context].
-# To customize, specify your own lists (replaces built-in defaults):
+# Specifying a list replaces the built-in defaults (not appends).
 # regenerable_paths = ["target/", "node_modules/", "my-cache/"]
 # protected_paths = ["src/", "lib/", ".git/", ".env", ".ssh/", "secrets/"]
 ```

--- a/config.default.toml
+++ b/config.default.toml
@@ -158,17 +158,16 @@ message = "omamori blocked explain via AI (oracle attack prevention)"
 # match_any = ["-r", "-rf", "-fr", "--recursive"]
 # message = "omamori moved targets to backup instead of deleting"
 
-# --- Context-aware evaluation (new in v0.4) ---
-# Uncomment to enable context-aware rule evaluation.
-# When present (even empty), built-in defaults for protected/regenerable paths activate.
-#
-# [context]
-# protected_paths = ["src/", "lib/", ".git/", ".env", ".ssh/"]
-# regenerable_paths = ["target/", "dist/", "node_modules/", "build/", "__pycache__/", ".cache/"]
-#
-# [context.git]
-# enabled = true
-# timeout_ms = 100
+# --- Context-aware evaluation (enabled by default since v0.10.9) ---
+# Built-in defaults are active. Uncomment individual fields to customize.
+
+[context]
+protected_paths = ["src/", "lib/", ".git/", ".env", ".ssh/"]
+regenerable_paths = ["target/", "node_modules/", ".next/", "dist/", "build/", "__pycache__/", ".cache/"]
+
+[context.git]
+enabled = true
+timeout_ms = 100
 
 [audit]
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -1383,7 +1383,10 @@ action = "block"
     #[test]
     fn default_config_has_context_enabled() {
         let config = Config::default();
-        assert!(config.context.is_some(), "context should be enabled by default");
+        assert!(
+            config.context.is_some(),
+            "context should be enabled by default"
+        );
         let ctx = config.context.unwrap();
         assert!(!ctx.regenerable_paths.is_empty());
         assert!(!ctx.protected_paths.is_empty());
@@ -1395,7 +1398,9 @@ action = "block"
         let toml_str = include_str!("../config.default.toml");
         let parsed: Config = toml::from_str(toml_str).unwrap();
         let code_ctx = crate::context::ContextConfig::default();
-        let toml_ctx = parsed.context.expect("config.default.toml must have [context]");
+        let toml_ctx = parsed
+            .context
+            .expect("config.default.toml must have [context]");
         assert_eq!(toml_ctx.regenerable_paths, code_ctx.regenerable_paths);
         assert_eq!(toml_ctx.protected_paths, code_ctx.protected_paths);
         assert_eq!(toml_ctx.git.enabled, code_ctx.git.enabled);

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,8 +23,8 @@ pub struct Config {
     pub rules: Vec<RuleConfig>,
     #[serde(default)]
     pub audit: AuditConfig,
-    /// Context-aware evaluation config. None = context evaluation disabled (v0.3 compat).
-    /// Present (even empty) = built-in defaults active.
+    /// Context-aware evaluation config. Enabled by default (v0.10.9+).
+    /// None disables context evaluation; Some(_) activates built-in defaults.
     #[serde(default)]
     pub context: Option<ContextConfig>,
 }
@@ -35,7 +35,7 @@ impl Default for Config {
             detectors: default_detectors(),
             rules: default_rules(),
             audit: AuditConfig::default(),
-            context: None,
+            context: Some(crate::context::ContextConfig::default()),
         }
     }
 }
@@ -651,6 +651,18 @@ pub fn config_template() -> String {
          # destination = \"/tmp/omamori-quarantine/\"\n\
          # match_any = [\"-r\", \"-rf\", \"-fr\", \"--recursive\"]\n\
          # message = \"omamori moved targets to backup instead of deleting\"\n",
+    );
+    out.push_str(
+        "\n# --- Context-aware evaluation (enabled by default) ---\n\
+         # Built-in defaults are active. Uncomment lines below to customize.\n\
+         [context]\n\
+         # regenerable_paths = [\"target/\", \"node_modules/\", \".next/\", \"dist/\", \
+         \"build/\", \"__pycache__/\", \".cache/\"]\n\
+         # protected_paths = [\"src/\", \"lib/\", \".git/\", \".env\", \".ssh/\"]\n\
+         #\n\
+         # [context.git]\n\
+         # enabled = true\n\
+         # timeout_ms = 100\n",
     );
     out
 }
@@ -1363,6 +1375,74 @@ action = "block"
              In code only: {:?}",
             toml_names.difference(&code_names).collect::<Vec<_>>(),
             code_names.difference(&toml_names).collect::<Vec<_>>(),
+        );
+    }
+
+    // --- Context default-on (v0.10.9) ---
+
+    #[test]
+    fn default_config_has_context_enabled() {
+        let config = Config::default();
+        assert!(config.context.is_some(), "context should be enabled by default");
+        let ctx = config.context.unwrap();
+        assert!(!ctx.regenerable_paths.is_empty());
+        assert!(!ctx.protected_paths.is_empty());
+        assert!(ctx.git.enabled, "git-aware should be enabled by default");
+    }
+
+    #[test]
+    fn config_default_toml_context_matches_defaults() {
+        let toml_str = include_str!("../config.default.toml");
+        let parsed: Config = toml::from_str(toml_str).unwrap();
+        let code_ctx = crate::context::ContextConfig::default();
+        let toml_ctx = parsed.context.expect("config.default.toml must have [context]");
+        assert_eq!(toml_ctx.regenerable_paths, code_ctx.regenerable_paths);
+        assert_eq!(toml_ctx.protected_paths, code_ctx.protected_paths);
+        assert_eq!(toml_ctx.git.enabled, code_ctx.git.enabled);
+        assert_eq!(toml_ctx.git.timeout_ms, code_ctx.git.timeout_ms);
+    }
+
+    #[test]
+    fn config_template_roundtrip_has_context() {
+        let template = config_template();
+        let parsed: Config = toml::from_str(&template).unwrap();
+        assert!(
+            parsed.context.is_some(),
+            "config_template() must produce a TOML with [context] active"
+        );
+    }
+
+    #[test]
+    fn serde_empty_git_section_defaults_enabled_true() {
+        let toml_str = "[context]\n[context.git]\n";
+        let parsed: Config = toml::from_str(toml_str).unwrap();
+        let ctx = parsed.context.expect("[context] should parse");
+        assert!(
+            ctx.git.enabled,
+            "empty [context.git] should default to enabled=true"
+        );
+    }
+
+    #[test]
+    fn existing_config_without_context_stays_none() {
+        let toml_str = r#"
+[[detectors]]
+name = "claude-code"
+type = "env_var"
+env_key = "CLAUDECODE"
+env_value = "1"
+
+[[rules]]
+name = "rm-recursive-to-trash"
+command = "rm"
+action = "trash"
+match_any = ["-r", "-rf"]
+message = "moved to trash"
+"#;
+        let parsed: Config = toml::from_str(toml_str).unwrap();
+        assert!(
+            parsed.context.is_none(),
+            "config without [context] section must parse to context: None"
         );
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -26,9 +26,19 @@ pub struct ContextConfig {
     pub git: GitContextConfig,
 }
 
+impl Default for ContextConfig {
+    fn default() -> Self {
+        Self {
+            regenerable_paths: default_regenerable_paths(),
+            protected_paths: default_protected_paths(),
+            git: GitContextConfig::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitContextConfig {
-    #[serde(default)]
+    #[serde(default = "default_git_enabled")]
     pub enabled: bool,
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
@@ -37,7 +47,7 @@ pub struct GitContextConfig {
 impl Default for GitContextConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             timeout_ms: default_timeout_ms(),
         }
     }
@@ -45,6 +55,10 @@ impl Default for GitContextConfig {
 
 fn default_timeout_ms() -> u64 {
     100
+}
+
+fn default_git_enabled() -> bool {
+    true
 }
 
 // ---------------------------------------------------------------------------

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -1331,14 +1331,14 @@ mod tests {
     /// cannot find config.toml and falls back to `Config::default()`.
     ///
     /// # Safety
-    /// Env-var mutation is guarded by `#[serial_test::serial]` on every caller.
+    /// Env-var mutation is guarded by `#[serial_test::serial(home_env)]` on every caller.
     fn isolate_config() -> (Option<String>, Option<String>, PathBuf) {
         let dir = std::env::temp_dir().join(format!("omamori-gr-iso-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let old_xdg = std::env::var("XDG_CONFIG_HOME").ok();
         let old_home = std::env::var("HOME").ok();
-        // SAFETY: serialized by #[serial_test::serial] — no concurrent env reads.
+        // SAFETY: serialized by #[serial_test::serial(home_env)] — no concurrent env reads.
         unsafe {
             std::env::set_var("XDG_CONFIG_HOME", dir.join("xdg"));
             std::env::set_var("HOME", &dir);
@@ -1347,7 +1347,7 @@ mod tests {
     }
 
     fn restore_config(old_xdg: Option<String>, old_home: Option<String>, dir: PathBuf) {
-        // SAFETY: serialized by #[serial_test::serial] — no concurrent env reads.
+        // SAFETY: serialized by #[serial_test::serial(home_env)] — no concurrent env reads.
         unsafe {
             match old_xdg {
                 Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
@@ -1362,7 +1362,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn check_command_for_hook_blocks_rm_rf_with_default_rules() {
         let (old_xdg, old_home, dir) = isolate_config();
 
@@ -1387,7 +1387,7 @@ mod tests {
     /// detectors operate at the token level without a single pattern string
     /// or byte offset to report.
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn block_meta_phase1b_has_null_metadata() {
         let (old_xdg, old_home, dir) = isolate_config();
         let result = check_command_for_hook("unset CLAUDECODE");
@@ -1414,7 +1414,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn check_command_for_hook_allows_safe_command() {
         let (old_xdg, old_home, dir) = isolate_config();
 
@@ -1731,7 +1731,7 @@ mod tests {
     // --- GR-007: check_command_for_hook meta-pattern ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn check_command_for_hook_blocks_meta_pattern() {
         let (old_xdg, old_home, dir) = isolate_config();
 
@@ -1747,7 +1747,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn check_command_for_hook_allows_echo() {
         let (old_xdg, old_home, dir) = isolate_config();
 
@@ -1820,13 +1820,13 @@ mod tests {
     // --- BLOCK: whitespace bypass (#145) — all use assert_blocks_meta ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_unset_double_space() {
         assert_blocks_meta("unset  CLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_unset_tab() {
         assert_blocks_meta("unset\tCLAUDECODE");
     }
@@ -1834,13 +1834,13 @@ mod tests {
     // --- BLOCK: VARNAME= assignment (Codex 6-B: missing test) ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_var_assignment_empty() {
         assert_blocks_meta("CLAUDECODE=");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_var_assignment_value() {
         assert_blocks_meta("CLAUDECODE=fake");
     }
@@ -1848,19 +1848,19 @@ mod tests {
     // --- BLOCK: separator-adjacent (Codex 6-A regression fix) ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_semicolon_adjacent_unset() {
         assert_blocks_meta("echo ok;unset CLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_and_adjacent_export() {
         assert_blocks_meta("cmd&&export -nCLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_newline_adjacent_env_u() {
         assert_blocks_meta("echo ok\nenv -u CLAUDECODE bash");
     }
@@ -1868,43 +1868,43 @@ mod tests {
     // --- BLOCK: operator-after command position (Codex 6-B: missing boundary) ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_after_semicolon() {
         assert_blocks_meta("echo ok ; unset CLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_after_pipe() {
         assert_blocks_meta("cat /dev/null | unset CLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_env_u_extra_spaces() {
         assert_blocks_meta("env  -u  CLAUDECODE bash");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_env_u_tabs() {
         assert_blocks_meta("env\t-u\tCLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_env_u_combined() {
         assert_blocks_meta("env -uCLAUDECODE bash");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_export_n_extra_space() {
         assert_blocks_meta("export  -n  CLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_export_n_combined() {
         assert_blocks_meta("export -nCLAUDECODE");
     }
@@ -1912,19 +1912,19 @@ mod tests {
     // --- BLOCK: assignment prefix (#145) ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_assignment_prefix_unset() {
         assert_blocks_meta("FOO=1 unset CLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_assignment_prefix_env_u() {
         assert_blocks_meta("BAR=x env -uCLAUDECODE bash");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_multi_assignment_export() {
         assert_blocks_meta("X=1 Y=2 export -n CLAUDECODE");
     }
@@ -1932,25 +1932,25 @@ mod tests {
     // --- ALLOW: command position false positive prevention (#145) ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_benign_printf_unset_args() {
         assert_allows("printf '%s %s' unset CLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_benign_echo_unset() {
         assert_allows("echo unset CLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_benign_echo_env_u() {
         assert_allows("echo env -u CLAUDECODE");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_benign_printf_var_assignment() {
         assert_allows("printf %s CLAUDECODE=test");
     }
@@ -1958,25 +1958,25 @@ mod tests {
     // --- ALLOW: quoted string false positive prevention (#145) ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_benign_printf_unset_quoted() {
         assert_allows("printf 'unset  CLAUDECODE'");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_benign_echo_env_u_quoted() {
         assert_allows("echo \"env  -u  CLAUDECODE\"");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_benign_echo_newline_in_quotes() {
         assert_allows("echo 'line1\nline2'");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_benign_env_assignment_in_string() {
         assert_allows("echo 'CLAUDECODE=test'");
     }
@@ -1984,79 +1984,79 @@ mod tests {
     // --- BLOCK: PATH override shim bypass (#227) — all use assert_blocks_meta ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_inline_rm() {
         assert_blocks_meta("PATH=/usr/bin:$PATH rm dummy.txt");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_inline_git() {
         assert_blocks_meta("PATH=/usr/bin git status");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_inline_chmod() {
         assert_blocks_meta("PATH=/opt/bin chmod 755 file");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_inline_find() {
         assert_blocks_meta("PATH=/usr/bin find . -name foo");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_inline_rsync() {
         assert_blocks_meta("PATH=/usr/bin rsync -a src/ dst/");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_empty_value_rm() {
         assert_blocks_meta("PATH= rm file");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_env_rm() {
         assert_blocks_meta("env PATH=/usr/bin rm file");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_env_i_rm() {
         assert_blocks_meta("env -i PATH=/usr/bin rm file");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_env_u_home_path_rm() {
         assert_blocks_meta("env -uHOME PATH=/usr/bin rm file");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_env_dashdash_rm() {
         assert_blocks_meta("env -- PATH=/usr/bin rm file");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_usr_bin_env_rm() {
         assert_blocks_meta("/usr/bin/env PATH=/usr/bin rm file");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_env_git() {
         assert_blocks_meta("env PATH=/opt/git/bin git push");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_compound_tail() {
         assert_blocks_meta("echo ok; PATH=/usr/bin rm file");
     }
@@ -2064,25 +2064,25 @@ mod tests {
     // --- ALLOW: PATH override with non-shim commands ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_non_shim_node() {
         assert_allows("PATH=/custom/dir node script.js");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_non_shim_python() {
         assert_allows("PATH=/opt/python/bin python -c 'print(1)'");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_export_path() {
         assert_allows("export PATH=/usr/local/bin:$PATH");
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn phase1b_path_override_env_non_shim() {
         assert_allows("env PATH=/custom/dir node script.js");
     }
@@ -2095,7 +2095,7 @@ mod tests {
     /// performance contract. CI runs on a known-slow shared runner so the
     /// budget is generous; local Apple Silicon p99 typically ~ 1ms.
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn p99_hook_check_latency_under_budget() {
         const SAMPLES: usize = 500;
         const P99_BUDGET_MICROS: u128 = 12_000;

--- a/src/engine/shim.rs
+++ b/src/engine/shim.rs
@@ -735,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn ensure_settings_resyncs_on_legacy_matcher() {
         let dir = std::env::temp_dir().join(format!("omamori-shim-legacy-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
@@ -792,7 +792,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn ensure_settings_resyncs_when_entry_missing() {
         // P1-1 (Codex R1): if settings.json exists with user hooks but no
         // omamori entry, the shim must merge one in, not silently no-op.
@@ -847,7 +847,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn ensure_settings_returns_false_on_skipped() {
         // P1-3 (Codex R1): merge result Skipped (e.g. symlink target) must NOT
         // be reported as a successful re-sync.
@@ -884,7 +884,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn ensure_settings_no_op_when_current() {
         let dir = std::env::temp_dir().join(format!("omamori-shim-current-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
@@ -926,7 +926,7 @@ mod tests {
 
     // V-006: Shim resyncs when multiple omamori entries exist (stale accumulation)
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn ensure_settings_resyncs_when_multiple_entries() {
         let dir = std::env::temp_dir().join(format!("omamori-shim-multi-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1919,7 +1919,7 @@ mod tests {
     // --- G-12: auto_setup_codex_if_needed ---
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn auto_setup_codex_skips_without_env() {
         // SAFETY: serial_test ensures no concurrent access to env vars
         let saved = std::env::var_os("CODEX_CI");
@@ -1939,7 +1939,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn auto_setup_codex_skips_when_wrapper_exists() {
         // SAFETY: serial_test ensures no concurrent access to env vars
         let saved = std::env::var_os("CODEX_CI");
@@ -2015,7 +2015,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_creates_when_missing() {
         let dir = fresh_test_dir("v001");
         let script = fake_script(&dir);
@@ -2044,7 +2044,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_preserves_user_hooks() {
         let dir = fresh_test_dir("v002");
         let script = fake_script(&dir);
@@ -2093,7 +2093,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_is_idempotent() {
         let dir = fresh_test_dir("v003");
         let script = fake_script(&dir);
@@ -2124,7 +2124,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_migrates_legacy_boolean_matcher() {
         let dir = fresh_test_dir("v004");
         let script = fake_script(&dir);
@@ -2167,7 +2167,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_migrates_wildcard_matcher() {
         let dir = fresh_test_dir("v005");
         let script = fake_script(&dir);
@@ -2198,7 +2198,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     #[cfg(unix)]
     fn merge_claude_writes_with_mode_0o600() {
         use std::os::unix::fs::PermissionsExt;
@@ -2225,7 +2225,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_skips_corrupted_json() {
         let dir = fresh_test_dir("v007");
         let script = fake_script(&dir);
@@ -2246,7 +2246,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_handles_large_settings_file() {
         let dir = fresh_test_dir("v008");
         let script = fake_script(&dir);
@@ -2289,7 +2289,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_handles_empty_file() {
         let dir = fresh_test_dir("v009");
         let script = fake_script(&dir);
@@ -2308,7 +2308,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     #[cfg(unix)]
     fn merge_claude_skips_symlink() {
         let dir = fresh_test_dir("v011");
@@ -2400,7 +2400,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_handles_custom_base_dir() {
         // P2-2 (Codex R1): identification must work for `--base-dir` installs,
         // not just the default ~/.omamori prefix.
@@ -2434,7 +2434,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn remove_claude_does_not_touch_user_hook_inside_omamori_dir() {
         // R4 regression (Codex Round 4): the surgical pass must match the
         // CANONICAL omamori script path, not any path under base_dir.
@@ -2500,7 +2500,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn remove_claude_surgically_removes_omamori_from_hybrid() {
         // R3 regression (Codex Round 3): uninstall must surgically remove
         // the omamori inner hook from a hybrid entry, even though the
@@ -2561,7 +2561,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_does_not_replace_hybrid_entry() {
         // R2 regression (Codex Round 2): a "hybrid" entry — one that contains
         // BOTH the omamori command and a user-managed sibling hook — must NOT
@@ -2622,7 +2622,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn remove_claude_settings_entry_preserves_hybrid_entry() {
         // R2 regression (Codex Round 2): uninstall must not delete a hybrid
         // entry, because it contains a user hook. Only canonical (omamori-
@@ -2674,7 +2674,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn remove_claude_settings_entry_preserves_user_hooks() {
         // P1-2 (Codex R1): uninstall must remove the omamori entry but leave
         // user-managed hooks intact.
@@ -2742,7 +2742,7 @@ mod tests {
     // V-001: Cross-root stale cleanup (core #254 bug)
     // -----------------------------------------------------------------------
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_removes_all_stale_entries_from_different_roots() {
         let dir = fresh_test_dir("v001-stale");
         let script = fake_script(&dir);
@@ -2805,7 +2805,7 @@ mod tests {
     // V-002: Legacy entry cleanup (untagged, path-based fallback)
     // -----------------------------------------------------------------------
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_cleans_legacy_entry_without_version_tag() {
         let dir = fresh_test_dir("v002-legacy");
         let script = fake_script(&dir);
@@ -2856,7 +2856,7 @@ mod tests {
     // V-004: Hybrid entry preservation with stale cleanup
     // -----------------------------------------------------------------------
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_preserves_hybrid_with_stale_cleanup() {
         let dir = fresh_test_dir("v004-hybrid");
         let script = fake_script(&dir);
@@ -2917,7 +2917,7 @@ mod tests {
     // V-005: Uninstall cleans multiple stale entries
     // -----------------------------------------------------------------------
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn remove_claude_cleans_multiple_stale_entries() {
         let dir = fresh_test_dir("v005-rm-stale");
         let base_dir = dir.join(".omamori");
@@ -2977,7 +2977,7 @@ mod tests {
     // V-008: Idempotency after stale cleanup
     // -----------------------------------------------------------------------
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn merge_claude_idempotent_after_stale_cleanup() {
         let dir = fresh_test_dir("v008-idem");
         let script = fake_script(&dir);

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -1273,7 +1273,7 @@ mod tests {
     // =========================================================================
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn path_order_shim_before_usr_bin_is_ok() {
         let dir =
             std::env::temp_dir().join(format!("omamori-integrity-g10-1-{}", std::process::id()));
@@ -1293,7 +1293,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn path_order_shim_after_usr_bin_is_warn() {
         let dir =
             std::env::temp_dir().join(format!("omamori-integrity-g10-2-{}", std::process::id()));
@@ -1313,7 +1313,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn path_order_shim_not_in_path_is_warn() {
         let dir =
             std::env::temp_dir().join(format!("omamori-integrity-g10-3-{}", std::process::id()));
@@ -1332,7 +1332,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn path_order_usr_bin_not_in_path_is_ok() {
         let dir =
             std::env::temp_dir().join(format!("omamori-integrity-g10-4-{}", std::process::id()));
@@ -1502,7 +1502,7 @@ mod tests {
     // ---------------------------------------------------------------------
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn check_claude_settings_warns_when_missing() {
         let dir =
             std::env::temp_dir().join(format!("omamori-int-no-claude-{}", std::process::id()));
@@ -1523,7 +1523,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn check_claude_settings_fails_on_legacy_matcher() {
         let dir = std::env::temp_dir().join(format!("omamori-int-legacy-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
@@ -1567,7 +1567,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn check_claude_settings_fails_when_only_hybrid_entry_exists() {
         // R2 regression (Codex Round 2): if the user has merged the omamori
         // command into a hybrid entry (with sibling user hooks), there is no
@@ -1619,7 +1619,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     #[cfg(unix)]
     fn check_claude_settings_fails_on_non_executable_script() {
         // P1-4 (Codex R1): if the script is not executable, hash match alone
@@ -1675,7 +1675,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn check_claude_settings_ok_when_wired_up() {
         let dir = std::env::temp_dir().join(format!("omamori-int-ok-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
@@ -1723,7 +1723,7 @@ mod tests {
 
     // V-007: Doctor detects duplicate/stale omamori entries
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn doctor_detects_duplicate_omamori_entries() {
         let dir = std::env::temp_dir().join(format!("omamori-int-dup-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
@@ -1786,7 +1786,7 @@ mod tests {
     /// claude-pretooluse.sh (but outside omamori's hooks/ dir) must NOT
     /// be counted as a duplicate omamori entry.
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(home_env)]
     fn doctor_does_not_count_user_hook_as_duplicate() {
         let dir = std::env::temp_dir().join(format!("omamori-int-nodup-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

- Context-aware evaluation (regenerable-path downgrade + git-aware evaluation) is now **enabled by default** for new installs, eliminating first-day false positives on `rm -rf target/`, `rm -rf node_modules/`, etc.
- Existing users without a `[context]` section in their config are completely unaffected (`context` remains `None` via `build_merged_config`)
- Users with `[context]` but no `[context.git]` will now get git-aware evaluation activated (safer direction)

## Changes

- `Config::default()`: `context: None` → `context: Some(ContextConfig::default())`
- `GitContextConfig` serde default: `#[serde(default)]` (= `false`) → `#[serde(default = "default_git_enabled")]` (= `true`)
- `config_template()`: `[context]` section header uncommented so `omamori init` creates context-enabled config
- `config.default.toml`: `[context]` and `[context.git]` sections uncommented, `regenerable_paths` aligned with code defaults
- README: "Opt-in" → "Enabled by default"
- 5 new tests including backward-compat pin (`existing_config_without_context_stays_none`)

## Codex review

- R1: 3 findings. F1 (git clean -fdx LogOnly) = off-thesis, deferred. F2 (README contradiction) = adopted. F3 (backward compat test) = adopted.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo test` — 787 tests, 0 failed
- [x] `cargo run -- test` — all context tests PASS (regenerable-path-downgrade, protected-path-escalate, git-aware-evaluation)
- [x] `/simplify` — 3 parallel review agents, no actionable findings

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)