### PR TITLE
fix(actions): redirect git stash stdout to stderr

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -221,18 +221,31 @@ impl ExecOps for SystemOps {
     }
 
     fn git_stash(&mut self) -> Result<(), String> {
+        use std::io::Write;
+        use std::process::Stdio;
+
         // Remove AI detector env vars so the internal git call does not
         // trigger omamori's own protection (self-interference prevention).
         let mut cmd = Command::new("git");
-        cmd.arg("stash").arg("push").arg("--include-untracked");
+        cmd.arg("stash")
+            .arg("push")
+            .arg("--include-untracked")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
         for key in &self.detector_env_keys {
             cmd.env_remove(key);
         }
-        let status = cmd.status().map_err(|error| error.to_string())?;
-        if status.success() {
+        let output = cmd.output().map_err(|error| error.to_string())?;
+        if !output.stdout.is_empty() {
+            let _ = io::stderr().write_all(&output.stdout);
+        }
+        if output.status.success() {
             Ok(())
         } else {
-            Err(format!("git stash exited with status {:?}", status.code()))
+            Err(format!(
+                "git stash exited with status {:?}",
+                output.status.code(),
+            ))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix `git_stash()` stdout leak during stash-then-exec action (#283)
- `git stash push --include-untracked` output ("Saved working directory...") was leaking to parent stdout, violating omamori's output channel contract (stderr = omamori messages, stdout = original command output only)
- Switch from `.status()` to `.output()` with `.stdout(Stdio::piped())` + `.stderr(Stdio::inherit())`, then `write_all` captured stdout to stderr (byte-preserving)

## Changes
- `src/actions.rs`: `SystemOps::git_stash()` — capture stdout, inherit stderr, redirect captured stdout to stderr via `io::stderr().write_all()`

## Design decisions
- **`.stderr(Stdio::inherit())`** over capture-both: bug is stdout-only; stderr works correctly as-is
- **`write_all`** over `eprint!`: byte-preserving channel redirect, no UTF-8 lossy conversion
- **Trait signature unchanged**: `ExecOps::git_stash()` returns `Result<(), String>` as before
- **FakeOps mock unchanged**: mock doesn't exercise subprocess I/O

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test` — 769 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Acceptance test S-3: `git reset --hard` with dirty worktree → verify stdout contains only git reset output, stderr contains stash info

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)