### PR TITLE
docs: bump to v0.10.10

### DIFF
--- a/ACCEPTANCE_TEST.md
+++ b/ACCEPTANCE_TEST.md
@@ -61,7 +61,7 @@ omamori install --force
 #    既存 session 内 hook script は古い binary path を embed している場合がある
 
 # (4) 開始時 sanity check (このセクションを始める前に必ず通す)
-omamori --version | grep -qE '0\.10\.9' && echo "v0.10.9 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
+omamori --version | grep -qE '0\.10\.10' && echo "v0.10.10 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
 
 # (5) AI 環境を維持 (raw terminal でも同じ)
 export CLAUDECODE=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.10.10] - 2026-05-18
+
+**Summary**: Fix stash-then-exec stdout leak — `git stash push` informational output ("Saved working directory...") was leaking to the parent process stdout, violating omamori's output channel contract. Now captured and redirected to stderr (byte-preserving).
+
+### Fixed
+
+- **git stash stdout leak during stash-then-exec** — `SystemOps::git_stash()` used `.status()` which inherited stdout from the parent process. Switched to `.output()` with `.stdout(Stdio::piped())` and `.stderr(Stdio::inherit())`, then `write_all` captured stdout to stderr. The original command's stdout (e.g. `git reset --hard` output) is unaffected. ([#283](https://github.com/yottayoshida/omamori/issues/283))
+
 ## [0.10.9] - 2026-05-17
 
 **Summary**: Context-aware evaluation is now enabled by default. New installs get smart regenerable-path downgrade (Tier 1) and git-aware evaluation (Tier 2) out of the box, eliminating first-day false positives on `rm -rf target/`, `rm -rf node_modules/`, etc. Existing users without a `[context]` section in their config are completely unaffected (`context` remains `None`). Users with `[context]` but no `[context.git]` will now get git-aware evaluation activated (safer direction — opt out by adding `[context.git]\nenabled = false`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "criterion",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.10.9"
+version = "0.10.10"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"


### PR DESCRIPTION
## Summary
- Version bump to v0.10.10
- CHANGELOG entry for #283 fix (stash-then-exec stdout leak)
- ACCEPTANCE_TEST.md version update

## Changes
- `Cargo.toml`: 0.10.9 → 0.10.10
- `Cargo.lock`: auto-updated
- `CHANGELOG.md`: v0.10.10 entry
- `ACCEPTANCE_TEST.md`: version check updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)