### PR TITLE
docs(security): document Codex CLI sandbox constraints

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -748,6 +748,26 @@ This filter assumes the live entry's command path does not contain `omamori-inst
 
 **Why no automatic fix**: a full automated cleanup would require ~500 lines (test HOME isolation across 7 sites + dedup logic strengthening + warning UX + CI lint to prevent regression) for an issue with zero impact on production users and a one-line manual cleanup for contributors. The cost/value did not justify implementation in v0.9.7. If the contributor population grows or a related issue surfaces (e.g. [#206](https://github.com/yottayoshida/omamori/issues/206) OpenClaw hook coexistence touches the same identification logic), this can be reopened. See [#210 close comment](https://github.com/yottayoshida/omamori/issues/210#issuecomment-4350136214) for the full investigation log.
 
+### Codex CLI sandbox constraints (v0.10.11+)
+
+Codex CLI runs commands inside a [sandbox](https://developers.openai.com/codex/concepts/sandboxing) that restricts filesystem writes to the working directory and `/tmp` by default (`workspace-write` mode). This creates two structural limitations for omamori:
+
+| Constraint | Root cause | Impact | Mitigation |
+|------------|-----------|--------|------------|
+| **Layer 1 PATH shim ineffective** | Codex spawns non-login shells — `~/.zshrc` is never sourced, so `~/.omamori/shim` is not in `$PATH` | Layer 1 interception does not fire. Commands like `rm -rf /` go directly to the system binary | Layer 2 hook (`hook-check --provider codex` via `~/.codex/hooks.json`) is unaffected and catches the same commands. Layer 1 is defense-in-depth; Layer 2 is the primary gate in Codex environments |
+| **Audit log write fails (EPERM)** | `~/.local/share/omamori/audit.jsonl` is outside the sandbox's writable roots | `logger.append()` returns `PermissionDenied`. The audit chain has a gap for events that occur inside the sandbox | Block decisions are **not affected** — the hook returns "block" to the AI tool regardless of audit success (best-effort audit, SEC-7 invariant). omamori emits a stderr warning with sandbox-specific guidance when this occurs |
+
+**Security impact**: None. Layer 2 hook protection is fully functional in Codex CLI. The PATH shim (Layer 1) is defense-in-depth that is already documented as bypassable via absolute paths (`/bin/rm`). Audit gaps mean `omamori audit show --action block` is incomplete for sandboxed sessions, but the block enforcement itself is intact.
+
+**Workaround** (optional — enables audit recording inside sandbox): Add the omamori data directory to Codex's writable roots in `~/.codex/config.toml`:
+
+```toml
+[sandbox_workspace_write]
+writable_roots = ["~/.local/share/omamori"]
+```
+
+See also: [ACCEPTANCE_TEST.md "Headless / Codex compatibility"](./ACCEPTANCE_TEST.md) for which acceptance test rows require non-sandboxed execution. Filed as [#271](https://github.com/yottayoshida/omamori/issues/271).
+
 ## AI-assisted Contribution Invariants (v0.9.3+)
 
 omamori is developed with AI coding assistants (Claude Code / Codex). That

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -759,10 +759,20 @@ fn audit_log_unknown_tool_fail_open(
     event.target_count = tool_input.as_object().map(|o| o.len()).unwrap_or(0);
 
     if let Err(e) = logger.append(event) {
-        eprintln!(
-            "omamori warning: failed to record unknown_tool_fail_open event for '{tool_name}': {e}. \
-             The 'omamori audit unknown' review surface is incomplete for this event."
-        );
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            eprintln!(
+                "omamori warning: audit write denied for unknown tool '{tool_name}': {e}. \
+                 This is expected in sandboxed environments (e.g. Codex CLI) where writes to \
+                 ~/.local/share/omamori/ are restricted. The fail-open decision is unaffected — \
+                 only audit recording failed. To enable audit in sandbox, add \
+                 ~/.local/share/omamori to your sandbox's writable paths."
+            );
+        } else {
+            eprintln!(
+                "omamori warning: failed to record unknown_tool_fail_open event for '{tool_name}': {e}. \
+                 The 'omamori audit unknown' review surface is incomplete for this event."
+            );
+        }
     }
 }
 
@@ -876,10 +886,20 @@ fn audit_log_hook_block(
     event.unwrap_chain = unwrap_chain.map(|c| vec![c]);
 
     if let Err(e) = logger.append(event) {
-        eprintln!(
-            "omamori warning: failed to record Layer 2 hook deny event for {command:?}: {e}. \
-             The 'omamori audit show --action block' surface is incomplete for this event."
-        );
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            eprintln!(
+                "omamori warning: audit write denied for {command:?}: {e}. \
+                 This is expected in sandboxed environments (e.g. Codex CLI) where writes to \
+                 ~/.local/share/omamori/ are restricted. The block decision is unaffected — \
+                 only audit recording failed. To enable audit in sandbox, add \
+                 ~/.local/share/omamori to your sandbox's writable paths."
+            );
+        } else {
+            eprintln!(
+                "omamori warning: failed to record Layer 2 hook deny event for {command:?}: {e}. \
+                 The 'omamori audit show --action block' surface is incomplete for this event."
+            );
+        }
     }
 }
 

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -777,10 +777,10 @@ fn warn_audit_append_error(
     if e.kind() == std::io::ErrorKind::PermissionDenied {
         eprintln!(
             "omamori warning: audit write denied for {context}: {e}. \
-             This is expected in sandboxed environments (e.g. Codex CLI) where writes to \
-             ~/.local/share/omamori/ are restricted. The {decision_kind} decision is \
-             unaffected — only audit recording failed. To enable audit in sandbox, add \
-             ~/.local/share/omamori to your sandbox's writable paths."
+             This is expected in sandboxed environments (e.g. Codex CLI) that restrict \
+             writes outside the working directory. The {decision_kind} decision is \
+             unaffected — only audit recording failed. Add the audit log's parent \
+             directory to your sandbox's writable paths to restore recording."
         );
     } else {
         eprintln!(

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -759,20 +759,34 @@ fn audit_log_unknown_tool_fail_open(
     event.target_count = tool_input.as_object().map(|o| o.len()).unwrap_or(0);
 
     if let Err(e) = logger.append(event) {
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            eprintln!(
-                "omamori warning: audit write denied for unknown tool '{tool_name}': {e}. \
-                 This is expected in sandboxed environments (e.g. Codex CLI) where writes to \
-                 ~/.local/share/omamori/ are restricted. The fail-open decision is unaffected — \
-                 only audit recording failed. To enable audit in sandbox, add \
-                 ~/.local/share/omamori to your sandbox's writable paths."
-            );
-        } else {
-            eprintln!(
-                "omamori warning: failed to record unknown_tool_fail_open event for '{tool_name}': {e}. \
-                 The 'omamori audit unknown' review surface is incomplete for this event."
-            );
-        }
+        warn_audit_append_error(
+            &e,
+            &format_args!("unknown tool '{tool_name}'"),
+            "fail-open",
+            "omamori audit unknown",
+        );
+    }
+}
+
+fn warn_audit_append_error(
+    e: &std::io::Error,
+    context: &dyn std::fmt::Display,
+    decision_kind: &str,
+    audit_surface: &str,
+) {
+    if e.kind() == std::io::ErrorKind::PermissionDenied {
+        eprintln!(
+            "omamori warning: audit write denied for {context}: {e}. \
+             This is expected in sandboxed environments (e.g. Codex CLI) where writes to \
+             ~/.local/share/omamori/ are restricted. The {decision_kind} decision is \
+             unaffected — only audit recording failed. To enable audit in sandbox, add \
+             ~/.local/share/omamori to your sandbox's writable paths."
+        );
+    } else {
+        eprintln!(
+            "omamori warning: failed to record audit event for {context}: {e}. \
+             The '{audit_surface}' review surface is incomplete for this event."
+        );
     }
 }
 
@@ -886,20 +900,12 @@ fn audit_log_hook_block(
     event.unwrap_chain = unwrap_chain.map(|c| vec![c]);
 
     if let Err(e) = logger.append(event) {
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            eprintln!(
-                "omamori warning: audit write denied for {command:?}: {e}. \
-                 This is expected in sandboxed environments (e.g. Codex CLI) where writes to \
-                 ~/.local/share/omamori/ are restricted. The block decision is unaffected — \
-                 only audit recording failed. To enable audit in sandbox, add \
-                 ~/.local/share/omamori to your sandbox's writable paths."
-            );
-        } else {
-            eprintln!(
-                "omamori warning: failed to record Layer 2 hook deny event for {command:?}: {e}. \
-                 The 'omamori audit show --action block' surface is incomplete for this event."
-            );
-        }
+        warn_audit_append_error(
+            &e,
+            &format_args!("{command:?}"),
+            "block",
+            "omamori audit show --action block",
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `### Codex CLI sandbox constraints` section to SECURITY.md under Known Operational Caveats, documenting PATH shim ineffectiveness and audit write EPERM in Codex CLI sandbox
- Improve audit failure warnings in `hook.rs` to detect `PermissionDenied` and emit sandbox-specific guidance instead of raw "os error 1"
- Block decisions are unaffected (SEC-7 invariant preserved)

## Changes
- `SECURITY.md`: New subsection with root cause / impact / mitigation table, workaround (`writable_roots`), and cross-references to ACCEPTANCE_TEST.md and #271
- `src/engine/hook.rs`: `audit_log_hook_block()` and `audit_log_unknown_tool_fail_open()` now branch on `ErrorKind::PermissionDenied` for actionable sandbox messages

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test` — all tests pass, no warnings
- [x] `cargo fmt --check` — clean
- [x] SECURITY.md cross-reference consistency check (L592, L461 — no contradictions)
- [ ] CI pass

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)