### PR TITLE
docs: bump to v0.10.11

### DIFF
--- a/ACCEPTANCE_TEST.md
+++ b/ACCEPTANCE_TEST.md
@@ -61,7 +61,7 @@ omamori install --force
 #    既存 session 内 hook script は古い binary path を embed している場合がある
 
 # (4) 開始時 sanity check (このセクションを始める前に必ず通す)
-omamori --version | grep -qE '0\.10\.10' && echo "v0.10.10 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
+omamori --version | grep -qE '0\.10\.11' && echo "v0.10.11 ready" || { echo "FAIL: install release-candidate binary first"; exit 1; }
 
 # (5) AI 環境を維持 (raw terminal でも同じ)
 export CLAUDECODE=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.10.11] - 2026-05-19
+
+**Summary**: Document Codex CLI sandbox structural constraints in SECURITY.md and improve audit write failure warnings with `PermissionDenied` detection. Block decisions are completely unaffected (SEC-7 invariant preserved).
+
+### Added
+
+- **SECURITY.md: Codex CLI sandbox constraints section** — Documents two structural limitations when running under Codex CLI sandbox: PATH shim ineffectiveness (non-login shell) and audit write EPERM (restricted writable roots). Includes workaround guidance and cross-references. ([#271](https://github.com/yottayoshida/omamori/issues/271))
+
+### Changed
+
+- **Improved audit failure warnings for sandboxed environments** — When `logger.append()` fails with `PermissionDenied`, the warning now explains the sandbox context and provides actionable guidance (add audit log directory to writable paths) instead of a generic "failed to record" message. Non-permission errors retain the original message. Extracted `warn_audit_append_error` helper to centralize the branching logic. ([#271](https://github.com/yottayoshida/omamori/issues/271))
+
 ## [0.10.10] - 2026-05-18
 
 **Summary**: Fix stash-then-exec stdout leak — `git stash push` informational output ("Saved working directory...") was leaking to the parent process stdout, violating omamori's output channel contract. Now captured and redirected to stderr (byte-preserving).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,9 +552,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "criterion",
  "hmac",
@@ -1571,9 +1571,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.10.10"
+version = "0.10.11"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"


### PR DESCRIPTION
## Summary
- Version bump to v0.10.11 for PR #286 (Codex sandbox docs + audit warning improvement)
- CHANGELOG entry added
- ACCEPTANCE_TEST.md version reference updated

## Test plan
- [ ] CI passes (Cargo.lock updated via `cargo generate-lockfile`)
- [ ] `cargo test` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
