### PR TITLE
feat: replace verbose install output with concise summary banner

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -158,8 +158,7 @@ fn aggregate_layer2_status(result: &installer::InstallResult) -> Layer2Status {
         Some(installer::ClaudeSettingsOutcome::Skipped(reason)) => {
             warnings.push(format!("Claude Code: {reason}"));
             if result.settings_snippet.is_some() {
-                warnings
-                    .push("  cat ~/.omamori/hooks/claude-settings.snippet.json".to_string());
+                warnings.push("  cat ~/.omamori/hooks/claude-settings.snippet.json".to_string());
             }
         }
         Some(_) => tools.push("Claude Code".to_string()),
@@ -184,8 +183,7 @@ fn aggregate_layer2_status(result: &installer::InstallResult) -> Layer2Status {
     } else if codex_hooks_ok && codex_config_disabled {
         warnings.push("Codex CLI: codex_hooks = false (set by user)".to_string());
         warnings.push("  set codex_hooks = true in ~/.codex/config.toml".to_string());
-    } else if let Some(installer::CodexHooksOutcome::Skipped(reason)) =
-        &result.codex_hooks_outcome
+    } else if let Some(installer::CodexHooksOutcome::Skipped(reason)) = &result.codex_hooks_outcome
     {
         warnings.push(format!("Codex CLI: {reason}"));
     }
@@ -274,7 +272,11 @@ mod tests {
 
         let l2 = aggregate_layer2_status(&r);
         assert_eq!(l2.tools, vec!["Claude Code"]);
-        assert!(l2.warnings.iter().any(|w| w.contains("codex_hooks = false")));
+        assert!(
+            l2.warnings
+                .iter()
+                .any(|w| w.contains("codex_hooks = false"))
+        );
     }
 
     #[test]
@@ -289,8 +291,9 @@ mod tests {
     fn claude_ok_codex_skipped_mixed() {
         let mut r = empty_result();
         r.claude_settings_outcome = Some(installer::ClaudeSettingsOutcome::AlreadyPresent);
-        r.codex_hooks_outcome =
-            Some(installer::CodexHooksOutcome::Skipped("not installed".to_string()));
+        r.codex_hooks_outcome = Some(installer::CodexHooksOutcome::Skipped(
+            "not installed".to_string(),
+        ));
 
         let l2 = aggregate_layer2_status(&r);
         assert_eq!(l2.tools, vec!["Claude Code"]);

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -52,97 +52,37 @@ pub(crate) fn run_install_command(args: &[OsString]) -> Result<i32, AppError> {
         generate_hooks,
     })?;
 
-    // --- Categorized checklist output ---
+    // --- Summary banner ---
     println!("\nomamori setup complete:\n");
 
-    // Shims
-    println!("Shims:");
-    println!("  [done] {}", result.linked_commands.join(", "));
+    // Layer 1 (PATH shims)
+    println!(
+        "  \u{2713} Layer 1 (PATH shims): {}/{} installed",
+        result.linked_commands.len(),
+        installer::SHIM_COMMANDS.len()
+    );
 
-    // Hooks
-    println!("\nHooks:");
-    if let Some(script) = &result.hook_script {
-        println!("  [done] Claude Code hook: {}", script.display());
-    }
-    if let Some(snippet) = &result.settings_snippet {
-        println!(
-            "  [done] Claude Code settings snippet: {}",
-            snippet.display()
-        );
-    }
-    match &result.claude_settings_outcome {
-        Some(installer::ClaudeSettingsOutcome::Created) => {
-            println!("  [done] Claude Code settings.json: created ~/.claude/settings.json");
-        }
-        Some(installer::ClaudeSettingsOutcome::Merged) => {
-            println!("  [done] Claude Code settings.json: merged into ~/.claude/settings.json");
-        }
-        Some(installer::ClaudeSettingsOutcome::AlreadyPresent) => {
-            println!("  [skip] Claude Code settings.json: already configured");
-        }
-        Some(installer::ClaudeSettingsOutcome::MatcherMigrated) => {
-            println!(
-                "  [migrated] Claude Code settings.json: matcher migrated to current spec (\"Bash\")"
-            );
-        }
-        Some(installer::ClaudeSettingsOutcome::StaleEntriesCleaned(n)) => {
-            println!(
-                "  [done] Claude Code settings.json: cleaned {n} stale hook(s), merged current entry"
-            );
-        }
-        Some(installer::ClaudeSettingsOutcome::Skipped(reason)) => {
-            println!("  [warn] Claude Code settings.json: {reason}");
-            println!(
-                "         Manual merge needed: cat ~/.omamori/hooks/claude-settings.snippet.json"
-            );
-        }
-        None => {}
-    }
-    if let Some(cursor_snippet) = &result.cursor_hook_snippet {
-        println!("  [done] Cursor hook snippet: {}", cursor_snippet.display());
-    }
-    if let Some(wrapper) = &result.codex_wrapper {
-        println!("  [done] Codex CLI wrapper: {}", wrapper.display());
-    }
-    match &result.codex_hooks_outcome {
-        Some(installer::CodexHooksOutcome::Created) => {
-            println!("  [done] Codex CLI hooks.json: created ~/.codex/hooks.json");
-        }
-        Some(installer::CodexHooksOutcome::Merged) => {
-            println!("  [done] Codex CLI hooks.json: merged into ~/.codex/hooks.json");
-        }
-        Some(installer::CodexHooksOutcome::AlreadyPresent) => {
-            println!("  [skip] Codex CLI hooks.json: already configured");
-        }
-        Some(installer::CodexHooksOutcome::Skipped(reason)) => {
-            println!("  [warn] Codex CLI hooks.json: {reason}");
-            println!("         Manual merge needed: cat ~/.omamori/hooks/codex-hooks.snippet.json");
-        }
-        None => {}
-    }
-    match &result.codex_config_outcome {
-        Some(installer::CodexConfigOutcome::Added) => {
-            println!("  [done] Codex CLI config.toml: set [features] codex_hooks = true");
-            println!("         (backup: ~/.codex/config.toml.bak)");
-        }
-        Some(installer::CodexConfigOutcome::AlreadyEnabled) => {
-            println!("  [skip] Codex CLI config.toml: codex_hooks already enabled");
-        }
-        Some(installer::CodexConfigOutcome::ExplicitlyDisabled) => {
-            println!(
-                "  [warn] Codex CLI config.toml: codex_hooks = false (set by user, not changed)"
-            );
-            println!("         omamori hooks will NOT activate until you set codex_hooks = true");
-            println!("         in ~/.codex/config.toml");
-        }
-        Some(installer::CodexConfigOutcome::Skipped(reason)) => {
-            println!("  [warn] Codex CLI config.toml: {reason}");
-        }
-        None => {}
+    // Layer 2 (hooks) — aggregate tool statuses
+    let mut layer2_warnings: Vec<String> = Vec::new();
+    if generate_hooks {
+        let l2 = aggregate_layer2_status(&result);
+        let layer2_symbol = if l2.warnings.is_empty() {
+            "\u{2713}"
+        } else {
+            "!"
+        };
+        let layer2_summary = if l2.tools.is_empty() {
+            "no tools detected".to_string()
+        } else {
+            l2.tools.join(", ")
+        };
+        println!("  {layer2_symbol} Layer 2 (hooks):      {layer2_summary}");
+        layer2_warnings = l2.warnings;
+    } else {
+        println!("  - Layer 2 (hooks):      not requested (run with --hooks)");
     }
 
-    // Config
-    println!("\nConfig:");
+    // Config (side effect: auto-create if missing)
     let config_status = match config::default_config_path() {
         Some(config_path) if !config_path.exists() => {
             match config::write_default_config(&config_path, false) {
@@ -153,9 +93,9 @@ pub(crate) fn run_install_command(args: &[OsString]) -> Result<i32, AppError> {
         Some(config_path) => format!("[skip] Already exists: {}", config_path.display()),
         None => "[warn] Not created: HOME/XDG_CONFIG_HOME not set".to_string(),
     };
-    println!("  {config_status}");
+    println!("  \u{2713} Config:               {config_status}");
 
-    // Auto-test
+    // Policy (auto-test)
     let load_result = load_config(None)?;
     let test_results = run_policy_tests(&load_result);
     let failures = test_results.iter().filter(|r| !r.passed).count();
@@ -167,36 +107,99 @@ pub(crate) fn run_install_command(args: &[OsString]) -> Result<i32, AppError> {
         .count();
     if failures == 0 {
         println!(
-            "  [done] {} rules verified, {} detection tests passed",
+            "  \u{2713} Policy:               {} rules verified, {} tests passed",
             active_rules,
             test_results.len()
         );
     } else {
         println!(
-            "  [FAIL] {} detection test(s) failed — run `omamori test` for details",
+            "  \u{2717} Policy:               {} test(s) failed \u{2014} run `omamori test` for details",
             failures
         );
+    }
+
+    // Warnings (collected from Layer 2)
+    if !layer2_warnings.is_empty() {
+        println!();
+        for w in &layer2_warnings {
+            if w.starts_with("  ") {
+                println!("    {w}");
+            } else {
+                println!("  ! {w}");
+            }
+        }
     }
 
     // Next steps
     println!("\nNext steps:");
     println!(
-        "  [todo] Add to your shell profile (~/.zshrc or ~/.bashrc):\n\n    export PATH=\"{}:$PATH\"",
+        "  Add to ~/.zshrc:  export PATH=\"{}:$PATH\"",
         result.shim_dir.display()
     );
-    if result.cursor_hook_snippet.is_some() {
-        let hooks_dir = result
-            .cursor_hook_snippet
-            .as_ref()
-            .map(|p| p.parent().unwrap().display().to_string())
-            .unwrap_or_default();
-        println!(
-            "\n  [todo] Merge Cursor hook into .cursor/hooks.json:\n\n    cat {hooks_dir}/cursor-hooks.snippet.json"
-        );
-    }
+    println!("  Verify:           omamori doctor");
+    println!("  Dry-run:          omamori test");
 
     println!();
     Ok(0)
+}
+
+#[derive(Debug)]
+struct Layer2Status {
+    tools: Vec<String>,
+    warnings: Vec<String>,
+}
+
+fn aggregate_layer2_status(result: &installer::InstallResult) -> Layer2Status {
+    let mut tools = Vec::new();
+    let mut warnings = Vec::new();
+
+    // Claude Code
+    match &result.claude_settings_outcome {
+        Some(installer::ClaudeSettingsOutcome::Skipped(reason)) => {
+            warnings.push(format!("Claude Code: {reason}"));
+            if result.settings_snippet.is_some() {
+                warnings
+                    .push("  cat ~/.omamori/hooks/claude-settings.snippet.json".to_string());
+            }
+        }
+        Some(_) => tools.push("Claude Code".to_string()),
+        None => {}
+    }
+
+    // Codex CLI — both hooks AND config must be OK
+    let codex_hooks_ok = matches!(
+        &result.codex_hooks_outcome,
+        Some(
+            installer::CodexHooksOutcome::Created
+                | installer::CodexHooksOutcome::Merged
+                | installer::CodexHooksOutcome::AlreadyPresent
+        )
+    );
+    let codex_config_disabled = matches!(
+        &result.codex_config_outcome,
+        Some(installer::CodexConfigOutcome::ExplicitlyDisabled)
+    );
+    if codex_hooks_ok && !codex_config_disabled {
+        tools.push("Codex CLI".to_string());
+    } else if codex_hooks_ok && codex_config_disabled {
+        warnings.push("Codex CLI: codex_hooks = false (set by user)".to_string());
+        warnings.push("  set codex_hooks = true in ~/.codex/config.toml".to_string());
+    } else if let Some(installer::CodexHooksOutcome::Skipped(reason)) =
+        &result.codex_hooks_outcome
+    {
+        warnings.push(format!("Codex CLI: {reason}"));
+    }
+    if let Some(installer::CodexConfigOutcome::Skipped(reason)) = &result.codex_config_outcome {
+        warnings.push(format!("Codex CLI config: {reason}"));
+    }
+
+    // Cursor — always manual merge
+    if result.cursor_hook_snippet.is_some() {
+        warnings.push("Cursor: manual merge needed".to_string());
+        warnings.push("  cat ~/.omamori/hooks/cursor-hooks.snippet.json".to_string());
+    }
+
+    Layer2Status { tools, warnings }
 }
 
 pub(crate) fn run_uninstall_command(args: &[OsString]) -> Result<i32, AppError> {
@@ -229,4 +232,79 @@ pub(crate) fn run_uninstall_command(args: &[OsString]) -> Result<i32, AppError> 
     );
     println!("Removed {} file(s)", result.removed_entries.len());
     Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn empty_result() -> installer::InstallResult {
+        installer::InstallResult {
+            shim_dir: PathBuf::from("/tmp/shim"),
+            linked_commands: vec![],
+            hook_script: None,
+            settings_snippet: None,
+            cursor_hook_snippet: None,
+            codex_wrapper: None,
+            codex_hooks_outcome: None,
+            codex_config_outcome: None,
+            claude_settings_outcome: None,
+        }
+    }
+
+    #[test]
+    fn all_success_no_cursor() {
+        let mut r = empty_result();
+        r.claude_settings_outcome = Some(installer::ClaudeSettingsOutcome::Created);
+        r.codex_hooks_outcome = Some(installer::CodexHooksOutcome::Created);
+        r.codex_config_outcome = Some(installer::CodexConfigOutcome::Added);
+
+        let l2 = aggregate_layer2_status(&r);
+        assert_eq!(l2.tools, vec!["Claude Code", "Codex CLI"]);
+        assert!(l2.warnings.is_empty());
+    }
+
+    #[test]
+    fn codex_hooks_ok_but_config_disabled_is_warn() {
+        let mut r = empty_result();
+        r.claude_settings_outcome = Some(installer::ClaudeSettingsOutcome::Merged);
+        r.codex_hooks_outcome = Some(installer::CodexHooksOutcome::Created);
+        r.codex_config_outcome = Some(installer::CodexConfigOutcome::ExplicitlyDisabled);
+
+        let l2 = aggregate_layer2_status(&r);
+        assert_eq!(l2.tools, vec!["Claude Code"]);
+        assert!(l2.warnings.iter().any(|w| w.contains("codex_hooks = false")));
+    }
+
+    #[test]
+    fn all_none_no_tools() {
+        let r = empty_result();
+        let l2 = aggregate_layer2_status(&r);
+        assert!(l2.tools.is_empty());
+        assert!(l2.warnings.is_empty());
+    }
+
+    #[test]
+    fn claude_ok_codex_skipped_mixed() {
+        let mut r = empty_result();
+        r.claude_settings_outcome = Some(installer::ClaudeSettingsOutcome::AlreadyPresent);
+        r.codex_hooks_outcome =
+            Some(installer::CodexHooksOutcome::Skipped("not installed".to_string()));
+
+        let l2 = aggregate_layer2_status(&r);
+        assert_eq!(l2.tools, vec!["Claude Code"]);
+        assert!(l2.warnings.iter().any(|w| w.contains("not installed")));
+    }
+
+    #[test]
+    fn cursor_always_warns() {
+        let mut r = empty_result();
+        r.claude_settings_outcome = Some(installer::ClaudeSettingsOutcome::Created);
+        r.cursor_hook_snippet = Some(PathBuf::from("/tmp/cursor-hooks.snippet.json"));
+
+        let l2 = aggregate_layer2_status(&r);
+        assert_eq!(l2.tools, vec!["Claude Code"]);
+        assert!(l2.warnings.iter().any(|w| w.contains("Cursor")));
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -46,10 +46,7 @@ fn install_creates_shims_without_touching_shell_config() {
     assert!(base_dir.join("hooks/cursor-hooks.snippet.json").exists());
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("Add to"),
-        "stdout: {stdout}"
-    );
+    assert!(stdout.contains("Add to"), "stdout: {stdout}");
     assert!(stdout.contains("Layer 1"), "stdout: {stdout}");
     assert!(stdout.contains("Layer 2"), "stdout: {stdout}");
     assert!(stdout.contains("Cursor"), "stdout: {stdout}");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -47,12 +47,12 @@ fn install_creates_shims_without_touching_shell_config() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("[todo] Add to your shell profile"),
+        stdout.contains("Add to"),
         "stdout: {stdout}"
     );
-    assert!(stdout.contains("Shims:"), "stdout: {stdout}");
-    assert!(stdout.contains("Hooks:"), "stdout: {stdout}");
-    assert!(stdout.contains("Cursor hook snippet"), "stdout: {stdout}");
+    assert!(stdout.contains("Layer 1"), "stdout: {stdout}");
+    assert!(stdout.contains("Layer 2"), "stdout: {stdout}");
+    assert!(stdout.contains("Cursor"), "stdout: {stdout}");
 
     let _ = fs::remove_dir_all(base_dir);
 }


### PR DESCRIPTION
## Summary
- Replace 40+ lines of per-file install output with a 4-line status banner (Layer 1/2/Config/Policy)
- Extract `aggregate_layer2_status()` for testable Layer 2 tool classification
- Codex CLI requires both hooks + config OK to be classified as "configured" (prevents false-OK when `codex_hooks = false`)

Closes #278

## Changes

### `src/cli/install.rs`
- Replace lines 55-198 (verbose output block) with concise summary banner
- Add `Layer2Status` struct and `aggregate_layer2_status()` function
- 5 unit tests for Layer 2 aggregation edge cases (all-success, config-disabled-warn, all-none, mixed, cursor-always-warns)

### `tests/integration.rs`
- Update 4 assertions: `[todo] Add to your shell profile` → `Add to`, `Shims:` → `Layer 1`, `Hooks:` → `Layer 2`, `Cursor hook snippet` → `Cursor`
- 3 existing assertions preserved unchanged: `[done] Created`, `[skip] Already exists`, `rules verified`

## Output examples

**Success path:**
```
omamori setup complete:

  ✓ Layer 1 (PATH shims): 5/5 installed
  ✓ Layer 2 (hooks):      Claude Code, Codex CLI
  ✓ Config:               [skip] Already exists: ~/.config/omamori/config.toml
  ✓ Policy:               13 rules verified, 12 tests passed

Next steps:
  Add to ~/.zshrc:  export PATH="~/.omamori/shim:$PATH"
  Verify:           omamori doctor
  Dry-run:          omamori test
```

**Warning path (Cursor + Codex config disabled):**
```
omamori setup complete:

  ✓ Layer 1 (PATH shims): 5/5 installed
  ! Layer 2 (hooks):      Claude Code
  ✓ Config:               [done] Created: ~/.config/omamori/config.toml
  ✓ Policy:               13 rules verified, 12 tests passed

  ! Codex CLI: codex_hooks = false (set by user)
      set codex_hooks = true in ~/.codex/config.toml
  ! Cursor: manual merge needed
      cat ~/.omamori/hooks/cursor-hooks.snippet.json

Next steps:
  Add to ~/.zshrc:  export PATH="~/.omamori/shim:$PATH"
  Verify:           omamori doctor
  Dry-run:          omamori test
```

**No --hooks flag:**
```
omamori setup complete:

  ✓ Layer 1 (PATH shims): 5/5 installed
  - Layer 2 (hooks):      not requested (run with --hooks)
  ✓ Config:               [skip] Already exists: ~/.config/omamori/config.toml
  ✓ Policy:               13 rules verified, 12 tests passed

Next steps:
  Add to ~/.zshrc:  export PATH="~/.omamori/shim:$PATH"
  Verify:           omamori doctor
  Dry-run:          omamori test
```

## Testing
- [x] `cargo test` — 916 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo build` — clean
- [x] 5 new unit tests for Layer 2 aggregation
- [x] 12 integration tests pass (4 assertions updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)