### PR TITLE
feat: extend --json-error contract to all deny paths

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -115,23 +115,23 @@ This rule ensures that the boundary matrix and test corpus grow together and tha
 | DI-15 | *(Retired in v0.10.4)* | Was: data-context substitution preservation via `subst_depth` tracking (v0.10.3). Removed with `strip_quoted_data` — no longer needed since meta-pattern substring matching is gone. |
 | DI-16 | *(Retired in v0.10.4)* | Was: data-flag allow emits audit with `layer2:relaxed:*` tag (v0.10.3). Removed with the data-context heuristic — `relaxed_by` field is always `None`. |
 
-### `hook-check --json-error` schema (v0.10.3+, PR1b)
+### `hook-check --json-error` schema (v0.10.3+, extended in #249)
 
-When `--json-error` is passed to `omamori hook-check`, **blocked shell commands** emit a single JSON object to **stderr** (in place of free-form text). Allow paths still emit the regular Claude Code hook response on stdout. AI agent integrations consume this for retry / approach-switch decisions.
+When `--json-error` is passed to `omamori hook-check`, **all deny paths** emit a single JSON object to **stderr** (in place of free-form text). Allow paths still emit the regular Claude Code hook response on stdout. AI agent integrations consume this for retry / approach-switch decisions.
 
-**Current scope**: the JSON contract applies to the **shell-command path** only (i.e. `tool_input.command` blocked by Phase 1B token detection / Phase 2 rule match / Phase 2 structural unwrap). Other deny paths — malformed hook input, file-op deny on protected paths, unknown-tool fail-open — currently retain free-form stderr; extension to those paths is tracked as a follow-up issue. AI agents can still detect these blocks by exit code 2.
+**Scope**: the JSON contract applies to all deny paths — shell-command blocks (Phase 1B token detection / Phase 2 rule match / Phase 2 structural unwrap), malformed hook input, and file-op deny on protected paths. AI agents parse one format regardless of block reason.
 
 **Schema**:
 
 ```json
 {
   "blocked": true,
-  "layer": "layer2:meta-pattern" | "layer2:rule" | "layer2:structural" | "layer2:pipe-to-shell:<wrapper>" | "layer2:obfuscated-expansion",
+  "layer": "layer2:meta-pattern" | "layer2:rule" | "layer2:structural" | "layer2:pipe-to-shell:<wrapper>" | "layer2:obfuscated-expansion" | "layer2:input-validation" | "layer2:file-protection",
   "rule_id": "<rule_name or layer-specific identifier>",
   "reason": "<human-readable message>",
-  "matched_pattern": "<protected pattern token>" | null,
+  "matched_pattern": "<pattern string>" | null,
   "matched_position": { "start": <usize>, "end": <usize> } | null,
-  "hint": "run `omamori explain -- <command>` for details"
+  "hint": "<action guidance for AI agent>"
 }
 ```
 
@@ -139,9 +139,24 @@ When `--json-error` is passed to `omamori hook-check`, **blocked shell commands*
 
 - `blocked`: always `true` (allow path uses Claude Code hook response, not this schema)
 - `layer`: forensic layer identifier prefixed with `layer2:` to match the audit log `detection_layer` field exactly. Stderr JSON `layer` and audit row `detection_layer` are interchangeable for correlation
-- `rule_id`: for `BlockRule` it is the rule name (e.g. `omamori-config-modify-block`); for `BlockMeta` it is the reason string itself; for `BlockStructural` it is the constant string `"structural"`
-- `matched_pattern`: the protected pattern token (`"config disable"`, `"omamori uninstall"`, etc.) when known. `null` for structural blocks (no specific pattern matched) and Phase 1B token-level detections (env tampering / PATH override) where no single substring identifies the trigger
+- `rule_id`: for `BlockRule` it is the rule name (e.g. `omamori-config-modify-block`); for `BlockMeta` it is the reason string itself; for `BlockStructural` it is the constant string `"structural"`; for input validation it is `"invalid-input"`; for file protection it is `"protected-file"`
+- `matched_pattern`: the protected pattern token when known. `null` for structural blocks, Phase 1B token-level detections, and input validation errors
 - `matched_position`: byte range `[start, end)` of the match in the original command string when known; `null` when position tracking is not available for the layer
+- `hint`: action guidance for the AI agent consumer. Shell-command blocks reference `omamori explain`; input validation and file protection blocks use a "Tell the user:" pattern directing the AI to inform the user and offer alternatives
+
+**Layer values**:
+
+| Layer | Deny path |
+|-------|-----------|
+| `layer2:meta-pattern` | Phase 1B token-level detection (env tampering, config commands) |
+| `layer2:rule` | Phase 2 rule match (e.g. `rm-recursive-to-trash`) |
+| `layer2:structural` | Phase 2 structural detection (no wrapper kind) |
+| `layer2:pipe-to-shell:<wrapper>` | Phase 2 pipe-to-shell with wrapper (e.g. `env`, `bash`) |
+| `layer2:obfuscated-expansion` | Phase 2 obfuscated expansion detection |
+| `layer2:input-validation` | Malformed or incomplete hook input (JSON parse failure or missing fields) |
+| `layer2:file-protection` | Protected file modification attempt |
+
+**Security note — input validation errors**: `MalformedJson` and `MalformedMissingField` emit identical JSON (same layer, rule_id, reason) to minimize oracle exposure. Attackers cannot distinguish JSON parse failures from missing-field errors, preventing incremental input refinement. The reason string is static and never includes raw stdin content to prevent reflection attacks.
 
 **Trade-off — audit gap in `--json-error` mode**:
 

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -389,6 +389,17 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
 
     match extract_hook_input(&input) {
         HookInput::MalformedJson => {
+            if json_error {
+                emit_json_error(
+                    "layer2:input-validation",
+                    "invalid-input",
+                    "hook input could not be validated",
+                    None,
+                    None,
+                    "Tell the user: this action was blocked by omamori because the input could not be verified. Ask if you should try a different approach or if the user prefers to handle it directly.",
+                );
+                return Ok(2);
+            }
             eprintln!("omamori hook: blocked — hook input is not valid JSON");
             eprintln!("  The command was denied because omamori cannot verify its safety.");
             eprintln!(
@@ -404,6 +415,17 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
             Ok(2)
         }
         HookInput::MalformedMissingField => {
+            if json_error {
+                emit_json_error(
+                    "layer2:input-validation",
+                    "invalid-input",
+                    "hook input could not be validated",
+                    None,
+                    None,
+                    "Tell the user: this action was blocked by omamori because the input could not be verified. Ask if you should try a different approach or if the user prefers to handle it directly.",
+                );
+                return Ok(2);
+            }
             eprintln!("omamori hook: blocked — required fields missing from hook input");
             eprintln!("  The command was denied because omamori cannot verify its safety.");
             eprintln!("  Expected: tool_input.command or tool_input.file_path");
@@ -421,8 +443,19 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
             tool_input,
         } => run_hook_check_unknown_tool(&tool_name, &tool_input, &provider, verbose, json_error),
         HookInput::FileOp { tool, path } => {
-            if let Some(reason) = is_protected_file_path(&path) {
-                eprintln!("omamori hook: blocked {tool} to protected file — {reason}");
+            if let Some((pattern, description)) = is_protected_file_path(&path) {
+                if json_error {
+                    emit_json_error(
+                        "layer2:file-protection",
+                        "protected-file",
+                        &format!("blocked {tool} to protected file — {description}"),
+                        Some(pattern),
+                        None,
+                        "Tell the user: this file is protected by omamori and AI modifications are blocked. Describe the intended change and ask if you should try a different approach or if the user prefers to make the change directly.",
+                    );
+                    return Ok(2);
+                }
+                eprintln!("omamori hook: blocked {tool} to protected file — {description}");
                 eprintln!("  AI agents cannot modify omamori configuration or security files.");
                 eprintln!(
                     "  To edit config: use `omamori config` CLI or edit the file directly in your terminal."
@@ -485,7 +518,7 @@ fn run_hook_check_command(
                     reason,
                     matched_pattern,
                     matched_position.as_ref(),
-                    command,
+                    &format!("run `omamori explain -- {command}` for details"),
                 );
             } else {
                 audit_log_hook_block(
@@ -524,7 +557,7 @@ fn run_hook_check_command(
                     &message,
                     matched_pattern,
                     matched_position.as_ref(),
-                    command,
+                    &format!("run `omamori explain -- {command}` for details"),
                 );
             } else {
                 audit_log_hook_block(
@@ -571,7 +604,7 @@ fn run_hook_check_command(
                     &message,
                     matched_pattern,
                     matched_position.as_ref(),
-                    command,
+                    &format!("run `omamori explain -- {command}` for details"),
                 );
             } else {
                 audit_log_hook_block(command, provider, None, None, detection_layer);
@@ -634,8 +667,19 @@ fn run_hook_check_unknown_tool(
             run_hook_check_command(cmd, provider, verbose, json_error)
         }
         InputShape::FileOp(path) => {
-            if let Some(reason) = is_protected_file_path(path) {
-                eprintln!("omamori hook: blocked {tool_name} to protected file — {reason}");
+            if let Some((pattern, description)) = is_protected_file_path(path) {
+                if json_error {
+                    emit_json_error(
+                        "layer2:file-protection",
+                        "protected-file",
+                        &format!("blocked {tool_name} to protected file — {description}"),
+                        Some(pattern),
+                        None,
+                        "Tell the user: this file is protected by omamori and AI modifications are blocked. Describe the intended change and ask if you should try a different approach or if the user prefers to make the change directly.",
+                    );
+                    return Ok(2);
+                }
+                eprintln!("omamori hook: blocked {tool_name} to protected file — {description}");
                 eprintln!("  AI agents cannot modify omamori configuration or security files.");
                 eprintln!(
                     "  To edit config: use `omamori config` CLI or edit the file directly in your terminal."
@@ -824,6 +868,8 @@ const VALID_DETECTION_LAYERS_STATIC: &[&str] = &[
     "layer2:rule",
     "layer2:structural",
     "layer2:obfuscated-expansion",
+    "layer2:input-validation",
+    "layer2:file-protection",
 ];
 
 /// Validate that `detection_layer` value falls within the v0.9.7 taxonomy.
@@ -1017,7 +1063,7 @@ pub(crate) const PROTECTED_FILE_PATTERNS: &[(&str, &str)] = &[
 ];
 
 /// Check whether a file path targets a protected omamori file.
-fn is_protected_file_path(path: &str) -> Option<&'static str> {
+fn is_protected_file_path(path: &str) -> Option<(&'static str, &'static str)> {
     let lexical = crate::context::normalize_path(path);
 
     let candidates: Vec<std::path::PathBuf> = match std::fs::canonicalize(&lexical) {
@@ -1033,11 +1079,11 @@ fn is_protected_file_path(path: &str) -> Option<&'static str> {
     let lexical_str = lexical.to_string_lossy();
     for &(pattern, reason) in PROTECTED_FILE_PATTERNS {
         if lexical_str.contains(pattern) {
-            return Some(reason);
+            return Some((pattern, reason));
         }
         for candidate in &candidates {
             if candidate.to_string_lossy().contains(pattern) {
-                return Some(reason);
+                return Some((pattern, reason));
             }
         }
     }
@@ -1270,7 +1316,7 @@ fn emit_json_error(
     reason: &str,
     matched_pattern: Option<&str>,
     matched_position: Option<&Range<usize>>,
-    command: &str,
+    hint: &str,
 ) {
     let payload = serde_json::json!({
         "blocked": true,
@@ -1282,7 +1328,7 @@ fn emit_json_error(
             "start": r.start,
             "end": r.end,
         })),
-        "hint": format!("run `omamori explain -- {command}` for details"),
+        "hint": hint,
     });
     eprintln!(
         "{}",

--- a/src/engine/hook.rs
+++ b/src/engine/hook.rs
@@ -396,7 +396,7 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
                     "hook input could not be validated",
                     None,
                     None,
-                    "Tell the user: this action was blocked by omamori because the input could not be verified. Ask if you should try a different approach or if the user prefers to handle it directly.",
+                    HINT_INPUT_VALIDATION,
                 );
                 return Ok(2);
             }
@@ -422,7 +422,7 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
                     "hook input could not be validated",
                     None,
                     None,
-                    "Tell the user: this action was blocked by omamori because the input could not be verified. Ask if you should try a different approach or if the user prefers to handle it directly.",
+                    HINT_INPUT_VALIDATION,
                 );
                 return Ok(2);
             }
@@ -451,7 +451,7 @@ pub(crate) fn run_hook_check(args: &[OsString]) -> Result<i32, AppError> {
                         &format!("blocked {tool} to protected file — {description}"),
                         Some(pattern),
                         None,
-                        "Tell the user: this file is protected by omamori and AI modifications are blocked. Describe the intended change and ask if you should try a different approach or if the user prefers to make the change directly.",
+                        HINT_FILE_PROTECTION,
                     );
                     return Ok(2);
                 }
@@ -675,7 +675,7 @@ fn run_hook_check_unknown_tool(
                         &format!("blocked {tool_name} to protected file — {description}"),
                         Some(pattern),
                         None,
-                        "Tell the user: this file is protected by omamori and AI modifications are blocked. Describe the intended change and ask if you should try a different approach or if the user prefers to make the change directly.",
+                        HINT_FILE_PROTECTION,
                     );
                     return Ok(2);
                 }
@@ -1307,6 +1307,10 @@ fn parse_provider_flag(args: &[OsString]) -> String {
 fn parse_json_error_flag(args: &[OsString]) -> bool {
     args.iter().any(|a| a.to_str() == Some("--json-error"))
 }
+
+const HINT_INPUT_VALIDATION: &str = "Tell the user: this action was blocked by omamori because the input could not be verified. Ask if you should try a different approach or if the user prefers to handle it directly.";
+
+const HINT_FILE_PROTECTION: &str = "Tell the user: this file is protected by omamori and AI modifications are blocked. Describe the intended change and ask if you should try a different approach or if the user prefers to make the change directly.";
 
 /// Emit a structured JSON error to stderr for `--json-error` mode.
 /// Schema is documented in SECURITY.md "hook-check --json-error schema".

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1846,21 +1846,26 @@ fn hook_check_blocks_rm_reversed_flags() {
 // Codex review (Phase 6-B) flagged the previous internal-enum-only test
 // as insufficient (mutation resistance weak, false confidence high).
 
-/// Run `omamori hook-check --json-error --provider claude-code` with stdin.
-fn run_hook_check_json_error(input: &str) -> (String, String, i32) {
+fn run_hook_check_json_error_impl(input: &str, verbose: bool) -> (String, String, i32) {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let test_home = std::env::temp_dir().join(format!("omamori-cli-jsonerr-{nanos}"));
+    let suffix = if verbose { "-v" } else { "" };
+    let test_home = std::env::temp_dir().join(format!("omamori-cli-jsonerr{suffix}-{nanos}"));
     let _ = std::fs::create_dir_all(&test_home);
 
-    let mut child = Command::new(binary())
-        .args(["hook-check", "--provider", "claude-code", "--json-error"])
+    let mut cmd = Command::new(binary());
+    cmd.args(["hook-check", "--provider", "claude-code", "--json-error"])
         .env("HOME", &test_home)
         .env("XDG_CONFIG_HOME", test_home.join(".config"))
         .env("XDG_DATA_HOME", test_home.join(".local/share"))
-        .env("XDG_CACHE_HOME", test_home.join(".cache"))
+        .env("XDG_CACHE_HOME", test_home.join(".cache"));
+    if verbose {
+        cmd.env("OMAMORI_VERBOSE", "1");
+    }
+
+    let mut child = cmd
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1880,6 +1885,11 @@ fn run_hook_check_json_error(input: &str) -> (String, String, i32) {
     let exit_code = output.status.code().unwrap_or(-1);
     let _ = std::fs::remove_dir_all(&test_home);
     (stdout, stderr, exit_code)
+}
+
+/// Run `omamori hook-check --json-error --provider claude-code` with stdin.
+fn run_hook_check_json_error(input: &str) -> (String, String, i32) {
+    run_hook_check_json_error_impl(input, false)
 }
 
 /// Parse the stderr of `--json-error` mode as a single JSON object.
@@ -2144,39 +2154,7 @@ fn hook_check_json_error_fileop_single_object_contract() {
 }
 
 fn run_hook_check_json_error_verbose(input: &str) -> (String, String, i32) {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let test_home = std::env::temp_dir().join(format!("omamori-cli-jsonerr-v-{nanos}"));
-    let _ = std::fs::create_dir_all(&test_home);
-
-    let mut child = Command::new(binary())
-        .args(["hook-check", "--provider", "claude-code", "--json-error"])
-        .env("HOME", &test_home)
-        .env("XDG_CONFIG_HOME", test_home.join(".config"))
-        .env("XDG_DATA_HOME", test_home.join(".local/share"))
-        .env("XDG_CACHE_HOME", test_home.join(".cache"))
-        .env("OMAMORI_VERBOSE", "1")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("failed to spawn hook-check --json-error verbose");
-
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(input.as_bytes())
-        .unwrap();
-
-    let output = child.wait_with_output().expect("failed to wait");
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    let exit_code = output.status.code().unwrap_or(-1);
-    let _ = std::fs::remove_dir_all(&test_home);
-    (stdout, stderr, exit_code)
+    run_hook_check_json_error_impl(input, true)
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2017,8 +2017,7 @@ fn hook_check_json_error_stderr_is_single_object() {
 
 #[test]
 fn hook_check_json_error_malformed_json() {
-    let (stdout, stderr, exit_code) =
-        run_hook_check_json_error("this is not json at all");
+    let (stdout, stderr, exit_code) = run_hook_check_json_error("this is not json at all");
     assert_eq!(exit_code, 2);
     assert!(stdout.is_empty());
     let json = parse_json_error_stderr(&stderr);
@@ -2077,10 +2076,7 @@ fn hook_check_json_error_fileop_protected_file() {
     assert_eq!(json["layer"], "layer2:file-protection");
     assert_eq!(json["rule_id"], "protected-file");
     assert!(
-        json["reason"]
-            .as_str()
-            .unwrap()
-            .contains("protected file"),
+        json["reason"].as_str().unwrap().contains("protected file"),
         "reason must mention protected file"
     );
     assert!(
@@ -2159,8 +2155,7 @@ fn run_hook_check_json_error_verbose(input: &str) -> (String, String, i32) {
 
 #[test]
 fn hook_check_json_error_verbose_malformed_no_raw_input() {
-    let (_, stderr, exit_code) =
-        run_hook_check_json_error_verbose("this is not json at all");
+    let (_, stderr, exit_code) = run_hook_check_json_error_verbose("this is not json at all");
     assert_eq!(exit_code, 2);
     let trimmed = stderr.trim();
     assert!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2000,3 +2000,218 @@ fn hook_check_json_error_stderr_is_single_object() {
         "stderr must be a single JSON object (got {trimmed:?})"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #249: --json-error for MalformedJson, MalformedMissingField, FileOp
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hook_check_json_error_malformed_json() {
+    let (stdout, stderr, exit_code) =
+        run_hook_check_json_error("this is not json at all");
+    assert_eq!(exit_code, 2);
+    assert!(stdout.is_empty());
+    let json = parse_json_error_stderr(&stderr);
+    assert_eq!(json["blocked"], serde_json::Value::Bool(true));
+    assert_eq!(json["layer"], "layer2:input-validation");
+    assert_eq!(json["rule_id"], "invalid-input");
+    assert_eq!(json["reason"], "hook input could not be validated");
+    assert!(json["matched_pattern"].is_null());
+    assert!(json["matched_position"].is_null());
+    assert!(
+        json["hint"].as_str().unwrap().starts_with("Tell the user:"),
+        "hint must use Tell-the-user pattern"
+    );
+}
+
+#[test]
+fn hook_check_json_error_malformed_missing_field() {
+    let input = serde_json::json!({
+        "tool_name": "Bash",
+        "tool_input": {}
+    })
+    .to_string();
+    let (stdout, stderr, exit_code) = run_hook_check_json_error(&input);
+    assert_eq!(exit_code, 2);
+    assert!(stdout.is_empty());
+    let json = parse_json_error_stderr(&stderr);
+    assert_eq!(json["blocked"], serde_json::Value::Bool(true));
+    assert_eq!(
+        json["layer"], "layer2:input-validation",
+        "MalformedMissingField uses same layer as MalformedJson (oracle minimization)"
+    );
+    assert_eq!(
+        json["rule_id"], "invalid-input",
+        "MalformedMissingField uses same rule_id as MalformedJson (oracle minimization)"
+    );
+    assert_eq!(json["reason"], "hook input could not be validated");
+    assert!(json["matched_pattern"].is_null());
+}
+
+#[test]
+fn hook_check_json_error_fileop_protected_file() {
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "/home/user/.config/omamori/config.toml",
+            "old_string": "x",
+            "new_string": "y"
+        }
+    })
+    .to_string();
+    let (stdout, stderr, exit_code) = run_hook_check_json_error(&input);
+    assert_eq!(exit_code, 2);
+    assert!(stdout.is_empty());
+    let json = parse_json_error_stderr(&stderr);
+    assert_eq!(json["blocked"], serde_json::Value::Bool(true));
+    assert_eq!(json["layer"], "layer2:file-protection");
+    assert_eq!(json["rule_id"], "protected-file");
+    assert!(
+        json["reason"]
+            .as_str()
+            .unwrap()
+            .contains("protected file"),
+        "reason must mention protected file"
+    );
+    assert!(
+        json["matched_pattern"].is_string(),
+        "FileOp must report the matched pattern"
+    );
+    assert!(
+        json["hint"].as_str().unwrap().starts_with("Tell the user:"),
+        "hint must use Tell-the-user pattern"
+    );
+}
+
+#[test]
+fn hook_check_json_error_fileop_unknown_tool() {
+    let input = serde_json::json!({
+        "tool_name": "SomeEditor",
+        "tool_input": {
+            "file_path": "/home/user/.config/omamori/config.toml"
+        }
+    })
+    .to_string();
+    let (stdout, stderr, exit_code) = run_hook_check_json_error(&input);
+    assert_eq!(exit_code, 2);
+    assert!(stdout.is_empty());
+    let json = parse_json_error_stderr(&stderr);
+    assert_eq!(json["blocked"], serde_json::Value::Bool(true));
+    assert_eq!(json["layer"], "layer2:file-protection");
+    assert_eq!(json["rule_id"], "protected-file");
+    assert!(
+        json["matched_pattern"].is_string(),
+        "FileOp via unknown tool must also report matched pattern"
+    );
+}
+
+#[test]
+fn hook_check_json_error_malformed_single_object_contract() {
+    let (_, stderr, _) = run_hook_check_json_error("not json");
+    let trimmed = stderr.trim();
+    assert!(
+        trimmed.starts_with('{') && trimmed.ends_with('}'),
+        "MalformedJson stderr must be a single JSON object (got {trimmed:?})"
+    );
+    assert_eq!(
+        trimmed.lines().count(),
+        1,
+        "stderr must be exactly one line"
+    );
+}
+
+#[test]
+fn hook_check_json_error_fileop_single_object_contract() {
+    let input = serde_json::json!({
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": "/home/user/.config/omamori/config.toml",
+            "content": "x"
+        }
+    })
+    .to_string();
+    let (_, stderr, _) = run_hook_check_json_error(&input);
+    let trimmed = stderr.trim();
+    assert!(
+        trimmed.starts_with('{') && trimmed.ends_with('}'),
+        "FileOp stderr must be a single JSON object (got {trimmed:?})"
+    );
+    assert_eq!(
+        trimmed.lines().count(),
+        1,
+        "stderr must be exactly one line"
+    );
+}
+
+fn run_hook_check_json_error_verbose(input: &str) -> (String, String, i32) {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let test_home = std::env::temp_dir().join(format!("omamori-cli-jsonerr-v-{nanos}"));
+    let _ = std::fs::create_dir_all(&test_home);
+
+    let mut child = Command::new(binary())
+        .args(["hook-check", "--provider", "claude-code", "--json-error"])
+        .env("HOME", &test_home)
+        .env("XDG_CONFIG_HOME", test_home.join(".config"))
+        .env("XDG_DATA_HOME", test_home.join(".local/share"))
+        .env("XDG_CACHE_HOME", test_home.join(".cache"))
+        .env("OMAMORI_VERBOSE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn hook-check --json-error verbose");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().expect("failed to wait");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exit_code = output.status.code().unwrap_or(-1);
+    let _ = std::fs::remove_dir_all(&test_home);
+    (stdout, stderr, exit_code)
+}
+
+#[test]
+fn hook_check_json_error_verbose_malformed_no_raw_input() {
+    let (_, stderr, exit_code) =
+        run_hook_check_json_error_verbose("this is not json at all");
+    assert_eq!(exit_code, 2);
+    let trimmed = stderr.trim();
+    assert!(
+        trimmed.starts_with('{') && trimmed.ends_with('}'),
+        "verbose + json-error must still be single JSON (got {trimmed:?})"
+    );
+    assert!(
+        !trimmed.contains("raw input"),
+        "verbose raw-input must not leak in json-error mode"
+    );
+}
+
+#[test]
+fn hook_check_json_error_verbose_fileop_no_extra_lines() {
+    let input = serde_json::json!({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "/home/user/.config/omamori/config.toml",
+            "old_string": "x",
+            "new_string": "y"
+        }
+    })
+    .to_string();
+    let (_, stderr, exit_code) = run_hook_check_json_error_verbose(&input);
+    assert_eq!(exit_code, 2);
+    let trimmed = stderr.trim();
+    assert_eq!(
+        trimmed.lines().count(),
+        1,
+        "verbose + json-error FileOp must be single line (got {trimmed:?})"
+    );
+}


### PR DESCRIPTION
## Summary

- Extend `--json-error` structured JSON output from shell-command blocks only to **all deny paths**: malformed input, missing fields, and protected file operations
- AI agents now parse one JSON format regardless of block reason (previously had to fall back to exit-code-only detection for non-command blocks)
- No behavioral changes for users without `--json-error` flag

## Changes

### `emit_json_error` signature change
`command: &str` → `hint: &str` — callers now pass the hint string directly instead of having it derived from the command. Existing 3 call sites pass `format!("run \`omamori explain -- {command}\` for details")` preserving current behavior.

### `is_protected_file_path` return type change
`Option<&'static str>` → `Option<(&'static str, &'static str)>` — returns `(pattern, reason)` tuple so `matched_pattern` can be populated in JSON output.

### New `--json-error` branches
| Deny path | layer | rule_id |
|-----------|-------|---------|
| MalformedJson | `layer2:input-validation` | `invalid-input` |
| MalformedMissingField | `layer2:input-validation` | `invalid-input` |
| FileOp (direct) | `layer2:file-protection` | `protected-file` |
| FileOp (unknown-tool) | `layer2:file-protection` | `protected-file` |

### Security design decisions
- **Oracle minimization**: MalformedJson and MalformedMissingField emit identical JSON — attackers cannot distinguish parse failures from missing-field errors
- **No raw stdin reflection**: reason strings are static, never interpolated from input
- **"Tell the user:" hint pattern**: hints direct AI agents to inform the user and offer alternatives (different approach vs. user handles directly), without providing bypass information
- **Early return**: json_error branches return before verbose code, structurally preventing raw-input leakage

### Documentation
- SECURITY.md updated: scope expanded from "shell-command path only" to "all deny paths", new layer values documented, oracle minimization noted

## Test plan
- [x] 8 new integration tests (malformed JSON, missing field, FileOp direct, FileOp unknown-tool, single-object contracts, verbose suppression)
- [x] All 4 existing json-error tests pass unchanged
- [x] Full test suite: 924 passed, 0 failed
- [x] `RUSTFLAGS='-D warnings' cargo test` clean

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)