### PR TITLE
feat: add `omamori setup` one-command onboarding (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.11.0] - 2026-05-30
+
+**Summary**: Add `omamori setup` — a single interactive command that replaces the 5-step manual onboarding flow (install → hooks → edit shell profile → source → doctor) with one guided wizard. The y/n prompt (default Y) appends a portable `$HOME/.omamori/shim` PATH entry to the user's shell profile. AI environments auto-skip the profile prompt. Includes `--dry-run` preview and `--non-interactive` mode for CI.
+
+### Added
+
+- **`omamori setup` subcommand** — Orchestrates `installer::install()` (shims + hooks), shell profile PATH append, and `integrity::full_check()` verification in a 3-step guided flow. Detects shell from `$SHELL` basename (zsh, bash only). Appends `export PATH="$HOME/.omamori/shim:$PATH"` with a versioned marker comment for idempotency. Exit codes: 0 (all done), 1 (preflight error or doctor failure), 2 (installed but profile skipped). ([#277](https://github.com/yottayoshida/omamori/issues/277))
+- **`--dry-run` flag** — Shows what `setup` would do without creating or modifying any files. Correctly reflects AI environment detection (skips profile preview when AI env detected). ([#277](https://github.com/yottayoshida/omamori/issues/277))
+- **`--non-interactive` flag** — Auto-appends PATH without prompting. Automatically enabled in AI environments (`CLAUDECODE`, `CODEX_CLI`, etc.). ([#277](https://github.com/yottayoshida/omamori/issues/277))
+- **AI environment detection (DI-7)** — Reuses `doctor::is_ai_environment()` to skip profile modification when running inside AI agents. Install and hooks proceed normally (they strengthen protection). Manual PATH instructions printed instead. ([#277](https://github.com/yottayoshida/omamori/issues/277))
+- **Broken symlink detection** — `handle_profile()` uses `fs::symlink_metadata()` to detect broken symlinks at the shell profile path before attempting any I/O, providing a clear error message instead of a confusing OS-level "No such file or directory". ([#277](https://github.com/yottayoshida/omamori/issues/277))
+- **10 integration tests** — Covering non-interactive, idempotency, dry-run, AI env, unknown shell, already-configured, non-TTY stdin, bash profile selection, and unknown flag error paths. ([#277](https://github.com/yottayoshida/omamori/issues/277))
+
+### Changed
+
+- **`is_ai_environment()` visibility** — Changed from private to `pub(crate)` in `doctor.rs` so `setup.rs` can reuse it. No public API change. ([#277](https://github.com/yottayoshida/omamori/issues/277))
+- **`layer2_tool_names()` respects `codex_config_outcome`** — No longer reports "Codex CLI" as installed when `codex_hooks = false` in the user's config (`ExplicitlyDisabled`). Previously only checked `codex_hooks_outcome`. ([#277](https://github.com/yottayoshida/omamori/issues/277))
+- **Exit code reflects doctor verification** — `setup` returns exit 1 when `integrity::full_check()` finds failures, even if install and profile steps succeeded. Previously only checked profile status. ([#277](https://github.com/yottayoshida/omamori/issues/277))
+
 ## [0.10.14] - 2026-05-24
 
 **Summary**: Categorize `omamori --help` output into ESSENTIALS / DIAGNOSTICS / CONFIGURATION sections and hide internal commands (`hook-check`, `cursor-hook`, `exec`) behind `--help-all`. Error messages now show a concise one-line hint instead of the full usage dump. Display-only change with no behavioral or routing modifications.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.10.14"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.10.14"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -491,7 +491,7 @@ fn remediation_hint(rem: &Remediation, ai_env: bool) -> String {
 }
 
 /// Lightweight AI environment check reusing the detector infrastructure.
-fn is_ai_environment() -> bool {
+pub(crate) fn is_ai_environment() -> bool {
     let detectors = crate::config::default_detectors();
     let env_pairs: Vec<(String, String)> = std::env::vars().collect();
     let detection = crate::detector::evaluate_detectors(&detectors, &env_pairs);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,4 +15,5 @@ pub(crate) mod explain;
 pub(crate) mod install;
 pub(crate) mod policy_test;
 pub(crate) mod report;
+pub(crate) mod setup;
 pub(crate) mod status;

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -1,0 +1,384 @@
+//! `omamori setup` — one-command interactive onboarding.
+//!
+//! Orchestrates: install (shims + hooks) → shell profile → doctor verification.
+
+use std::env;
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use crate::config;
+use crate::installer::{self, InstallOptions, SHIM_COMMANDS};
+use crate::integrity::{self, CheckStatus};
+use crate::util::USAGE_HINT;
+use crate::AppError;
+
+use super::doctor::is_ai_environment;
+
+const MARKER: &str = "# Added by omamori setup";
+
+#[derive(Debug, Clone, Copy)]
+enum ShellKind {
+    Zsh,
+    Bash,
+}
+
+impl ShellKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Zsh => "zsh",
+            Self::Bash => "bash",
+        }
+    }
+}
+
+pub(crate) fn run_setup_command(args: &[OsString]) -> Result<i32, AppError> {
+    // --- Preflight: determine execution mode BEFORE any mutations ---
+    let mut dry_run = false;
+    let mut non_interactive = false;
+    let mut base_dir: Option<PathBuf> = None;
+    let mut index = 2usize;
+
+    while let Some(arg) = args.get(index).and_then(|item| item.to_str()) {
+        match arg {
+            "--dry-run" => {
+                dry_run = true;
+                index += 1;
+            }
+            "--non-interactive" => {
+                non_interactive = true;
+                index += 1;
+            }
+            "--base-dir" => {
+                let value = args.get(index + 1).ok_or_else(|| {
+                    AppError::Usage("setup requires a path after --base-dir".to_string())
+                })?;
+                base_dir = Some(PathBuf::from(value));
+                index += 2;
+            }
+            _ => {
+                return Err(AppError::Usage(format!(
+                    "unknown setup flag: {arg}\n\n{USAGE_HINT}"
+                )));
+            }
+        }
+    }
+
+    let custom_base = base_dir.is_some();
+    let base_dir = base_dir.unwrap_or_else(installer::default_base_dir);
+    let ai_env = is_ai_environment();
+
+    if ai_env {
+        non_interactive = true;
+    }
+
+    // Non-TTY stdin without --non-interactive: fail BEFORE any file I/O
+    if !non_interactive && !dry_run && !io::stdin().is_terminal() {
+        eprintln!("error: stdin is not a terminal");
+        eprintln!("Use --non-interactive to run without prompts.");
+        return Ok(1);
+    }
+
+    let shell = detect_shell();
+    let profile = shell.and_then(|s| detect_profile_path(s));
+
+    if dry_run {
+        return print_dry_run(&base_dir, shell, profile.as_deref(), custom_base, ai_env);
+    }
+
+    // --- [1/3] Install shims and hooks ---
+    println!("\nomamori setup \u{2014} one-command installation\n");
+    println!("  [1/3] Installing shims and hooks...");
+
+    let source_exe = installer::resolve_stable_exe_path(&env::current_exe()?);
+    let result = installer::install(&InstallOptions {
+        base_dir: base_dir.clone(),
+        source_exe,
+        generate_hooks: true,
+    })?;
+
+    println!(
+        "  \u{2713} Layer 1 (PATH shims): {}/{} installed",
+        result.linked_commands.len(),
+        SHIM_COMMANDS.len()
+    );
+
+    let l2_tools = layer2_tool_names(&result);
+    let l2_label = if l2_tools.is_empty() {
+        "no tools detected".to_string()
+    } else {
+        l2_tools.join(", ")
+    };
+    println!("  \u{2713} Layer 2 (hooks):      {l2_label}");
+
+    match config::default_config_path() {
+        Some(p) if !p.exists() => match config::write_default_config(&p, false) {
+            Ok(_) => println!("  \u{2713} Config:               {}", p.display()),
+            Err(e) => println!("  ! Config:               not created: {e}"),
+        },
+        Some(p) => println!("  \u{2713} Config:               {}", p.display()),
+        None => println!("  ! Config:               HOME/XDG_CONFIG_HOME not set"),
+    };
+
+    // --- [2/3] Shell profile ---
+    println!("\n  [2/3] Shell profile");
+
+    let profile_done = if ai_env {
+        println!("  - AI environment detected; skipping profile modification.");
+        print_manual_path_instructions(&result.shim_dir);
+        false
+    } else if custom_base {
+        println!("  - Custom --base-dir; add PATH manually:");
+        print_manual_path_instructions(&result.shim_dir);
+        false
+    } else if shell.is_none() {
+        println!("  - Unknown shell; add PATH manually:");
+        print_manual_path_instructions(&result.shim_dir);
+        false
+    } else if let Some(ref profile_path) = profile {
+        handle_profile(profile_path, &result.shim_dir, shell.unwrap(), non_interactive)?
+    } else {
+        println!("  - Shell profile not found; add PATH manually:");
+        print_manual_path_instructions(&result.shim_dir);
+        false
+    };
+
+    // --- [3/3] Verification ---
+    println!("\n  [3/3] Verification");
+    let report = integrity::full_check(&base_dir);
+    let (mut ok_count, mut fail_count, mut warn_count) = (0, 0, 0);
+    for item in &report.items {
+        match item.status {
+            CheckStatus::Ok => ok_count += 1,
+            CheckStatus::Fail => fail_count += 1,
+            CheckStatus::Warn => warn_count += 1,
+        }
+    }
+
+    if fail_count == 0 && warn_count == 0 {
+        println!("  \u{2713} doctor: OK ({ok_count} checks passed)");
+    } else if fail_count == 0 {
+        println!("  ! doctor: {ok_count} OK, {warn_count} warning(s)");
+    } else {
+        println!("  \u{2717} doctor: {fail_count} failed, {warn_count} warning(s)");
+    }
+
+    // --- Summary ---
+    println!("\n  Setup complete!\n");
+    println!("    Protected commands: {}", SHIM_COMMANDS.join(", "));
+    if profile_done {
+        if let Some(ref p) = profile {
+            println!("    \u{25b8} Activate now:  source {}", p.display());
+            println!("      (or open a new terminal tab)");
+        }
+    }
+    println!("    Verify anytime:  omamori doctor");
+    println!();
+
+    if fail_count > 0 {
+        Ok(1)
+    } else if profile_done {
+        Ok(0)
+    } else {
+        Ok(2)
+    }
+}
+
+fn handle_profile(
+    profile_path: &Path,
+    shim_dir: &Path,
+    shell: ShellKind,
+    non_interactive: bool,
+) -> Result<bool, AppError> {
+    // Reject broken symlinks before any read
+    if fs::symlink_metadata(profile_path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+        && !profile_path.exists()
+    {
+        eprintln!(
+            "  ! {} is a broken symlink; skipping.",
+            profile_path.display()
+        );
+        print_manual_path_instructions(shim_dir);
+        return Ok(false);
+    }
+
+    // Reject non-regular files (directory, device, etc.) before any read
+    if profile_path.exists() && !profile_path.is_file() {
+        eprintln!(
+            "  ! {} is not a regular file; skipping.",
+            profile_path.display()
+        );
+        print_manual_path_instructions(shim_dir);
+        return Ok(false);
+    }
+
+    if path_already_configured(profile_path)? {
+        println!("  \u{2713} Already in PATH");
+        return Ok(true);
+    }
+
+    println!("  Detected: {} ({})", shell.name(), profile_path.display());
+    println!("  Will add:  export PATH=\"$HOME/.omamori/shim:$PATH\"");
+
+    let should_append = if non_interactive {
+        true
+    } else {
+        println!(
+            "  This is safe to undo \u{2014} just delete the last line of {}.",
+            profile_path.display()
+        );
+        prompt_yes_no("  Add to shell profile? [Y/n]: ")
+    };
+
+    if !should_append {
+        println!("  - Skipped. Add manually:");
+        print_manual_path_instructions(shim_dir);
+        return Ok(false);
+    }
+
+    append_path_to_profile(profile_path)?;
+    println!("  \u{2713} Added to {}", profile_path.display());
+    Ok(true)
+}
+
+fn detect_shell() -> Option<ShellKind> {
+    let shell_var = env::var("SHELL").ok()?;
+    let basename = Path::new(&shell_var).file_name()?.to_str()?;
+    match basename {
+        "zsh" => Some(ShellKind::Zsh),
+        "bash" => Some(ShellKind::Bash),
+        _ => None,
+    }
+}
+
+fn detect_profile_path(shell: ShellKind) -> Option<PathBuf> {
+    let home = PathBuf::from(env::var("HOME").ok()?);
+    match shell {
+        ShellKind::Zsh => Some(home.join(".zshrc")),
+        ShellKind::Bash => {
+            let bash_profile = home.join(".bash_profile");
+            if bash_profile.exists() {
+                Some(bash_profile)
+            } else {
+                Some(home.join(".bashrc"))
+            }
+        }
+    }
+}
+
+fn path_already_configured(profile: &Path) -> Result<bool, AppError> {
+    if !profile.exists() {
+        return Ok(false);
+    }
+    let content = fs::read_to_string(profile)?;
+    Ok(content.contains(MARKER) || content.contains(".omamori/shim"))
+}
+
+fn append_path_to_profile(profile: &Path) -> Result<(), AppError> {
+    if let Some(parent) = profile.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let block = format!(
+        "\n{MARKER} (v{})\nexport PATH=\"$HOME/.omamori/shim:$PATH\"\n",
+        env!("CARGO_PKG_VERSION"),
+    );
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(profile)?;
+    file.write_all(block.as_bytes())?;
+    Ok(())
+}
+
+fn prompt_yes_no(prompt: &str) -> bool {
+    print!("{prompt}");
+    let _ = io::stdout().flush();
+    let mut input = String::new();
+    match io::stdin().lock().read_line(&mut input) {
+        Ok(0) | Err(_) => false,
+        Ok(_) => {
+            let trimmed = input.trim();
+            trimmed.is_empty()
+                || trimmed.eq_ignore_ascii_case("y")
+                || trimmed.eq_ignore_ascii_case("yes")
+        }
+    }
+}
+
+fn layer2_tool_names(result: &installer::InstallResult) -> Vec<String> {
+    let mut tools = Vec::new();
+    if matches!(
+        &result.claude_settings_outcome,
+        Some(
+            installer::ClaudeSettingsOutcome::Created
+                | installer::ClaudeSettingsOutcome::Merged
+                | installer::ClaudeSettingsOutcome::AlreadyPresent
+                | installer::ClaudeSettingsOutcome::MatcherMigrated
+                | installer::ClaudeSettingsOutcome::StaleEntriesCleaned(_)
+        )
+    ) {
+        tools.push("Claude Code".to_string());
+    }
+    if matches!(
+        &result.codex_hooks_outcome,
+        Some(
+            installer::CodexHooksOutcome::Created
+                | installer::CodexHooksOutcome::Merged
+                | installer::CodexHooksOutcome::AlreadyPresent
+        )
+    ) && !matches!(
+        &result.codex_config_outcome,
+        Some(installer::CodexConfigOutcome::ExplicitlyDisabled)
+    ) {
+        tools.push("Codex CLI".to_string());
+    }
+    tools
+}
+
+fn print_manual_path_instructions(shim_dir: &Path) {
+    println!("    export PATH=\"{}:$PATH\"", shim_dir.display());
+}
+
+fn print_dry_run(
+    base_dir: &Path,
+    shell: Option<ShellKind>,
+    profile: Option<&Path>,
+    custom_base: bool,
+    ai_env: bool,
+) -> Result<i32, AppError> {
+    println!("\nomamori setup --dry-run (preview only, no changes)\n");
+
+    println!("  [1/3] Would install shims and hooks");
+    println!("    Base dir:  {}", base_dir.display());
+    println!("    Shims:     {}", SHIM_COMMANDS.join(", "));
+    println!("    Hooks:     enabled");
+
+    println!("\n  [2/3] Shell profile");
+    if ai_env {
+        println!("    Would skip: AI environment detected");
+    } else if custom_base {
+        println!("    Would skip: custom --base-dir");
+    } else if shell.is_none() {
+        println!("    Would skip: unknown shell");
+    } else if let Some(p) = profile {
+        let already = path_already_configured(p).unwrap_or(false);
+        if already {
+            println!("    Target:    {}", p.display());
+            println!("    Status:    already configured");
+        } else {
+            println!("    Target:    {}", p.display());
+            println!("    Would add: export PATH=\"$HOME/.omamori/shim:$PATH\"");
+        }
+    } else {
+        println!("    Would skip: shell profile not found");
+    }
+
+    println!("\n  [3/3] Would run doctor verification");
+    println!("\nNo changes made.");
+    Ok(0)
+}

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -8,11 +8,11 @@ use std::fs::{self, OpenOptions};
 use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
+use crate::AppError;
 use crate::config;
 use crate::installer::{self, InstallOptions, SHIM_COMMANDS};
 use crate::integrity::{self, CheckStatus};
 use crate::util::USAGE_HINT;
-use crate::AppError;
 
 use super::doctor::is_ai_environment;
 
@@ -81,7 +81,7 @@ pub(crate) fn run_setup_command(args: &[OsString]) -> Result<i32, AppError> {
     }
 
     let shell = detect_shell();
-    let profile = shell.and_then(|s| detect_profile_path(s));
+    let profile = shell.and_then(detect_profile_path);
 
     if dry_run {
         return print_dry_run(&base_dir, shell, profile.as_deref(), custom_base, ai_env);
@@ -132,12 +132,12 @@ pub(crate) fn run_setup_command(args: &[OsString]) -> Result<i32, AppError> {
         println!("  - Custom --base-dir; add PATH manually:");
         print_manual_path_instructions(&result.shim_dir);
         false
+    } else if let (Some(s), Some(profile_path)) = (shell, &profile) {
+        handle_profile(profile_path, &result.shim_dir, s, non_interactive)?
     } else if shell.is_none() {
         println!("  - Unknown shell; add PATH manually:");
         print_manual_path_instructions(&result.shim_dir);
         false
-    } else if let Some(ref profile_path) = profile {
-        handle_profile(profile_path, &result.shim_dir, shell.unwrap(), non_interactive)?
     } else {
         println!("  - Shell profile not found; add PATH manually:");
         print_manual_path_instructions(&result.shim_dir);
@@ -167,11 +167,9 @@ pub(crate) fn run_setup_command(args: &[OsString]) -> Result<i32, AppError> {
     // --- Summary ---
     println!("\n  Setup complete!\n");
     println!("    Protected commands: {}", SHIM_COMMANDS.join(", "));
-    if profile_done {
-        if let Some(ref p) = profile {
-            println!("    \u{25b8} Activate now:  source {}", p.display());
-            println!("      (or open a new terminal tab)");
-        }
+    if profile_done && let Some(ref p) = profile {
+        println!("    \u{25b8} Activate now:  source {}", p.display());
+        println!("      (or open a new terminal tab)");
     }
     println!("    Verify anytime:  omamori doctor");
     println!();
@@ -287,10 +285,7 @@ fn append_path_to_profile(profile: &Path) -> Result<(), AppError> {
         env!("CARGO_PKG_VERSION"),
     );
 
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(profile)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(profile)?;
     file.write_all(block.as_bytes())?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use cli::explain::run_explain_command;
 use cli::install::{run_install_command, run_uninstall_command};
 use cli::policy_test::run_policy_test_command;
 use cli::report::run_report_command;
+use cli::setup::run_setup_command;
 use cli::status::run_status_command;
 use engine::exec::run_exec_command;
 use engine::hook::{run_cursor_hook, run_hook_check};
@@ -84,6 +85,7 @@ pub fn run(args: &[OsString]) -> Result<i32, AppError> {
         Some("override") => run_override_command(args),
         Some("audit") => run_audit_command(args),
         Some("doctor") => run_doctor_command(args),
+        Some("setup") => run_setup_command(args),
         Some("explain") => run_explain_command(args),
         Some("report") => run_report_command(args),
         Some("status") => run_status_command(args),

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,6 +17,7 @@ pub(crate) fn usage_text() -> &'static str {
 omamori — AI tool safety guard
 
 ESSENTIALS
+  setup [--dry-run] [--non-interactive]            One-command install + shell profile + verify
   doctor                                          Check protection health
   test                                            Verify policy rules match expected actions
 
@@ -44,6 +45,7 @@ pub(crate) fn usage_text_full() -> &'static str {
 omamori — AI tool safety guard
 
 ESSENTIALS
+  setup [--dry-run] [--non-interactive]            One-command install + shell profile + verify
   doctor                                          Check protection health
   test                                            Verify policy rules match expected actions
 
@@ -315,6 +317,7 @@ mod tests {
 
         let routable = [
             "test",
+            "setup",
             "install",
             "uninstall",
             "init",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2431,10 +2431,7 @@ fn setup_non_tty_without_flag_exits_1() {
     assert_eq!(code, 1, "non-TTY without --non-interactive should exit 1");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("not a terminal"),
-        "stderr: {stderr}"
-    );
+    assert!(stderr.contains("not a terminal"), "stderr: {stderr}");
 
     // No mutations should have occurred
     assert!(
@@ -2528,8 +2525,5 @@ fn setup_unknown_flag_errors() {
 
     assert!(!output.status.success(), "unknown flag should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("unknown setup flag"),
-        "stderr: {stderr}"
-    );
+    assert!(stderr.contains("unknown setup flag"), "stderr: {stderr}");
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2188,3 +2188,348 @@ fn hook_check_json_error_verbose_fileop_no_extra_lines() {
         "verbose + json-error FileOp must be single line (got {trimmed:?})"
     );
 }
+
+// ---------------------------------------------------------------------------
+// setup command tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn setup_dry_run_no_mutations() {
+    let base = unique_dir("setup-dry");
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["setup", "--dry-run", "--base-dir"])
+        .arg(&base)
+        .env("SHELL", "/bin/zsh")
+        .output()
+        .expect("failed to run setup --dry-run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("dry-run"), "stdout: {stdout}");
+    assert!(stdout.contains("No changes made"), "stdout: {stdout}");
+
+    let shim_dir = base.join("shim");
+    assert!(!shim_dir.exists(), "dry-run should not create shim dir");
+
+    let _ = fs::remove_dir_all(&base);
+}
+
+#[test]
+fn setup_non_interactive_installs_and_appends() {
+    let home = unique_dir("setup-ni-home");
+    let profile = home.join(".zshrc");
+    fs::write(&profile, "# existing content\n").unwrap();
+
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["setup", "--non-interactive"])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("SHELL", "/bin/zsh")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to run setup --non-interactive");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "exit={} stderr: {}",
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("[1/3]"), "stdout: {stdout}");
+    assert!(stdout.contains("Setup complete"), "stdout: {stdout}");
+
+    // Shims installed under $HOME/.omamori/shim
+    let shim_dir = home.join(".omamori").join("shim");
+    assert!(shim_dir.join("rm").exists(), "rm shim missing");
+
+    let content = fs::read_to_string(&profile).unwrap();
+    assert!(
+        content.contains("# Added by omamori setup"),
+        "profile: {content}"
+    );
+    assert!(
+        content.contains("export PATH=\""),
+        "profile must contain export PATH line: {content}"
+    );
+    assert!(
+        content.contains(".omamori/shim"),
+        "export PATH must reference .omamori/shim: {content}"
+    );
+    assert!(
+        content.starts_with("# existing content"),
+        "existing content must be preserved"
+    );
+
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn setup_idempotent_no_duplicate_path() {
+    let home = unique_dir("setup-idem-home");
+    let profile = home.join(".zshrc");
+    fs::write(&profile, "").unwrap();
+
+    for _ in 0..2 {
+        let mut cmd = Command::new(binary());
+        clean_ai_env(&mut cmd);
+        let output = cmd
+            .args(["setup", "--non-interactive"])
+            .env("HOME", &home)
+            .env("XDG_CONFIG_HOME", home.join(".config"))
+            .env("SHELL", "/bin/zsh")
+            .stdin(std::process::Stdio::null())
+            .output()
+            .expect("failed to run setup");
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let content = fs::read_to_string(&profile).unwrap();
+    let marker_count = content.matches("# Added by omamori setup").count();
+    assert_eq!(
+        marker_count, 1,
+        "marker should appear exactly once, got {marker_count}"
+    );
+    let export_count = content.matches("export PATH=").count();
+    assert_eq!(
+        export_count, 1,
+        "export PATH should appear exactly once, got {export_count}"
+    );
+
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn setup_unknown_shell_exits_2() {
+    let home = unique_dir("setup-unk-sh-home");
+
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["setup", "--non-interactive"])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env_remove("SHELL")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to run setup");
+
+    let code = output.status.code().unwrap_or(-1);
+    assert_eq!(code, 2, "unknown shell should exit 2");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Unknown shell"),
+        "stdout should mention unknown shell: {stdout}"
+    );
+
+    // Shims should still be installed (only profile is skipped)
+    assert!(
+        home.join(".omamori").join("shim").join("rm").exists(),
+        "shims should still be installed"
+    );
+
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn setup_ai_env_skips_profile() {
+    let base = unique_dir("setup-ai");
+    let home = unique_dir("setup-ai-home");
+    let profile = home.join(".zshrc");
+    fs::write(&profile, "").unwrap();
+
+    let output = Command::new(binary())
+        .args(["setup", "--base-dir"])
+        .arg(&base)
+        .env("HOME", &home)
+        .env("SHELL", "/bin/zsh")
+        .env("CLAUDECODE", "1")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to run setup in AI env");
+
+    let code = output.status.code().unwrap_or(-1);
+    assert_eq!(code, 2, "AI env should exit 2");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("AI environment"),
+        "should mention AI env: {stdout}"
+    );
+
+    let content = fs::read_to_string(&profile).unwrap();
+    assert!(
+        content.is_empty(),
+        "AI env should not modify profile: {content}"
+    );
+
+    let _ = fs::remove_dir_all(&base);
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn setup_already_configured_exits_0() {
+    let home = unique_dir("setup-already-home");
+    let profile = home.join(".zshrc");
+    fs::write(
+        &profile,
+        "# existing\n# Added by omamori setup (v0.10.0)\nexport PATH=\"/x:$PATH\"\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["setup", "--non-interactive"])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("SHELL", "/bin/zsh")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to run setup");
+
+    let code = output.status.code().unwrap_or(-1);
+    assert_eq!(code, 0, "already configured should exit 0");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Already in PATH"),
+        "should say already in PATH: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn setup_non_tty_without_flag_exits_1() {
+    let home = unique_dir("setup-nontty-home");
+
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["setup"])
+        .env("HOME", &home)
+        .env("SHELL", "/bin/zsh")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to run setup");
+
+    let code = output.status.code().unwrap_or(-1);
+    assert_eq!(code, 1, "non-TTY without --non-interactive should exit 1");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not a terminal"),
+        "stderr: {stderr}"
+    );
+
+    // No mutations should have occurred
+    assert!(
+        !home.join(".omamori").exists(),
+        "no shims should be installed"
+    );
+
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn setup_bash_uses_bashrc() {
+    let home = unique_dir("setup-bash-home");
+    // No .bash_profile → should fall back to .bashrc
+    let bashrc = home.join(".bashrc");
+    fs::write(&bashrc, "").unwrap();
+
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["setup", "--non-interactive"])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("SHELL", "/bin/bash")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to run setup with bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = fs::read_to_string(&bashrc).unwrap();
+    assert!(
+        content.contains("# Added by omamori setup"),
+        ".bashrc should be modified: {content}"
+    );
+
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn setup_bash_prefers_bash_profile() {
+    let home = unique_dir("setup-bashprof-home");
+    let bash_profile = home.join(".bash_profile");
+    let bashrc = home.join(".bashrc");
+    fs::write(&bash_profile, "").unwrap();
+    fs::write(&bashrc, "").unwrap();
+
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["setup", "--non-interactive"])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("SHELL", "/bin/bash")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to run setup with bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bp_content = fs::read_to_string(&bash_profile).unwrap();
+    let rc_content = fs::read_to_string(&bashrc).unwrap();
+    assert!(
+        bp_content.contains("# Added by omamori setup"),
+        ".bash_profile should be modified: {bp_content}"
+    );
+    assert!(
+        !rc_content.contains("# Added by omamori setup"),
+        ".bashrc should NOT be modified when .bash_profile exists: {rc_content}"
+    );
+
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn setup_unknown_flag_errors() {
+    let mut cmd = Command::new(binary());
+    clean_ai_env(&mut cmd);
+    let output = cmd
+        .args(["setup", "--bogus"])
+        .output()
+        .expect("failed to run setup");
+
+    assert!(!output.status.success(), "unknown flag should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown setup flag"),
+        "stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `omamori setup` subcommand that collapses the 5-step manual onboarding flow into a single interactive 3-step wizard: install shims+hooks → append shell profile PATH → run doctor verification
- Support `--dry-run` (preview only), `--non-interactive` (CI/scripted), and AI environment auto-detection (DI-7: skip profile modification)
- Portable `$HOME/.omamori/shim` PATH entry with versioned marker comment for idempotency
- Exit codes: 0 (all done), 1 (preflight error or doctor failure), 2 (installed but profile skipped)
- Bump version to 0.11.0

### Code review findings addressed

| Finding | Fix |
|---------|-----|
| Exit code ignored doctor failures | Exit 1 when `fail_count > 0` |
| Preview said `$HOME`, wrote absolute path | Export uses portable `$HOME/.omamori/shim` |
| Dry-run didn't reflect AI env skip | Pass `ai_env` to `print_dry_run` |
| `layer2_tool_names` ignored `codex_config_outcome` | Exclude "Codex CLI" when `ExplicitlyDisabled` |
| Broken symlink bypassed guard | Detect via `fs::symlink_metadata()` |

### Deferred (off-thesis)

- Policy-test verification in setup (separate concern, use `omamori test`)
- `path_already_configured` false positive on comments (low probability)
- Non-UTF-8 arg silent fallback (codebase-wide pattern)

## Test plan

- [x] `cargo test` — 953 tests pass (0 failed)
- [x] `RUSTFLAGS="-D warnings" cargo test` — no warnings
- [x] 10 setup-specific integration tests covering all variant flows
- [ ] Manual: `omamori setup --dry-run` on fresh install
- [ ] Manual: `omamori setup` full flow with `source ~/.zshrc` + `omamori doctor`
- [ ] CI: GitHub Actions pass

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)