### PR TITLE
chore: release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
-## [Unreleased]
+## [0.11.2] - 2026-06-07
 
 **Summary**: Materialize structural blocks instead of hard-blocking (#299). Materializable block reasons (PipeToShell, ParseError, TooManyTokens, TooManySegments) now write the command to a staging file and audit-log the event instead of blocking. Non-materializable reasons (InputTooLarge, ObfuscatedExpansion, DynamicGeneration, DepthExceeded) remain hard-blocked. Configurable via `[structural] action = "materialize" | "block"` in config.toml (default: materialize). Degraded config (corrupt TOML, insecure permissions) fails closed.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "criterion",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"


### PR DESCRIPTION
## Summary

- Bump version to v0.11.2 in Cargo.toml and Cargo.lock
- Update CHANGELOG `[Unreleased]` → `[0.11.2] - 2026-06-07`

Release content: #299 structural block materialization (PR1 #300 + PR2 #301 + PR3 #302) + README update (#303).

## Test plan

- [ ] CI passes
- [ ] Tag, push --tags, gh release create after merge
- [ ] crates.io publish confirmation
- [ ] brew upgrade + `omamori setup` verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)