### PR TITLE
chore: bump version to v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.11.3] - 2026-06-09
+
+**Summary**: Shim heartbeat liveness signal (#280). Every shim invocation touches a heartbeat file (at most once per UTC day), and `omamori doctor` displays last-active status under [Layer 1]. The write is fire-and-forget — filesystem failures never block command execution.
+
+### Added
+
+- **Heartbeat write in `run_shim()`** — `touch_heartbeat()` writes an RFC 3339 timestamp to `~/.local/share/omamori/heartbeat` via atomic temp-file + rename. Mtime-gated: only one write per UTC calendar day (~0.01ms stat on repeat invocations). O_NOFOLLOW + 0600 permissions + symlink rejection on both temp and final paths. ([#280](https://github.com/yottayoshida/omamori/issues/280))
+- **`omamori doctor` last-active sub-line** — Displays under [Layer 1]: "last active: today/yesterday/N days ago". 0–3 days = info, 4+ days = WARN, future mtime = WARN (clock skew), no file = "awaiting first invocation". ([#280](https://github.com/yottayoshida/omamori/issues/280))
+- **`omamori doctor --json` shim_activity field** — `last_active_days_ago` (integer or null) + `status` (ok/warn/clock_skew/awaiting_first_invocation). ([#280](https://github.com/yottayoshida/omamori/issues/280))
+- **`heartbeat_path()` returns `Option<PathBuf>`** — Silently skips heartbeat when HOME is unset (containers, some CI runners) instead of writing to a relative path. ([#280](https://github.com/yottayoshida/omamori/issues/280))
+- **16 unit tests** — Heartbeat write (create, permissions, skip-same-day, symlink rejection, future/old mtime overwrite, corrupt content, read-only dir, directory-at-path) + doctor display (missing, today, past, threshold boundary, symlink, directory, JSON output). ([#280](https://github.com/yottayoshida/omamori/issues/280))
+
 ## [0.11.2] - 2026-06-07
 
 **Summary**: Materialize structural blocks instead of hard-blocking (#299). Materializable block reasons (PipeToShell, ParseError, TooManyTokens, TooManySegments) now write the command to a staging file and audit-log the event instead of blocking. Non-materializable reasons (InputTooLarge, ObfuscatedExpansion, DynamicGeneration, DepthExceeded) remain hard-blocked. Configurable via `[structural] action = "materialize" | "block"` in config.toml (default: materialize). Degraded config (corrupt TOML, insecure permissions) fails closed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "criterion",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ $ omamori doctor
 Protection status: OK
 
   [Layer 1] PATH shims 6/6
+    last active: today
   [Layer 2] Hook defense 4/4
   [Integrity] Config & baseline 3/3
   [Risk signals] Last 30 days: quiet


### PR DESCRIPTION
## Summary
- Version bump for shim heartbeat liveness signal (#280)
- CHANGELOG entry for v0.11.3
- README: update `omamori doctor` output sample with `last active` sub-line under [Layer 1]

## Changes
- `Cargo.toml` / `Cargo.lock`: 0.11.2 → 0.11.3
- `CHANGELOG.md`: add [0.11.3] section
- `README.md`: add heartbeat line to doctor output example

## Test plan
- [ ] CI green
- [ ] After merge: tag v0.11.3, `cargo publish`, Homebrew tap update
- [ ] `brew upgrade omamori && omamori doctor` shows "last active" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)