### PR TITLE
chore: bump version to v0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.11.4] - 2026-06-16
+
+**Summary**: Staging file retention/GC (#313). Prune-on-write garbage collection for staging files created by the materialize feature, preventing unbounded disk growth. Files are pruned by age (default 7 days) and count cap (default 500). `omamori doctor` now surfaces staging usage for operational visibility.
+
+### Added
+
+- **Prune-on-write GC for staging files** — `try_prune_staging()` runs before every `write_staging_file()` call. Two-phase algorithm: Phase 1 deletes files older than `retention_days`, Phase 2 enforces `max_files` count cap (oldest first). Pre-write position handles strict-mode early returns and frees disk space before the upcoming write. `saturating_sub(1)` reserves a slot so post-write count never exceeds `max_files`. ([#313](https://github.com/yottayoshida/omamori/issues/313))
+- **`[structural]` config: `retention_days` and `max_files`** — `retention_days = 7` (0 = disabled, clamped 1–3650) and `max_files = 500` (0 = disabled, clamped 10–100000). Added to `config.default.toml` with comments. ([#313](https://github.com/yottayoshida/omamori/issues/313))
+- **`omamori doctor` staging section** — New `[Staging]` informational block: file count, total size, oldest file age. WARN thresholds: count > max_files, or oldest > 2× retention_days. ([#313](https://github.com/yottayoshida/omamori/issues/313))
+- **`omamori doctor --json` staging field** — `file_count`, `total_bytes`, `oldest_days_ago`, `status` (ok/warn/error), `retention_days`, `max_files`. Returns `status: "error"` with null config fields on config load failure. ([#313](https://github.com/yottayoshida/omamori/issues/313))
+- **27 new tests** — Age pruning (exact cutoff boundary), count cap (exact cap noop, one-over-cap), mixed age+count (verifies specific surviving files), pre-write reservation (saturating_sub), non-matching filenames/symlinks/empty dir skip, config validation (defaults, clamping, 0=disabled), doctor text + JSON output. ([#313](https://github.com/yottayoshida/omamori/issues/313))
+
+### Fixed
+
+- **retain failed-delete undercount** — Phase 1 age pruning now keeps files in the Vec when `remove_file` fails, so Phase 2 count-cap sees the actual on-disk file count. Previously, failed deletes were unconditionally dropped from the Vec, causing Phase 2 to undercount and skip necessary pruning. ([#313](https://github.com/yottayoshida/omamori/issues/313))
+
 ## [0.11.3] - 2026-06-09
 
 **Summary**: Shim heartbeat liveness signal (#280). Every shim invocation touches a heartbeat file (at most once per UTC day), and `omamori doctor` displays last-active status under [Layer 1]. The write is fire-and-forget — filesystem failures never block command execution.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "omamori"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "criterion",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamori"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2024"
 rust-version = "1.92"
 description = "AI Agent's Omamori — protect your system from dangerous commands executed via AI CLI tools"

--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ strict = true  # default: false. Hook-only commands (ls, cat, etc.) are not affe
 **Control structural block behavior** (materialize vs hard-block):
 ```toml
 [structural]
-action = "block"  # default: "materialize". Set to "block" to hard-block all structural patterns.
+action = "block"     # default: "materialize". Set to "block" to hard-block all structural patterns.
+retention_days = 7   # auto-prune staging files older than N days. 0 = disabled.
+max_files = 500      # cap on staging file count; oldest deleted first. 0 = disabled.
 ```
 
 **Notes**: config requires `chmod 600`. Destinations must be absolute paths on the same volume. System directories and symlinks are rejected.


### PR DESCRIPTION
## Summary
- Bump version to 0.11.4 in Cargo.toml / Cargo.lock
- Add CHANGELOG entry for v0.11.4 (staging retention GC, #313)
- Update README: add `retention_days` and `max_files` to `[structural]` config example

## Test plan
- [x] `cargo check` passes with new version
- [x] CI validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)